### PR TITLE
Fix configurer composition

### DIFF
--- a/config/cluster/host.go
+++ b/config/cluster/host.go
@@ -35,8 +35,8 @@ type configurer interface {
 	WriteFile(path, data, permissions string) error
 	UpdateEnvironment(map[string]string) error
 	DaemonReload() error
+	ReplaceK0sTokenPath(string) error
 	ServiceScriptPath(string) (string, error)
-	ReplaceK0sTokenPath() error
 	ReadFile(string) (string, error)
 	FileExist(string) bool
 	Chmod(string, string) error

--- a/configurer/linux.go
+++ b/configurer/linux.go
@@ -8,51 +8,18 @@ import (
 
 // Linux is a base module for various linux OS support packages
 type Linux struct {
-	os.Linux
+	Host os.Host
 }
 
-// TODO For some reason the rig stock OS functions do not get "inherited" and need to be proxied
-func (l *Linux) CheckPrivilege() error {
-	return l.Linux.CheckPrivilege()
-}
+// NOTE The Linux struct does not embed rig/os.Linux because it will confuse
+// go as the distro-configurers' parents embed it too. This means you can't
+// add functions to base Linux package that call functions in the rig/os.Linux package,
+// you can however write those functions in the distro-configurers.
+// An example of this problem is the ReplaceK0sTokenPath function, which would like to
+// call `l.ServiceScriptPath("kos")`, which was worked around here by getting the
+// path as a parameter.
 
-func (l *Linux) ServiceIsRunning(s string) bool {
-	return l.Linux.ServiceIsRunning(s)
-}
-
-func (l *Linux) StartService(s string) error {
-	return l.Linux.StartService(s)
-}
-
-func (l *Linux) RestartService(s string) error {
-	return l.Linux.RestartService(s)
-}
-
-func (l *Linux) WriteFile(path string, data string, permissions string) error {
-	return l.Linux.WriteFile(path, data, permissions)
-}
-
-func (l *Linux) UpdateEnvironment(env map[string]string) error {
-	return l.Linux.UpdateEnvironment(env)
-}
-
-func (l *Linux) ServiceScriptPath(s string) (string, error) {
-	return l.Linux.ServiceScriptPath(s)
-}
-
-func (l *Linux) DaemonReload() error {
-	return l.Linux.DaemonReload()
-}
-
-func (l *Linux) ReadFile(path string) (string, error) {
-	return l.Linux.ReadFile(path)
-}
-
-func (l *Linux) FileExist(path string) bool {
-	return l.Linux.FileExist(path)
-}
-
-func (l *Linux) Arch() (string, error) {
+func (l Linux) Arch() (string, error) {
 	arch, err := l.Host.ExecOutput("uname -m")
 	if err != nil {
 		return "", err
@@ -67,38 +34,34 @@ func (l *Linux) Arch() (string, error) {
 	}
 }
 
-func (l *Linux) Chmod(path, chmod string) error {
+func (l Linux) Chmod(path, chmod string) error {
 	return l.Host.Execf("sudo chmod %s %s", chmod, path)
 }
 
-func (l *Linux) K0sCmdf(template string, args ...interface{}) string {
+func (l Linux) K0sCmdf(template string, args ...interface{}) string {
 	return fmt.Sprintf("sudo %s %s", l.K0sBinaryPath(), fmt.Sprintf(template, args...))
 }
 
 // K0sConfigPath returns location of k0s configuration file
-func (l *Linux) K0sBinaryPath() string {
+func (l Linux) K0sBinaryPath() string {
 	return "/usr/bin/k0s"
 }
 
 // K0sConfigPath returns location of k0s configuration file
-func (l *Linux) K0sConfigPath() string {
+func (l Linux) K0sConfigPath() string {
 	return "/etc/k0s/k0s.yaml"
 }
 
 // K0sJoinToken returns location of k0s join token file
-func (l *Linux) K0sJoinTokenPath() string {
+func (l Linux) K0sJoinTokenPath() string {
 	return "/etc/k0s/k0stoken"
 }
 
 // RunK0sDownloader downloads k0s binaries using the online script
-func (l *Linux) RunK0sDownloader(version string) error {
+func (l Linux) RunK0sDownloader(version string) error {
 	return l.Host.Exec(fmt.Sprintf("curl get.k0s.sh | K0S_VERSION=v%s sh", version))
 }
 
-func (l *Linux) ReplaceK0sTokenPath() error {
-	fp, err := l.ServiceScriptPath("k0s")
-	if err != nil {
-		return err
-	}
-	return l.Host.Exec(fmt.Sprintf("sed -i 's^REPLACEME^%s^g' %s", l.K0sJoinTokenPath(), fp))
+func (l Linux) ReplaceK0sTokenPath(spath string) error {
+	return l.Host.Exec(fmt.Sprintf("sed -i 's^REPLACEME^%s^g' %s", l.K0sJoinTokenPath(), spath))
 }

--- a/configurer/linux/enterpriselinux/centos.go
+++ b/configurer/linux/enterpriselinux/centos.go
@@ -40,9 +40,7 @@ func init() {
 				},
 				EnterpriseLinux: k0slinux.EnterpriseLinux{
 					Linux: configurer.Linux{
-						Linux: os.Linux{
-							Host: h,
-						},
+						Host: h,
 					},
 				},
 			}

--- a/configurer/linux/enterpriselinux/oracle.go
+++ b/configurer/linux/enterpriselinux/oracle.go
@@ -38,9 +38,7 @@ func init() {
 				},
 				EnterpriseLinux: k0slinux.EnterpriseLinux{
 					Linux: configurer.Linux{
-						Linux: os.Linux{
-							Host: h,
-						},
+						Host: h,
 					},
 				},
 			}

--- a/configurer/linux/enterpriselinux/rhel.go
+++ b/configurer/linux/enterpriselinux/rhel.go
@@ -38,9 +38,7 @@ func init() {
 				},
 				EnterpriseLinux: k0slinux.EnterpriseLinux{
 					Linux: configurer.Linux{
-						Linux: os.Linux{
-							Host: h,
-						},
+						Host: h,
 					},
 				},
 			}

--- a/configurer/linux/sles.go
+++ b/configurer/linux/sles.go
@@ -27,9 +27,7 @@ func init() {
 					},
 				},
 				Linux: configurer.Linux{
-					Linux: os.Linux{
-						Host: h,
-					},
+					Host: h,
 				},
 			}
 		},

--- a/configurer/linux/ubuntu.go
+++ b/configurer/linux/ubuntu.go
@@ -27,9 +27,7 @@ func init() {
 					},
 				},
 				Linux: configurer.Linux{
-					Linux: os.Linux{
-						Host: h,
-					},
+					Host: h,
 				},
 			}
 		},

--- a/phase/install_workers.go
+++ b/phase/install_workers.go
@@ -44,7 +44,11 @@ func (p *InstallWorkers) Run() error {
 		}
 
 		log.Infof("%s: updating service script", h)
-		if err := h.Configurer.ReplaceK0sTokenPath(); err != nil {
+		spath, err := h.Configurer.ServiceScriptPath("k0s")
+		if err != nil {
+			return err
+		}
+		if err := h.Configurer.ReplaceK0sTokenPath(spath); err != nil {
 			return err
 		}
 


### PR DESCRIPTION
In #3 I had to "proxy" the functions from `configurer.Linux` to rig's `os.Linux` -- I believe this to be because the distro-based configurers (ubuntu, sles, ...) embed their "parents" (rig's `linux.Ubuntu`, `Linux.EnterpriseLinux`..) and go gets confused because it gets the same functions from two embedded structs.

With this modification, I was able to drop the proxying, with the caveat that any functions defined in the base `configurer.Linux` can not call any functions "inherited" from rig's `os.Linux`. The distro configurers and the users of the `configurer` interface can call them just fine.

There may be some hugely better way to implement this, which I'm not aware of, as I'm still fairly new to this go struct composition business.
