### PR TITLE
Update rig for SSH forwarding improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -219,7 +219,7 @@ environment:
 
 ###### `spec.hosts[*].files` &lt;sequence&gt; (optional)
 
-List of files to be uploaded to the host. 
+List of files to be uploaded to the host.
 
 Example:
 
@@ -238,6 +238,51 @@ Example:
 ##### `spec.hosts[*].ssh` &lt;mapping&gt; (optional)
 
 SSH connection options.
+
+Example:
+
+```yaml
+spec:
+  hosts:
+    - role: controller
+      ssh:
+        address: 10.0.0.2
+        user: ubuntu
+        keyPath: ~/.ssh/id_rsa
+```
+
+To tunnel connections through a bastion host. The bastion configuration has all the same fields as any SSH connection:
+
+```yaml
+spec:
+  hosts:
+    - role: controller
+      ssh:
+        address: 10.0.0.2
+        user: ubuntu
+        keyPath: ~/.ssh/id_rsa
+        bastion:
+          address: 10.0.0.1
+          user: root
+          keyPath: ~/.ssh/id_rsa2
+```
+
+SSH agent and auth forwarding are also supported, a host without a keyfile:
+
+```yaml
+spec:
+  hosts:
+    - role: controller
+      ssh:
+        address: 10.0.0.2
+        user: ubuntu
+```
+
+```
+$ ssh-add ~/.ssh/aws.pem
+$ ssh -A user@jumphost
+user@jumphost ~ $ k0sctl apply
+```
 
 ###### `spec.hosts[*].ssh.address` &lt;string&gt; (required)
 

--- a/README.md
+++ b/README.md
@@ -251,7 +251,7 @@ spec:
         keyPath: ~/.ssh/id_rsa
 ```
 
-To tunnel connections through a bastion host. The bastion configuration has all the same fields as any SSH connection:
+It's also possible to tunnel connections through a bastion host. The bastion configuration has all the same fields as any SSH connection:
 
 ```yaml
 spec:

--- a/go.mod
+++ b/go.mod
@@ -15,7 +15,7 @@ require (
 	github.com/go-playground/validator/v10 v10.4.1
 	github.com/hashicorp/go-version v1.2.1
 	github.com/k0sproject/dig v0.1.1
-	github.com/k0sproject/rig v0.3.8
+	github.com/k0sproject/rig v0.3.15
 	github.com/logrusorgru/aurora v2.0.3+incompatible
 	github.com/mattn/go-isatty v0.0.12
 	github.com/segmentio/analytics-go v3.1.0+incompatible

--- a/go.sum
+++ b/go.sum
@@ -149,8 +149,8 @@ github.com/jstemmer/go-junit-report v0.0.0-20190106144839-af01ea7f8024/go.mod h1
 github.com/jstemmer/go-junit-report v0.9.1/go.mod h1:Brl9GWCQeLvo8nXZwPNNblvFj/XSXhF0NWZEnDohbsk=
 github.com/k0sproject/dig v0.1.1 h1:TmNoZtsCXF3jDzwSSEEwKjjD7fG5IyG0p8uvK+z1Wyo=
 github.com/k0sproject/dig v0.1.1/go.mod h1:rBcqaQlJpcKdt2x/OE/lPvhGU50u/e95CSm5g/r4s78=
-github.com/k0sproject/rig v0.3.8 h1:OJB5kfRemBIu0RenDL8iDzmEmtRwwVqQeS01YxQl4zY=
-github.com/k0sproject/rig v0.3.8/go.mod h1:2FBHQkR4t9VveNzFF4iNuMGx9T171kKPNuS2PFunASI=
+github.com/k0sproject/rig v0.3.15 h1:hq5GxDw3PiozvteAqlZZbiKMWTA5r8/0FSEeBirbXxg=
+github.com/k0sproject/rig v0.3.15/go.mod h1:2FBHQkR4t9VveNzFF4iNuMGx9T171kKPNuS2PFunASI=
 github.com/kballard/go-shellquote v0.0.0-20180428030007-95032a82bc51 h1:Z9n2FFNUXsshfwJMBgNA0RU6/i7WVaAegv3PtuIHPMs=
 github.com/kballard/go-shellquote v0.0.0-20180428030007-95032a82bc51/go.mod h1:CzGEWj7cYgsdH8dAjBGEr58BoE7ScuLd+fwFZ44+/x8=
 github.com/kisielk/errcheck v1.2.0/go.mod h1:/BMXB+zMLi60iA8Vv6Ksmxu/1UDYcXs4uQLJ+jE2L00=


### PR DESCRIPTION
Fixes #116 

Adds SSH forwarding and bastion host support. `ssh-add foo.pem && ssh -A user@jumphost k0sctl apply` will now utilize auth forwarding. You can also configure a ssh jump-host with:

```yaml
    hosts:
        - role: controller
          ssh:
            address: 10.0.0.2
            keyPath: ~/.ssh/id2_rsa
            bastion:
              address: 10.0.0.1
              keyPath: ~/.ssh/id_rsa
```

Also adds simplistic HostKey checking support:

```yaml
ssh:
  address: 10.0.0.1
  hostKey: ecdsa-sha2-nistp256 AAAAE2Vjfdsvxxcvxvczhnnggff=
```
