### PR TITLE
Allow OS overriding in yaml config

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -100,6 +100,44 @@ jobs:
           LINUX_IMAGE: ${{ matrix.image }}
         run: make smoke-basic
 
+  smoke-os-override:
+    name: OS override smoke test
+    needs: build
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out code into the Go module directory
+        uses: actions/checkout@v2
+
+      - name: Set up Go
+        uses: actions/setup-go@v2
+        with:
+          go-version: 1.16
+
+      - name: Restore the compiled binary for smoke testing
+        uses: actions/cache@v2
+        id: restore-compiled-binary
+        with:
+          path: |
+            k0sctl
+          key: build-${{ github.run_id }}
+
+      - name: K0sctl cache
+        uses: actions/cache@v2
+        with:
+          path: |
+            /var/cache/k0sctl
+            ~/.k0sctl/cache
+            !*.log
+          key: k0sctl-cache
+
+      - name: Docker Layer Caching For Footloose
+        uses: satackey/action-docker-layer-caching@v0.0.11
+        continue-on-error: true
+
+      - name: Run OS override smoke test
+        run: make smoke-os-override
+
   smoke-upgrade:
     strategy:
       matrix:

--- a/Makefile
+++ b/Makefile
@@ -57,7 +57,7 @@ upload-%: bin/% $(github_release)
 .PHONY: upload
 upload: $(addprefix upload-,$(bins) $(checksums))
 
-smoketests := smoke-basic smoke-upgrade smoke-reset
+smoketests := smoke-basic smoke-upgrade smoke-reset smoke-os-override
 .PHONY: $(smoketests)
 $(smoketests): k0sctl
 	$(MAKE) -C smoke-test $@

--- a/README.md
+++ b/README.md
@@ -235,6 +235,16 @@ Example:
 * `dstDir`: Destination directory for the file(s). `k0sctl` will create full directory structure if it does not already exist on the host.
 * `perm`: File permission mode for uploaded file(s) and created directories
 
+##### `spec.hosts[*].os` &lt;string&gt; (optional) (default: ``)
+
+Override auto-detected OS distro. By default `k0sctl` detects the OS by reading `/etc/os-release` or `/usr/lib/os-release` files. In case your system is based on e.g. Debian but the OS release info has something else configured you can override `k0sctl`to use Debian based functionality for the node with:
+```yaml
+  - role: worker
+    os: debian
+    ssh:
+      address: 10.0.0.2
+```
+
 ##### `spec.hosts[*].ssh` &lt;mapping&gt; (optional)
 
 SSH connection options.

--- a/README.md
+++ b/README.md
@@ -237,7 +237,7 @@ Example:
 
 ##### `spec.hosts[*].os` &lt;string&gt; (optional) (default: ``)
 
-Override auto-detected OS distro. By default `k0sctl` detects the OS by reading `/etc/os-release` or `/usr/lib/os-release` files. In case your system is based on e.g. Debian but the OS release info has something else configured you can override `k0sctl`to use Debian based functionality for the node with:
+Override auto-detected OS distro. By default `k0sctl` detects the OS by reading `/etc/os-release` or `/usr/lib/os-release` files. In case your system is based on e.g. Debian but the OS release info has something else configured you can override `k0sctl` to use Debian based functionality for the node with:
 ```yaml
   - role: worker
     os: debian

--- a/config/cluster/host.go
+++ b/config/cluster/host.go
@@ -27,7 +27,7 @@ type Host struct {
 	K0sBinaryPath    string            `yaml:"k0sBinaryPath,omitempty"`
 	InstallFlags     Flags             `yaml:"installFlags,omitempty"`
 	Files            []UploadFile      `yaml:"files,omitempty"`
-	OSIDOverride     string            `yaml:"osIdOverride"`
+	OSIDOverride     string            `yaml:"os"`
 
 	Metadata   HostMetadata `yaml:"-"`
 	Configurer configurer   `yaml:"-"`

--- a/config/cluster/host.go
+++ b/config/cluster/host.go
@@ -27,6 +27,7 @@ type Host struct {
 	K0sBinaryPath    string            `yaml:"k0sBinaryPath,omitempty"`
 	InstallFlags     Flags             `yaml:"installFlags,omitempty"`
 	Files            []UploadFile      `yaml:"files,omitempty"`
+	OSIDOverride     string            `yaml:"osIdOverride"`
 
 	Metadata   HostMetadata `yaml:"-"`
 	Configurer configurer   `yaml:"-"`

--- a/phase/detect_os.go
+++ b/phase/detect_os.go
@@ -2,6 +2,7 @@ package phase
 
 import (
 	"github.com/k0sproject/k0sctl/config/cluster"
+
 	// anonymous import is needed to load the os configurers
 	_ "github.com/k0sproject/k0sctl/configurer"
 	// anonymous import is needed to load the os configurers
@@ -25,6 +26,10 @@ func (p *DetectOS) Title() string {
 // Run the phase
 func (p *DetectOS) Run() error {
 	return p.Config.Spec.Hosts.ParallelEach(func(h *cluster.Host) error {
+		if h.OSIDOverride != "" {
+			log.Infof("%s: overriding OS to %s", h, h.OSIDOverride)
+			h.OSVersion.ID = h.OSIDOverride
+		}
 		if err := h.ResolveConfigurer(); err != nil {
 			p.SetProp("missing-support", h.OSVersion.String())
 			return err

--- a/smoke-test/Makefile
+++ b/smoke-test/Makefile
@@ -24,3 +24,6 @@ smoke-upgrade: $(footloose) id_rsa_k0s
 
 smoke-reset: $(footloose) id_rsa_k0s
 	./smoke-reset.sh
+
+smoke-os-override: $(footloose) id_rsa_k0s
+	FOOTLOOSE_TEMPLATE=footloose.yaml.osoverride.tpl OS_RELEASE_PATH=$(realpath os-release) K0SCTL_YAML=k0sctl_osoverride.yaml ./smoke-basic.sh

--- a/smoke-test/footloose.yaml.osoverride.tpl
+++ b/smoke-test/footloose.yaml.osoverride.tpl
@@ -1,0 +1,41 @@
+cluster:
+  name: k0s
+  privateKey: ./id_rsa_k0s
+machines:
+- count: 1
+  backend: docker
+  spec:
+    image: quay.io/footloose/ubuntu18.04
+    name: manager%d
+    privileged: true
+    volumes:
+    - type: bind
+      source: /lib/modules
+      destination: /lib/modules
+    - type: volume
+      destination: /var/lib/k0s
+    portMappings:
+    - containerPort: 22
+      hostPort: 9022
+    - containerPort: 443
+      hostPort: 443
+    - containerPort: 6443
+      hostPort: 6443
+- count: 1
+  backend: docker
+  spec:
+    image: quay.io/footloose/ubuntu18.04
+    name: worker%d
+    privileged: true
+    volumes:
+    - type: bind
+      source: /lib/modules
+      destination: /lib/modules
+    - type: volume
+      destination: /var/lib/k0s
+    - type: bind
+      source: $OS_RELEASE_PATH
+      destination: /etc/os-release
+    portMappings:
+    - containerPort: 22
+      hostPort: 9022

--- a/smoke-test/k0sctl_osoverride.yaml
+++ b/smoke-test/k0sctl_osoverride.yaml
@@ -1,0 +1,46 @@
+apiVersion: k0sctl.k0sproject.io/v1beta1
+kind: cluster
+spec:
+  hosts:
+    - role: controller
+      uploadBinary: true
+      ssh:
+        address: "127.0.0.1"
+        port: 9022
+        keyPath: ./id_rsa_k0s
+    - role: worker
+      uploadBinary: true
+      osIdOverride: ubuntu
+      ssh:
+        address: "127.0.0.1"
+        port: 9023
+        keyPath: ./id_rsa_k0s
+  k0s:
+    version: "0.12.1"
+    config:
+      images:
+        konnectivity:
+          image: us.gcr.io/k8s-artifacts-prod/kas-network-proxy/proxy-agent
+          version: v0.0.13
+        metricsserver:
+          image: gcr.io/k8s-staging-metrics-server/metrics-server
+          version: v0.3.7
+        kubeproxy:
+          image: k8s.gcr.io/kube-proxy
+          version: v1.20.4
+        coredns:
+          image: quay.io/jnummelin/coredns
+          version: 1.7.0
+        calico:
+          cni:
+            image: quay.io/jnummelin/calico-cni
+            version: v3.16.2
+          flexvolume:
+            image: quay.io/jnummelin/calico-pod2daemon-flexvol
+            version: v3.16.2
+          node:
+            image: quay.io/jnummelin/calico-node
+            version: v3.16.2
+          kubecontrollers:
+            image: quay.io/jnummelin/calico-kube-controllers
+            version: v3.16.2

--- a/smoke-test/k0sctl_osoverride.yaml
+++ b/smoke-test/k0sctl_osoverride.yaml
@@ -10,7 +10,7 @@ spec:
         keyPath: ./id_rsa_k0s
     - role: worker
       uploadBinary: true
-      osIdOverride: ubuntu
+      os: ubuntu
       ssh:
         address: "127.0.0.1"
         port: 9023

--- a/smoke-test/os-release
+++ b/smoke-test/os-release
@@ -1,0 +1,12 @@
+NAME="Ubuntu-override-test"
+VERSION="18.04.3 LTS (Bionic Beaver)"
+ID=override-test
+ID_LIKE=debian
+PRETTY_NAME="Override-test -- Ubuntu 18.04.3 LTS"
+VERSION_ID="18.04"
+HOME_URL="https://www.ubuntu.com/"
+SUPPORT_URL="https://help.ubuntu.com/"
+BUG_REPORT_URL="https://bugs.launchpad.net/ubuntu/"
+PRIVACY_POLICY_URL="https://www.ubuntu.com/legal/terms-and-policies/privacy-policy"
+VERSION_CODENAME=bionic
+UBUNTU_CODENAME=bionic

--- a/smoke-test/smoke-basic.sh
+++ b/smoke-test/smoke-basic.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+K0SCTL_YAML=${K0SCTL_YAML:-"k0sctl.yaml"}
+
 set -e
 
 . ./smoke.common.sh
@@ -8,5 +10,5 @@ trap cleanup EXIT
 deleteCluster
 createCluster
 ../k0sctl init
-../k0sctl apply --config k0sctl.yaml --debug
-../k0sctl kubeconfig --config k0sctl.yaml | grep -v -- "-data"
+../k0sctl apply --config ${K0SCTL_YAML} --debug
+../k0sctl kubeconfig --config ${K0SCTL_YAML} | grep -v -- "-data"


### PR DESCRIPTION
Signed-off-by: Jussi Nummelin <jnummelin@mirantis.com>

This PR makes it possible to override detected OS via yaml config for a given host. Example:
```yaml
  - role: worker
    os: debian
    ssh:
      address: 10.0.0.2
```

k0sctl will still read and parse the os-release info, but it will use `debian` as the `OSVersion.ID` field to resolve the host configurer.

**TODO:**

- [x] docs
- [x] figure out better name for the `osIdOverride` field