### PR TITLE
Send external IP in analytics

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/bmizerany/assert v0.0.0-20160611221934-b7ed37b82869 // indirect
 	github.com/creasty/defaults v1.5.1
 	github.com/denisbrodbeck/machineid v1.0.1
+	github.com/glendc/go-external-ip v0.0.0-20200601212049-c872357d968e
 	github.com/go-playground/validator/v10 v10.4.1
 	github.com/hashicorp/go-version v1.2.1
 	github.com/k0sproject/rig v0.3.1

--- a/go.sum
+++ b/go.sum
@@ -64,6 +64,8 @@ github.com/evanphx/json-patch v4.9.0+incompatible/go.mod h1:50XU6AFN0ol/bzJsmQLi
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
 github.com/fsnotify/fsnotify v1.4.9/go.mod h1:znqG4EE+3YCdAaPaxE2ZRY/06pZUdp0tY4IgpuI1SZQ=
 github.com/ghodss/yaml v0.0.0-20150909031657-73d445a93680/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
+github.com/glendc/go-external-ip v0.0.0-20200601212049-c872357d968e h1:gLpAlmoGqnW3a3GCkOe+Ic8hZoSCfi0PdA0B8j7d6uw=
+github.com/glendc/go-external-ip v0.0.0-20200601212049-c872357d968e/go.mod h1:o9OoDQyE1WHvYVUH1FdFapy1/rCZHHq3O5wS4VA83ig=
 github.com/go-gl/glfw/v3.3/glfw v0.0.0-20191125211704-12ad95a8df72/go.mod h1:tQ2UAYgL5IevRw8kRxooKSPJfGvJ9fJQFa0TUsXzTg8=
 github.com/go-logr/logr v0.1.0/go.mod h1:ixOQHD9gLJUVQQ2ZOR7zLEifBX6tGkNJF4QyIY7sIas=
 github.com/go-logr/logr v0.2.0 h1:QvGt2nLcHH0WK9orKa+ppBPAxREcH364nPUedEpK0TY=

--- a/integration/segment/segment.go
+++ b/integration/segment/segment.go
@@ -51,6 +51,7 @@ func NewClient() (*Client, error) {
 		id = fmt.Sprintf("%x", b)
 		log.Tracef("generated a random machine ID: %s", id)
 	}
+	log.Tracef("using %s as machine ID", id)
 
 	consensus := externalip.DefaultConsensus(nil, nil)
 	if ip, err := consensus.ExternalIP(); err == nil {

--- a/integration/segment/segment.go
+++ b/integration/segment/segment.go
@@ -47,7 +47,7 @@ func NewClient() (*Client, error) {
 	if err != nil {
 		log.Tracef("error getting machine ID: %s", err.Error())
 		b := make([]byte, 8)
-		rand.Read(b)
+		_, _ = rand.Read(b)
 		id = fmt.Sprintf("%x", b)
 		log.Tracef("generated a random machine ID: %s", id)
 	}


### PR DESCRIPTION
Uses https://github.com/GlenDC/go-external-ip to get an external IP to be added to the event context.

It queries several services and uses the IP that gets reported most.
