### PR TITLE
Set '--config=/etc/k0s/k0s.yaml' only on controller install

### DIFF
--- a/config/cluster/host.go
+++ b/config/cluster/host.go
@@ -173,7 +173,9 @@ func (h *Host) K0sInstallCommand() string {
 		flags.AddUnlessExist(fmt.Sprintf(`--token-file "%s"`, h.K0sJoinTokenPath()))
 	}
 
-	flags.AddUnlessExist(fmt.Sprintf(`--config "%s"`, h.K0sConfigPath()))
+	if h.IsController() {
+		flags.AddUnlessExist(fmt.Sprintf(`--config "%s"`, h.K0sConfigPath()))
+	}
 
 	return h.Configurer.K0sCmdf("install %s %s", role, flags.Join())
 }

--- a/config/cluster/host_test.go
+++ b/config/cluster/host_test.go
@@ -62,7 +62,7 @@ func TestK0sInstallCommand(t *testing.T) {
 	h := Host{Role: "worker"}
 	h.Configurer = &mockconfigurer{}
 
-	require.Equal(t, `k0s install worker --token-file "from-configurer" --config "from-configurer"`, h.K0sInstallCommand())
+	require.Equal(t, `k0s install worker --token-file "from-configurer"`, h.K0sInstallCommand())
 
 	h.Role = "controller"
 	h.Metadata.IsK0sLeader = true

--- a/smoke-test/k0sctl.yaml
+++ b/smoke-test/k0sctl.yaml
@@ -15,7 +15,7 @@ spec:
         port: 9023
         keyPath: ./id_rsa_k0s
   k0s:
-    version: "0.11.0-rc1"
+    version: "0.11.0"
     config:
       images:
         konnectivity:

--- a/smoke-test/k0sctl.yaml
+++ b/smoke-test/k0sctl.yaml
@@ -16,3 +16,30 @@ spec:
         keyPath: ./id_rsa_k0s
   k0s:
     version: "0.11.0-rc1"
+    config:
+      images:
+        konnectivity:
+          image: us.gcr.io/k8s-artifacts-prod/kas-network-proxy/proxy-agent
+          version: v0.0.13
+        metricsserver:
+          image: gcr.io/k8s-staging-metrics-server/metrics-server
+          version: v0.3.7
+        kubeproxy:
+          image: k8s.gcr.io/kube-proxy
+          version: v1.20.4
+        coredns:
+          image: quay.io/jnummelin/coredns
+          version: 1.7.0
+        calico:
+          cni:
+            image: quay.io/jnummelin/calico-cni
+            version: v3.16.2
+          flexvolume:
+            image: quay.io/jnummelin/calico-pod2daemon-flexvol
+            version: v3.16.2
+          node:
+            image: quay.io/jnummelin/calico-node
+            version: v3.16.2
+          kubecontrollers:
+            image: quay.io/jnummelin/calico-kube-controllers
+            version: v3.16.2


### PR DESCRIPTION
Worker install does not take the config file flag at all

Signed-off-by: Jussi Nummelin <jnummelin@mirantis.com>