### PR TITLE
Add Before/After hooks to phases

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -11,6 +11,7 @@ require (
 	github.com/logrusorgru/aurora v2.0.3+incompatible
 	github.com/shiena/ansicolor v0.0.0-20200904210342-c7312218db18
 	github.com/sirupsen/logrus v1.7.0
+	github.com/stretchr/testify v1.4.0
 	github.com/urfave/cli/v2 v2.3.0
 	gopkg.in/yaml.v2 v2.2.3
 )

--- a/phase/generic_phase.go
+++ b/phase/generic_phase.go
@@ -10,7 +10,3 @@ func (p *GenericPhase) Prepare(c *config.Cluster) error {
 	p.Config = c
 	return nil
 }
-
-func (p *GenericPhase) ShouldRun() bool {
-	return true
-}

--- a/phase/manager_test.go
+++ b/phase/manager_test.go
@@ -1,0 +1,97 @@
+package phase
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/k0sproject/k0sctl/config"
+	"github.com/stretchr/testify/require"
+)
+
+type conditionalPhase struct {
+	shouldrunCalled bool
+	runCalled       bool
+}
+
+func (p *conditionalPhase) Title() string {
+	return "conditional phase"
+}
+
+func (p *conditionalPhase) ShouldRun() bool {
+	p.shouldrunCalled = true
+	return false
+}
+
+func (p *conditionalPhase) Run() error {
+	p.runCalled = true
+	return nil
+}
+
+func TestConditionalPhase(t *testing.T) {
+	m := Manager{}
+	p := &conditionalPhase{}
+	m.AddPhase(p)
+	require.NoError(t, m.Run())
+	require.False(t, p.runCalled, "run was not called")
+	require.True(t, p.shouldrunCalled, "shouldrun was not called")
+}
+
+type configPhase struct {
+	receivedConfig bool
+}
+
+func (p *configPhase) Title() string {
+	return "config phase"
+}
+
+func (p *configPhase) Prepare(c *config.Cluster) error {
+	p.receivedConfig = c != nil
+	return nil
+}
+
+func (c *configPhase) Run() error {
+	return nil
+}
+
+func TestConfigPhase(t *testing.T) {
+	m := Manager{Config: &config.Cluster{}}
+	p := &configPhase{}
+	m.AddPhase(p)
+	require.NoError(t, m.Run())
+	require.True(t, p.receivedConfig, "config was not received")
+}
+
+type hookedPhase struct {
+	beforeCalled bool
+	afterCalled  bool
+	err          error
+}
+
+func (p *hookedPhase) Title() string {
+	return "hooked phase"
+}
+
+func (p *hookedPhase) Before() error {
+	p.beforeCalled = true
+	return nil
+}
+
+func (p *hookedPhase) After(err error) error {
+	p.afterCalled = true
+	p.err = err
+	return nil
+}
+
+func (c *hookedPhase) Run() error {
+	return fmt.Errorf("run failed")
+}
+
+func TestHookedPhase(t *testing.T) {
+	m := Manager{}
+	p := &hookedPhase{}
+	m.AddPhase(p)
+	require.Error(t, m.Run())
+	require.True(t, p.beforeCalled, "before hook was not called")
+	require.True(t, p.afterCalled, "after hook was not called")
+	require.EqualError(t, p.err, "run failed")
+}


### PR DESCRIPTION
This will make it easy to add of analytics phases, such as:

```go
package analytics

type Phase struct {
  analytics segment.Properties
}

func (p *Phase) Before() error {
  analytics.Set("phase", p.Title())
  return nil
}

func (p *Phase) After(err error) error {
  p.analytics.Set("success", err == nil)
  segment.Enqueue(p.analytics)
  return nil
}
```

```go
package phase

type TrackedPhase struct {
  GenericPhase
  analytics.Phase
}

func (p *TrackedPhase) Run() error {
  p.analytics.Set("k0s-version", p.Config.Spec.K0s.Version)
  return nil
}
```

Also adds tests for phase manager functionality.
