### PR TITLE
Fix alpine support

### DIFF
--- a/configurer/linux/alpine.go
+++ b/configurer/linux/alpine.go
@@ -17,7 +17,7 @@ type Alpine struct {
 func init() {
 	registry.RegisterOSModule(
 		func(os rig.OSVersion) bool {
-			return os.ID == "slackware"
+			return os.ID == "alpine"
 		},
 		func() interface{} {
 			return Alpine{}


### PR DESCRIPTION
There was a copy & paste mistake, the os-id `slackware` was expected for alpine, obviously it needs to be `alpine`.
