### PR TITLE
Upgrade with migration

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -82,3 +82,37 @@ jobs:
         env:
           LINUX_IMAGE: ${{ matrix.image }}
         run: make smoke-basic
+
+  smoke-upgrade:
+    strategy:
+      matrix:
+        image:
+          - quay.io/footloose/ubuntu18.04
+          - quay.io/footloose/centos7
+          #- quay.io/footloose/amazonlinux2
+          #- quay.io/footloose/debian10
+          #- quay.io/footloose/fedora29
+    name: Upgrade 0.10 --> 0.11
+    needs: build
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out code into the Go module directory
+        uses: actions/checkout@v2
+      - name: Set up Go
+        uses: actions/setup-go@v2
+        with:
+          go-version: 1.15
+
+      - name: Restore compiled binary for smoke testing
+        uses: actions/cache@v2
+        id: restore-compiled-binary
+        with:
+          path: |
+            k0sctl
+          key: build-${{ github.run_id }}
+
+      - name: Run smoke tests
+        env:
+          LINUX_IMAGE: ${{ matrix.image }}
+        run: make smoke-upgrade

--- a/Makefile
+++ b/Makefile
@@ -56,7 +56,7 @@ upload-%: bin/% $(github_release)
 .PHONY: upload
 upload: $(addprefix upload-,$(bins) $(checksums))
 
-smoketests := smoke-basic
+smoketests := smoke-basic smoke-upgrade
 .PHONY: $(smoketests)
 $(smoketests): k0sctl
 	$(MAKE) -C smoke-test $@

--- a/Makefile
+++ b/Makefile
@@ -60,3 +60,15 @@ smoketests := smoke-basic
 .PHONY: $(smoketests)
 $(smoketests): k0sctl
 	$(MAKE) -C smoke-test $@
+
+golint := $(shell which golangci-lint)
+ifeq ($(golint),)
+golint := $(shell go env GOPATH)/bin/golangci-lint
+endif
+
+$(golint):
+	go get github.com/golangci/golangci-lint/cmd/golangci-lint@v1.31.0
+
+.PHONY: lint
+lint: $(golint)
+	$(golint) run ./...

--- a/cmd/apply.go
+++ b/cmd/apply.go
@@ -62,6 +62,8 @@ var applyCommand = &cli.Command{
 			&phase.InitializeK0s{},
 			&phase.InstallControllers{},
 			&phase.InstallWorkers{},
+			&phase.UpgradeControllers{},
+			&phase.UpgradeWorkers{},
 			&phase.Disconnect{},
 		)
 

--- a/cmd/apply.go
+++ b/cmd/apply.go
@@ -23,6 +23,10 @@ var applyCommand = &cli.Command{
 			Name:  "no-wait",
 			Usage: "Do not wait for worker nodes to join",
 		},
+		&cli.BoolFlag{
+			Name:  "no-drain",
+			Usage: "Do not drain worker nodes when upgrading",
+		},
 		debugFlag,
 		traceFlag,
 		analyticsFlag,
@@ -46,6 +50,7 @@ var applyCommand = &cli.Command{
 		}
 
 		phase.NoWait = ctx.Bool("no-wait")
+
 		manager := phase.Manager{Config: &c}
 
 		manager.AddPhase(
@@ -63,7 +68,9 @@ var applyCommand = &cli.Command{
 			&phase.InstallControllers{},
 			&phase.InstallWorkers{},
 			&phase.UpgradeControllers{},
-			&phase.UpgradeWorkers{},
+			&phase.UpgradeWorkers{
+				NoDrain: ctx.Bool("no-drain"),
+			},
 			&phase.Disconnect{},
 		)
 

--- a/config/cluster/host.go
+++ b/config/cluster/host.go
@@ -350,6 +350,21 @@ func (h *Host) NeedCurl() bool {
 	return false
 }
 
+// NeedIPTables returns true when the iptables package is needed on the host
+func (h *Host) NeedIPTables() bool {
+	// Windows does not need any packages iptables
+	if h.Configurer.Kind() == "windows" {
+		return false
+	}
+
+	// Controllers do not need iptables
+	if h.IsController() {
+		return false
+	}
+
+	return !h.Configurer.CommandExist(h, "iptables")
+}
+
 // WaitKubeAPIReady blocks until the local kube api responds to /version
 func (h *Host) WaitKubeAPIReady() error {
 	return h.WaitHTTPStatus("https://localhost:6443/version", 200)

--- a/config/cluster/host.go
+++ b/config/cluster/host.go
@@ -271,20 +271,12 @@ func (h *Host) WaitKubeNodeReady(node *Host) error {
 
 // DrainNode drains the given node
 func (h *Host) DrainNode(node *Host) error {
-	_, err := h.ExecOutput(h.Configurer.KubectlCmdf("drain --grace-period=120 --force --timeout=5m --ignore-daemonsets --delete-local-data %s", node.Metadata.Hostname), exec.HideOutput())
-	if err != nil {
-		return err
-	}
-	return nil
+	return h.Exec(h.Configurer.KubectlCmdf("drain --grace-period=120 --force --timeout=5m --ignore-daemonsets --delete-local-data %s", node.Metadata.Hostname))
 }
 
 // UncordonNode marks the node schedulable again
 func (h *Host) UncordonNode(node *Host) error {
-	_, err := h.ExecOutput(h.Configurer.KubectlCmdf("uncordon %s", node.Metadata.Hostname), exec.HideOutput())
-	if err != nil {
-		return err
-	}
-	return nil
+	return h.Exec(h.Configurer.KubectlCmdf("uncordon %s", node.Metadata.Hostname))
 }
 
 // CheckHTTPStatus will perform a web request to the url and return an error if the http status is not the expected
@@ -352,7 +344,7 @@ func (h *Host) NeedCurl() bool {
 
 // NeedIPTables returns true when the iptables package is needed on the host
 func (h *Host) NeedIPTables() bool {
-	// Windows does not need any packages iptables
+	// Windows does not need iptables 
 	if h.Configurer.Kind() == "windows" {
 		return false
 	}

--- a/config/cluster/k0s.go
+++ b/config/cluster/k0s.go
@@ -13,7 +13,7 @@ import (
 )
 
 // K0sMinVersion is the minimum k0s version supported
-const K0sMinVersion = "0.11.0-beta.1"
+const K0sMinVersion = "0.11.0-beta.2"
 
 // K0s holds configuration for bootstraping a k0s cluster
 type K0s struct {

--- a/config/cluster/k0s.go
+++ b/config/cluster/k0s.go
@@ -13,7 +13,7 @@ import (
 )
 
 // K0sMinVersion is the minimum k0s version supported
-const K0sMinVersion = "0.11.0-beta1"
+const K0sMinVersion = "0.11.0-beta.1"
 
 // K0s holds configuration for bootstraping a k0s cluster
 type K0s struct {

--- a/go.mod
+++ b/go.mod
@@ -5,10 +5,12 @@ go 1.15
 replace github.com/segmentio/analytics-go v3.1.0+incompatible => github.com/kke/analytics-go v1.2.1-0.20210209122110-10364370169e
 
 require (
+	github.com/Masterminds/semver v1.5.0
 	github.com/avast/retry-go v3.0.0+incompatible
 	github.com/bmizerany/assert v0.0.0-20160611221934-b7ed37b82869 // indirect
 	github.com/creasty/defaults v1.5.1
 	github.com/denisbrodbeck/machineid v1.0.1
+	github.com/gammazero/workerpool v1.1.1
 	github.com/go-playground/validator/v10 v10.4.1
 	github.com/hashicorp/go-version v1.2.1
 	github.com/k0sproject/dig v0.1.0
@@ -20,6 +22,7 @@ require (
 	github.com/stretchr/testify v1.7.0
 	github.com/urfave/cli/v2 v2.3.0
 	golang.org/x/sys v0.0.0-20200622214017-ed371f2e16b4
+	google.golang.org/appengine v1.6.5
 	gopkg.in/yaml.v2 v2.4.0
 	k8s.io/client-go v0.19.3
 )

--- a/go.sum
+++ b/go.sum
@@ -28,6 +28,8 @@ github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
 github.com/ChrisTrenkamp/goxpath v0.0.0-20170922090931-c385f95c6022 h1:y8Gs8CzNfDF5AZvjr+5UyGQvQEBL7pwo+v+wX6q9JI8=
 github.com/ChrisTrenkamp/goxpath v0.0.0-20170922090931-c385f95c6022/go.mod h1:nuWgzSkT5PnyOd+272uUmV0dnAnAn42Mk7PiQC5VzN4=
+github.com/Masterminds/semver v1.5.0 h1:H65muMkzWKEuNDnfl9d70GUjFniHKHRbFPGBuZ3QEww=
+github.com/Masterminds/semver v1.5.0/go.mod h1:MB6lktGJrhw8PrUyiEoblNEGEQ+RzHPF078ddwwvV3Y=
 github.com/NYTimes/gziphandler v0.0.0-20170623195520-56545f4a5d46/go.mod h1:3wb06e3pkSAbeQ52E9H9iFoQsEEwGN64994WTCIhntQ=
 github.com/PuerkitoBio/purell v1.0.0/go.mod h1:c11w/QuzBsJSee3cPx9rAFu61PvFxuPbtSwDGJws/X0=
 github.com/PuerkitoBio/urlesc v0.0.0-20160726150825-5bd2802263f2/go.mod h1:uGdkoq3SwY9Y+13GIhn11/XLaGBb4BfwItxLd5jeuXE=
@@ -63,6 +65,10 @@ github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7
 github.com/evanphx/json-patch v4.9.0+incompatible/go.mod h1:50XU6AFN0ol/bzJsmQLiYLvXMP4fmwYFNcr97nuDLSk=
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
 github.com/fsnotify/fsnotify v1.4.9/go.mod h1:znqG4EE+3YCdAaPaxE2ZRY/06pZUdp0tY4IgpuI1SZQ=
+github.com/gammazero/deque v0.0.0-20200721202602-07291166fe33 h1:UG4wNrJX9xSKnm/Gck5yTbxnOhpNleuE4MQRdmcGySo=
+github.com/gammazero/deque v0.0.0-20200721202602-07291166fe33/go.mod h1:D90+MBHVc9Sk1lJAbEVgws0eYEurY4mv2TDso3Nxh3w=
+github.com/gammazero/workerpool v1.1.1 h1:MN29GcZtZZAgzTU+Zk54Y+J9XkE54MoXON/NCZvNulo=
+github.com/gammazero/workerpool v1.1.1/go.mod h1:5BN0IJVRjSFAypo9QTJCaWdijjNz9Jjl6VFS1PRjCeg=
 github.com/ghodss/yaml v0.0.0-20150909031657-73d445a93680/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
 github.com/go-gl/glfw/v3.3/glfw v0.0.0-20191125211704-12ad95a8df72/go.mod h1:tQ2UAYgL5IevRw8kRxooKSPJfGvJ9fJQFa0TUsXzTg8=
 github.com/go-logr/logr v0.1.0/go.mod h1:ixOQHD9gLJUVQQ2ZOR7zLEifBX6tGkNJF4QyIY7sIas=

--- a/phase/configure_k0s.go
+++ b/phase/configure_k0s.go
@@ -96,7 +96,7 @@ func (p *ConfigureK0s) configureK0s(h *cluster.Host) error {
 		log.Debugf("%s: configuration did not change", h)
 	} else {
 		log.Infof("%s: configuration was changed", h)
-		if h.Metadata.K0sRunningVersion != "" {
+		if h.Metadata.K0sRunningVersion != "" && !h.Metadata.NeedsUpgrade {
 			log.Infof("%s: restarting the k0s service", h)
 			if err := h.Configurer.RestartService(h, h.K0sServiceName()); err != nil {
 				return err

--- a/phase/configure_k0s.go
+++ b/phase/configure_k0s.go
@@ -51,7 +51,7 @@ func (p *ConfigureK0s) Run() error {
 
 func (p *ConfigureK0s) validateConfig(h *cluster.Host) error {
 	log.Infof("%s: validating configuration", h)
-	output, err := h.ExecOutput(h.Configurer.K0sCmdf(`validate config -c "%s"`, h.K0sConfigPath()))
+	output, err := h.ExecOutput(h.Configurer.K0sCmdf(`validate config --config "%s"`, h.K0sConfigPath()))
 	if err != nil {
 		return fmt.Errorf("spec.k0s.config fails validation:\n%s", output)
 	}

--- a/phase/download_k0s.go
+++ b/phase/download_k0s.go
@@ -24,7 +24,7 @@ func (p *DownloadK0s) Title() string {
 func (p *DownloadK0s) Prepare(config *config.Cluster) error {
 	p.Config = config
 	p.hosts = p.Config.Spec.Hosts.Filter(func(h *cluster.Host) bool {
-		return h.Metadata.K0sBinaryVersion != p.Config.Spec.K0s.Version
+		return h.Metadata.K0sBinaryVersion != p.Config.Spec.K0s.Version && !h.Metadata.NeedsUpgrade
 	})
 	return nil
 }

--- a/phase/gather_k0s_facts.go
+++ b/phase/gather_k0s_facts.go
@@ -116,16 +116,16 @@ func (p *GatherK0sFacts) investigateK0s(h *cluster.Host) error {
 }
 
 func (p *GatherK0sFacts) needsUpgrade(h *cluster.Host) bool {
-	c, err := semver.NewConstraint(fmt.Sprintf("< %s", p.Config.Spec.K0s.Version))
+	target, err := semver.NewVersion(p.Config.Spec.K0s.Version)
 	if err != nil {
-		log.Warnf("%s: failed to parse version constraint: %s", h, err.Error())
+		log.Warnf("%s: failed to parse target version: %s", h, err.Error())
 		return false
 	}
 	current, err := semver.NewVersion(h.Metadata.K0sRunningVersion)
 	if err != nil {
-		log.Warnf("%s: failed to parse version info: %s", h, err.Error())
+		log.Warnf("%s: failed to parse running version: %s", h, err.Error())
 		return false
 	}
 
-	return c.Check(current)
+	return target.GreaterThan(current)
 }

--- a/phase/gather_k0s_facts.go
+++ b/phase/gather_k0s_facts.go
@@ -122,7 +122,7 @@ func (p *GatherK0sFacts) investigateK0s(h *cluster.Host) error {
 func (p *GatherK0sFacts) needsUpgrade(h *cluster.Host) bool {
 	c, err := semver.NewConstraint(fmt.Sprintf("< %s", p.Config.Spec.K0s.Version))
 	if err != nil {
-		log.Warnf("%s: failed to parse version contraint: %s", h, err.Error())
+		log.Warnf("%s: failed to parse version constraint: %s", h, err.Error())
 		return false
 	}
 	current, err := semver.NewVersion(h.Metadata.K0sRunningVersion)

--- a/phase/gather_k0s_facts.go
+++ b/phase/gather_k0s_facts.go
@@ -121,6 +121,10 @@ func (p *GatherK0sFacts) investigateK0s(h *cluster.Host) error {
 
 func (p *GatherK0sFacts) needsUpgrade(h *cluster.Host) bool {
 	c, err := semver.NewConstraint(fmt.Sprintf("< %s", p.Config.Spec.K0s.Version))
+	if err != nil {
+		log.Warnf("%s: failed to parse version contraint: %s", h, err.Error())
+		return false
+	}
 	current, err := semver.NewVersion(h.Metadata.K0sRunningVersion)
 	if err != nil {
 		log.Warnf("%s: failed to parse version info: %s", h, err.Error())

--- a/phase/gather_k0s_facts.go
+++ b/phase/gather_k0s_facts.go
@@ -84,17 +84,11 @@ func (p *GatherK0sFacts) investigateK0s(h *cluster.Host) error {
 		return nil
 	}
 
-<<<<<<< HEAD
 	switch status.Role {
 	case "server":
 		status.Role = "controller"
 	case "server+worker":
 		status.Role = "controller+worker"
-=======
-	// Legacy role change
-	if status.Role == "server" {
-		status.Role = "controller"
->>>>>>> 489e103... Initial upgrade with server->controller migration
 	}
 
 	if status.Role != h.Role {

--- a/phase/gather_k0s_facts.go
+++ b/phase/gather_k0s_facts.go
@@ -99,7 +99,9 @@ func (p *GatherK0sFacts) investigateK0s(h *cluster.Host) error {
 	h.Metadata.NeedsUpgrade = p.needsUpgrade(h)
 
 	log.Infof("%s: is running k0s %s version %s", h, h.Role, h.Metadata.K0sRunningVersion)
-	log.Infof("%s: need upgrade: %t", h, h.Metadata.NeedsUpgrade)
+	if h.Metadata.NeedsUpgrade {
+		log.Warnf("%s: k0s will be upgraded", h)
+	}
 
 	if !h.IsController() {
 		log.Infof("%s: checking if worker %s has joined", p.leader, h.Metadata.Hostname)

--- a/phase/prepare_hosts.go
+++ b/phase/prepare_hosts.go
@@ -35,6 +35,12 @@ func (p *PrepareHosts) prepareHost(h *cluster.Host) error {
 		}
 	}
 
+	if h.NeedIPTables() {
+		if err := h.Configurer.InstallPackage(h, "iptables"); err != nil {
+			return err
+		}
+	}
+
 	if h.IsController() && !h.Configurer.CommandExist(h, "kubectl") {
 		log.Infof("%s: installing kubectl", h)
 		if err := h.Configurer.InstallKubectl(h); err != nil {

--- a/phase/prepare_hosts.go
+++ b/phase/prepare_hosts.go
@@ -35,6 +35,7 @@ func (p *PrepareHosts) prepareHost(h *cluster.Host) error {
 		}
 	}
 
+	// TODO: combine with above using a slice of packages as each  InstallPackage call triggers an apt/zypper/etc update.
 	if h.NeedIPTables() {
 		if err := h.Configurer.InstallPackage(h, "iptables"); err != nil {
 			return err

--- a/phase/upgrade_controllers.go
+++ b/phase/upgrade_controllers.go
@@ -63,6 +63,9 @@ func (p *UpgradeControllers) Run() error {
 		if err := h.WaitK0sServiceRunning(); err != nil {
 			return err
 		}
+		if err := h.WaitKubeAPIReady(); err != nil {
+			return err
+		}
 
 	}
 	return nil

--- a/phase/upgrade_controllers.go
+++ b/phase/upgrade_controllers.go
@@ -1,0 +1,114 @@
+package phase
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/Masterminds/semver"
+	"github.com/k0sproject/k0sctl/config"
+	"github.com/k0sproject/k0sctl/config/cluster"
+	log "github.com/sirupsen/logrus"
+)
+
+// UpgradeControllers upgrades the controllers one-by-one
+type UpgradeControllers struct {
+	GenericPhase
+
+	hosts cluster.Hosts
+}
+
+// Title for the phase
+func (p *UpgradeControllers) Title() string {
+	return "Upgrade controllers"
+}
+
+// Prepare the phase
+func (p *UpgradeControllers) Prepare(config *config.Cluster) error {
+	log.Debugf("UpgradeControllers phase prep starting")
+	p.Config = config
+	var controllers cluster.Hosts = p.Config.Spec.Hosts.Controllers()
+	log.Debugf("%d controllers in total", len(controllers))
+	p.hosts = controllers.Filter(func(h *cluster.Host) bool {
+		return h.Metadata.NeedsUpgrade
+	})
+	log.Debugf("UpgradeControllers phase prepared, %d controllers needs upgrade", len(p.hosts))
+	return nil
+}
+
+// ShouldRun is true when there are controllers that needs to be upgraded
+func (p *UpgradeControllers) ShouldRun() bool {
+	return len(p.hosts) > 0
+}
+
+// Run the phase
+func (p *UpgradeControllers) Run() error {
+	for _, h := range p.hosts {
+		log.Infof("%s: starting upgrade", h)
+		if p.needsMigration(h) {
+			if err := p.migrateService(h); err != nil {
+				return err
+			}
+		} else {
+			h.Configurer.StopService(h, h.K0sServiceName())
+		}
+		if err := h.UpdateK0sBinary(p.Config.Spec.K0s.Version); err != nil {
+			return err
+		}
+		if err := h.Configurer.StartService(h, h.K0sServiceName()); err != nil {
+			return err
+		}
+		log.Infof("%s: waiting for the k0s service to start", h)
+		if err := h.WaitK0sServiceRunning(); err != nil {
+			return err
+		}
+
+	}
+	return nil
+}
+
+func (p *UpgradeControllers) needsUpgrade(h *cluster.Host) bool {
+	log.Debugf("%s: checking need for upgrade")
+	c, err := semver.NewConstraint(fmt.Sprintf("< %s", p.Config.Spec.K0s.Version))
+	current, err := semver.NewVersion(h.Metadata.K0sRunningVersion)
+	if err != nil {
+		log.Warnf("%s: failed to parse version info: %s", h, err.Error())
+		return false
+	}
+
+	return c.Check(current)
+}
+
+func (p *UpgradeControllers) needsMigration(h *cluster.Host) bool {
+	log.Debugf("%s: checking need for 0.10 --> 0.11 migration", h)
+	c, err := semver.NewConstraint("< 0.11")
+	current, err := semver.NewVersion(h.Metadata.K0sRunningVersion)
+	if err != nil {
+		log.Warnf("%s: failed to parse version info: %s", h, err.Error())
+		return false
+	}
+
+	return c.Check(current)
+}
+
+func (p *UpgradeControllers) migrateService(h *cluster.Host) error {
+
+	log.Infof("%s: Running with legacy service name, migrating...", h)
+	h.Configurer.StopService(h, "k0sserver")
+	sp, err := h.Configurer.ServiceScriptPath(h, "k0sserver")
+	if err != nil {
+		return err
+	}
+	if sp == "" {
+		return fmt.Errorf("service script path resolved to empty string")
+	}
+	log.Debugf("%s: found old service path: %s", h, sp)
+	newPath := strings.Replace(sp, "k0sserver", h.K0sServiceName(), 1)
+	if err != nil {
+		return err
+	}
+	if err := h.Configurer.MoveFile(h, sp, newPath); err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/phase/upgrade_controllers.go
+++ b/phase/upgrade_controllers.go
@@ -73,7 +73,7 @@ func (p *UpgradeControllers) Run() error {
 
 func (p *UpgradeControllers) needsMigration(h *cluster.Host) bool {
 	log.Debugf("%s: checking need for 0.10 --> 0.11 migration", h)
-	c, _ := semver.NewConstraint("< 0.11")
+	c, _ := semver.NewConstraint("< 0.11-0")
 	current, err := semver.NewVersion(h.Metadata.K0sRunningVersion)
 	if err != nil {
 		log.Warnf("%s: failed to parse version info: %s", h, err.Error())

--- a/phase/upgrade_controllers.go
+++ b/phase/upgrade_controllers.go
@@ -85,7 +85,7 @@ func (p *UpgradeControllers) needsMigration(h *cluster.Host) bool {
 
 func (p *UpgradeControllers) migrateService(h *cluster.Host) error {
 
-	log.Infof("%s: Running with legacy service name, migrating...", h)
+	log.Infof("%s: updating legacy 'k0sserver' service to '%s'", h, h.K0sServiceName())
 	if err := h.Configurer.StopService(h, "k0sserver"); err != nil {
 		return err
 	}

--- a/phase/upgrade_workers.go
+++ b/phase/upgrade_workers.go
@@ -1,0 +1,97 @@
+package phase
+
+import (
+	"fmt"
+	"math"
+
+	"github.com/gammazero/workerpool"
+	"github.com/k0sproject/k0sctl/config"
+	"github.com/k0sproject/k0sctl/config/cluster"
+	log "github.com/sirupsen/logrus"
+)
+
+// UpgradeWorkers upgrades workers in batches
+type UpgradeWorkers struct {
+	GenericPhase
+
+	hosts  cluster.Hosts
+	leader *cluster.Host
+}
+
+// Title for the phase
+func (p *UpgradeWorkers) Title() string {
+	return "Upgrade workers"
+}
+
+// Prepare the phase
+func (p *UpgradeWorkers) Prepare(config *config.Cluster) error {
+	p.Config = config
+	p.leader = p.Config.Spec.K0sLeader()
+	var workers cluster.Hosts = p.Config.Spec.Hosts.Workers()
+	log.Debugf("%d controllers in total", len(workers))
+	p.hosts = workers.Filter(func(h *cluster.Host) bool {
+		return h.Metadata.NeedsUpgrade
+	})
+	log.Debugf("UpgradeWorkers phase prepared, %d workers needs upgrade", len(p.hosts))
+
+	return nil
+}
+
+// ShouldRun is true when there are workers that needs to be upgraded
+func (p *UpgradeWorkers) ShouldRun() bool {
+	return len(p.hosts) > 0
+}
+
+// Run the phase
+func (p *UpgradeWorkers) Run() error {
+	// Upgrade worker hosts parallelly in 10% chunks
+	concurrentUpgrades := int(math.Floor(float64(len(p.hosts)) * 0.10))
+	if concurrentUpgrades == 0 {
+		concurrentUpgrades = 1
+	}
+	log.Infof("Upgrading %d workers in parallel", concurrentUpgrades)
+	wp := workerpool.New(concurrentUpgrades)
+	errors := make(map[string]error)
+	for _, w := range p.hosts {
+		h := w
+		wp.Submit(func() {
+			err := p.upgradeWorker(h)
+			if err != nil {
+				errors[h.String()] = err
+				log.Errorf("%s: upgrade failed: %s", h, err.Error())
+			}
+		})
+	}
+	wp.StopWait()
+
+	if len(errors) > 0 {
+		return fmt.Errorf("upgrading %d workers failed", len(errors))
+	}
+	return nil
+}
+
+func (p *UpgradeWorkers) upgradeWorker(h *cluster.Host) error {
+	log.Infof("%s: upgrade starting", h)
+	log.Debugf("%s: draining...", h)
+	if err := p.leader.DrainNode(h); err != nil {
+		return err
+	}
+	log.Debugf("%s: draining complete", h)
+
+	log.Debugf("%s: Update and restart service", h)
+	if err := h.Configurer.StopService(h, h.K0sServiceName()); err != nil {
+		return err
+	}
+	if err := h.UpdateK0sBinary(p.Config.Spec.K0s.Version); err != nil {
+		return err
+	}
+	if err := h.Configurer.StartService(h, h.K0sServiceName()); err != nil {
+		return err
+	}
+	log.Debugf("%s: marking node schedulable again", h)
+	if err := p.leader.UncordonNode(h); err != nil {
+		return err
+	}
+	log.Infof("%s: upgrade successful", h)
+	return nil
+}

--- a/phase/upload_binaries.go
+++ b/phase/upload_binaries.go
@@ -21,7 +21,7 @@ func (p *UploadBinaries) Title() string {
 func (p *UploadBinaries) Prepare(config *config.Cluster) error {
 	p.Config = config
 	p.hosts = p.Config.Spec.Hosts.Filter(func(h *cluster.Host) bool {
-		return h.K0sBinaryPath != "" && h.Metadata.K0sBinaryVersion != p.Config.Spec.K0s.Version
+		return h.K0sBinaryPath != "" && h.Metadata.K0sBinaryVersion != p.Config.Spec.K0s.Version && !h.Metadata.NeedsUpgrade
 	})
 	return nil
 }
@@ -33,7 +33,7 @@ func (p *UploadBinaries) ShouldRun() bool {
 
 // Run the phase
 func (p *UploadBinaries) Run() error {
-	return p.Config.Spec.Hosts.ParallelEach(p.uploadBinary)
+	return p.hosts.ParallelEach(p.uploadBinary)
 }
 
 func (p *UploadBinaries) uploadBinary(h *cluster.Host) error {

--- a/smoke-test/.gitignore
+++ b/smoke-test/.gitignore
@@ -1,2 +1,3 @@
 footloose.yaml
 id_rsa*
+k0sctl_040

--- a/smoke-test/Makefile
+++ b/smoke-test/Makefile
@@ -18,3 +18,6 @@ id_rsa_k0s:
 
 smoke-basic: $(footloose) id_rsa_k0s
 	./smoke-basic.sh
+
+smoke-upgrade: $(footloose) id_rsa_k0s
+	./smoke-upgrade.sh

--- a/smoke-test/k0sctl.yaml
+++ b/smoke-test/k0sctl.yaml
@@ -13,4 +13,4 @@ spec:
         port: 9023
         keyPath: ./id_rsa_k0s
   k0s:
-    version: "0.11.0-beta.1"
+    version: "0.11.0-beta.2"

--- a/smoke-test/k0sctl.yaml
+++ b/smoke-test/k0sctl.yaml
@@ -13,4 +13,4 @@ spec:
         port: 9023
         keyPath: ./id_rsa_k0s
   k0s:
-    version: "0.11.0-beta1"
+    version: "0.11.0-beta.1"

--- a/smoke-test/k0sctl_legacy.yaml
+++ b/smoke-test/k0sctl_legacy.yaml
@@ -1,0 +1,16 @@
+apiVersion: k0sctl.k0sproject.io/v1beta1
+kind: cluster
+spec:
+  hosts:
+    - role: server
+      ssh:
+        address: "127.0.0.1"
+        port: 9022
+        keyPath: ./id_rsa_k0s
+    - role: worker
+      ssh:
+        address: "127.0.0.1"
+        port: 9023
+        keyPath: ./id_rsa_k0s
+  k0s:
+    version: "0.10.0"

--- a/smoke-test/smoke-upgrade.sh
+++ b/smoke-test/smoke-upgrade.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+set -e
+
+function downloadOldK0sctl() {
+    curl -sSfL https://github.com/k0sproject/k0sctl/releases/download/v0.4.0/k0sctl-linux-x64 -o k0sctl_040
+    chmod +x k0sctl_040
+}
+
+. ./smoke.common.sh
+trap cleanup EXIT
+
+downloadOldK0sctl
+
+deleteCluster
+createCluster
+./k0sctl_040 apply --config k0sctl_legacy.yaml --debug
+../k0sctl apply --config k0sctl.yaml --debug
+../k0sctl kubeconfig --config k0sctl.yaml | grep -v -- "-data"


### PR DESCRIPTION
Contains now also #90 


Includes now a smoke test for the 0.10 -> 0.11 upgrade. Once there's 0.12 (or whatever comes after 0.11 final) k0s available we can update the upgrade version, change the min required version and drop the migration stuff.

