### PR TITLE
Use go 1.16 and build darwin-arm64

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -16,7 +16,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v2
       with:
-        go-version: 1.15
+        go-version: 1.16
 
     - name: Go modules cache
       uses: actions/cache@v2
@@ -72,7 +72,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.15
+          go-version: 1.16
 
       - name: Restore the compiled binary for smoke testing
         uses: actions/cache@v2
@@ -120,7 +120,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.15
+          go-version: 1.16
 
       - name: Restore the compiled binary for smoke testing
         uses: actions/cache@v2
@@ -171,7 +171,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.15
+          go-version: 1.16
 
       - name: Restore compiled binary for smoke testing
         uses: actions/cache@v2

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -12,18 +12,18 @@ jobs:
     steps:
       - name: Check out code into the Go module directory
         uses: actions/checkout@v2
-        
+
       # Ugly hack to get the tag name
       # github.ref gives the full reference like refs.tags.v0.0.1-beta1
       - name: Branch name
         id: branch_name
         run: |
           echo ::set-output name=TAG_NAME::${GITHUB_REF#refs/tags/}
-      
+
       - name: Set up Go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.15
+          go-version: 1.16
 
       - name: Build bins
         id: build_bins
@@ -31,7 +31,7 @@ jobs:
           SEGMENT_WRITE_KEY: ${{ secrets.SEGMENT_WRITE_KEY }}
           TAG_NAME: ${{ steps.branch_name.outputs.TAG_NAME }}
         run: make build-all
-      
+
       - name: Create Release in Github
         id: create_release
         uses: actions/create-release@v1
@@ -42,11 +42,11 @@ jobs:
           release_name: ${{ github.ref }}
           draft: true # So we can manually edit before publishing
           prerelease: ${{ contains(github.ref, '-') }} # v0.1.2-beta1, 1.2.3-rc1
-      
+
       - name: Upload artifacts
         id: upload
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # This token is provided by Actions
           TAG_NAME: ${{ steps.branch_name.outputs.TAG_NAME }}
         run: make upload
-          
+

--- a/Makefile
+++ b/Makefile
@@ -18,11 +18,14 @@ bin/k0sctl-win-x64.exe: $(GO_SRCS)
 bin/k0sctl-darwin-x64: $(GO_SRCS)
 	GOOS=darwin GOARCH=amd64 go build $(BUILD_FLAGS) -o bin/k0sctl-darwin-x64 main.go
 
+bin/k0sctl-darwin-arm64: $(GO_SRCS)
+	GOOS=darwin GOARCH=arm64 go build $(BUILD_FLAGS) -o bin/k0sctl-darwin-arm64 main.go
+
 bin/%.sha256: bin/%
 	sha256sum -b $< | sed 's/bin\///' > $@.tmp
 	mv $@.tmp $@
 
-bins := k0sctl-linux-x64 k0sctl-win-x64.exe k0sctl-darwin-x64
+bins := k0sctl-linux-x64 k0sctl-win-x64.exe k0sctl-darwin-x64 k0sctl-darwin-arm64
 checksums := $(addsuffix .sha256,$(bins))
 
 .PHONY: build-all

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/k0sproject/k0sctl
 
-go 1.15
+go 1.16
 
 replace github.com/segmentio/analytics-go v3.1.0+incompatible => github.com/kke/analytics-go v1.2.1-0.20210209122110-10364370169e
 


### PR DESCRIPTION
Fixes #91 

Switches go version used during build to 1.16 which will give some probably unnoticeable size/performance benefits, but will allow building binaries for [Apple M1](https://www.apple.com/mac/m1/)  equipped computers such as the new Macbooks.

There's no go 1.16 on brew yet (due to plenty of formulas that still use GOPATH), so local development on a mac could maybe run into some problems unless go is upgraded manually.

