### PR TITLE
Adjusted service name to 0.10 style k0s[role]

### DIFF
--- a/config/cluster/host.go
+++ b/config/cluster/host.go
@@ -145,3 +145,11 @@ func (h *Host) K0sInstallCommand() string {
 func (h *Host) IsController() bool {
 	return h.Role == "server" || h.Role == "server+worker"
 }
+
+// K0sServiceName returns correct service name
+func (h *Host) K0sServiceName() string {
+	if h.Role == "server+worker" {
+		return "k0sserver"
+	}
+	return "k0s" + h.Role
+}

--- a/phase/initialize_k0s.go
+++ b/phase/initialize_k0s.go
@@ -39,7 +39,7 @@ func (p *InitializeK0s) Run() error {
 	p.host.Metadata.IsK0sLeader = true
 	if p.host.Metadata.K0sRunningVersion != "" {
 		log.Infof("%s: k0s already running, reloading configuration", p.host)
-		if err := p.host.Configurer.RestartService("k0s"); err != nil {
+		if err := p.host.Configurer.RestartService(p.host.K0sServiceName()); err != nil {
 			return err
 		}
 		if err := p.waitK0s(); err != nil {
@@ -58,7 +58,7 @@ func (p *InitializeK0s) Run() error {
 		return err
 	}
 
-	if err := p.host.Configurer.StartService("k0s" + p.host.Role); err != nil {
+	if err := p.host.Configurer.StartService(p.host.K0sServiceName()); err != nil {
 		return err
 	}
 	if err := p.waitK0s(); err != nil {
@@ -90,7 +90,7 @@ func (p *InitializeK0s) waitK0s() error {
 	return retry.Do(
 		func() error {
 			log.Infof("%s: waiting for k0s service to start", p.host)
-			if !p.host.Configurer.ServiceIsRunning("k0s" + p.host.Role) {
+			if !p.host.Configurer.ServiceIsRunning(p.host.K0sServiceName()) {
 				return fmt.Errorf("not running")
 			}
 			return nil

--- a/phase/install_controllers.go
+++ b/phase/install_controllers.go
@@ -46,7 +46,7 @@ func (p *InstallControllers) Run() error {
 				return err
 			}
 			log.Infof("%s: starting service", h)
-			if err := h.Configurer.StartService("k0s" + h.Role); err != nil {
+			if err := h.Configurer.StartService(h.K0sServiceName()); err != nil {
 				return err
 			}
 		} else {

--- a/phase/install_workers.go
+++ b/phase/install_workers.go
@@ -44,7 +44,7 @@ func (p *InstallWorkers) Run() error {
 				return err
 			}
 			log.Infof("%s: starting service", h)
-			if err := h.Configurer.StartService("k0s" + h.Role); err != nil {
+			if err := h.Configurer.StartService(h.K0sServiceName()); err != nil {
 				return err
 			}
 			h.Metadata.K0sRunningVersion = p.Config.Spec.K0s.Version


### PR DESCRIPTION
When installing service with `k0s install [role]` service stub is named `k0s[role].service` 

I also added in config/cluster/host.go
```
if h.Role == "worker" {
		flags.AddUnlessExist(fmt.Sprintf(`--token-file "%s"`, h.K0sJoinTokenPath()))
	}
```

So the service stub is initialized properly for "server" role. 