### PR TITLE
Error out on version mismatch

### DIFF
--- a/phase/gather_k0s_facts.go
+++ b/phase/gather_k0s_facts.go
@@ -84,6 +84,10 @@ func (p *GatherK0sFacts) investigateK0s(h *cluster.Host) error {
 	}
 
 	h.Metadata.K0sRunningVersion = strings.TrimPrefix(status.Version, "v")
+	if p.Config.Spec.K0s.Version != h.Metadata.K0sRunningVersion {
+		return fmt.Errorf("%s: is running k0s %s version %s but target is %s - upgrade is not yet supported", h, h.Role, h.Metadata.K0sRunningVersion, p.Config.Spec.K0s.Version)
+	}
+
 	log.Infof("%s: is running k0s %s version %s", h, h.Role, h.Metadata.K0sRunningVersion)
 
 	if !h.IsController() {


### PR DESCRIPTION
Fixes #27 

Exit with error if spec.K0s.Version is different from the already running version for now.

