### PR TITLE
Do not upgrade when version came from defaulting

### DIFF
--- a/cmd/apply.go
+++ b/cmd/apply.go
@@ -60,6 +60,7 @@ var applyCommand = &cli.Command{
 			&phase.GatherFacts{},
 			&phase.ValidateHosts{},
 			&phase.GatherK0sFacts{},
+			&phase.ValidateFacts{},
 			&phase.DownloadBinaries{},
 			&phase.UploadBinaries{},
 			&phase.DownloadK0s{},

--- a/config/cluster/k0s.go
+++ b/config/cluster/k0s.go
@@ -24,7 +24,8 @@ type K0s struct {
 
 // K0sMetadata contains gathered information about k0s cluster
 type K0sMetadata struct {
-	ClusterID string
+	ClusterID        string
+	VersionDefaulted bool
 }
 
 // UnmarshalYAML sets in some sane defaults when unmarshaling the data from yaml
@@ -45,6 +46,7 @@ func (k *K0s) SetDefaults() {
 		preok := version.IsPre() || version.Version == "0.0.0"
 		if latest, err := github.LatestK0sVersion(preok); err == nil {
 			k.Version = latest
+			k.Metadata.VersionDefaulted = true
 		}
 	}
 

--- a/phase/gather_k0s_facts.go
+++ b/phase/gather_k0s_facts.go
@@ -45,7 +45,11 @@ func (p *GatherK0sFacts) Run() error {
 	}
 
 	var workers cluster.Hosts = p.Config.Spec.Hosts.Workers()
-	return workers.ParallelEach(p.investigateK0s)
+	if err := workers.ParallelEach(p.investigateK0s); err != nil {
+		return err
+	}
+
+	return nil
 }
 
 func (p *GatherK0sFacts) investigateK0s(h *cluster.Host) error {

--- a/phase/validate_facts.go
+++ b/phase/validate_facts.go
@@ -1,0 +1,87 @@
+package phase
+
+import (
+	"fmt"
+
+	"github.com/Masterminds/semver"
+	log "github.com/sirupsen/logrus"
+)
+
+// ValidateFacts performs remote OS detection
+type ValidateFacts struct {
+	GenericPhase
+}
+
+// Title for the phase
+func (p *ValidateFacts) Title() string {
+	return "Validate facts"
+}
+
+// Run the phase
+func (p *ValidateFacts) Run() error {
+	if err := p.validateDowngrade(); err != nil {
+		return err
+	}
+
+	if err := p.validateDefaultVersion(); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (p *ValidateFacts) validateDowngrade() error {
+	if p.Config.Spec.K0sLeader().Metadata.K0sRunningVersion == "" {
+		return nil
+	}
+
+	cfgV, err := semver.NewVersion(p.Config.Spec.K0s.Version)
+	if err != nil {
+		return err
+	}
+
+	runV, err := semver.NewVersion(p.Config.Spec.K0sLeader().Metadata.K0sRunningVersion)
+	if err != nil {
+		return err
+	}
+
+	if runV.GreaterThan(cfgV) {
+		return fmt.Errorf("can't perform a downgrade: %s > %s", runV.String(), cfgV.String())
+	}
+
+	return nil
+}
+
+func (p *ValidateFacts) validateDefaultVersion() error {
+	// Only check when running with a defaulted version
+	if !p.Config.Spec.K0s.Metadata.VersionDefaulted {
+		return nil
+	}
+
+	// Installing a fresh latest is ok
+	if p.Config.Spec.K0sLeader().Metadata.K0sRunningVersion == "" {
+		return nil
+	}
+
+	cfgV, err := semver.NewVersion(p.Config.Spec.K0s.Version)
+	if err != nil {
+		return err
+	}
+
+	runV, err := semver.NewVersion(p.Config.Spec.K0sLeader().Metadata.K0sRunningVersion)
+	if err != nil {
+		return err
+	}
+
+	// Upgrading should not be performed if the config version was defaulted
+	if cfgV.GreaterThan(runV) {
+		log.Warnf("spec.k0s.version was automatically defaulted to %s but the cluster is running %s", p.Config.Spec.K0s.Version, runV.String())
+		log.Warnf("to perform an upgrade, set the k0s version in the configuration explicitly")
+		p.Config.Spec.K0s.Version = runV.String()
+		for _, h := range p.Config.Spec.Hosts {
+			h.Metadata.NeedsUpgrade = false
+		}
+	}
+
+	return nil
+}

--- a/phase/validate_hosts.go
+++ b/phase/validate_hosts.go
@@ -4,13 +4,6 @@ import (
 	"fmt"
 
 	"github.com/k0sproject/k0sctl/config/cluster"
-
-	// anonymous import is needed to load the os configurers
-	_ "github.com/k0sproject/k0sctl/configurer"
-	// anonymous import is needed to load the os configurers
-	_ "github.com/k0sproject/k0sctl/configurer/linux"
-	// anonymous import is needed to load the os configurers
-	_ "github.com/k0sproject/k0sctl/configurer/linux/enterpriselinux"
 )
 
 // ValidateHosts performs remote OS detection


### PR DESCRIPTION
Fixes #97 

If `spec.k0s.version` came from defaulting to latest using the online resolver and it is newer than the running version, a warning will be displayed and the apply proceeds as if the version was set to the same as the running version, so no upgrade is performed.

