### PR TITLE
Fix disable-telemetry flag to be a true boolean flag

### DIFF
--- a/cmd/flags.go
+++ b/cmd/flags.go
@@ -44,9 +44,10 @@ var (
 		TakesFile: true,
 	}
 
-	analyticsFlag = &cli.StringFlag{
-		Name:   "--disable-telemetry",
-		Hidden: true,
+	analyticsFlag = &cli.BoolFlag{
+		Name:    "disable-telemetry",
+		EnvVars: []string{"DISABLE_TELEMETRY"},
+		Hidden:  true,
 	}
 )
 
@@ -95,6 +96,7 @@ func displayCopyright(ctx *cli.Context) error {
 
 func initAnalytics(ctx *cli.Context) error {
 	if ctx.Bool("disable-telemetry") {
+		log.Tracef("disabling telemetry")
 		return nil
 	}
 

--- a/smoke-test/smoke.common.sh
+++ b/smoke-test/smoke.common.sh
@@ -2,6 +2,7 @@ FOOTLOOSE_TEMPLATE=${FOOTLOOSE_TEMPLATE:-"footloose.yaml.tpl"}
 
 export LINUX_IMAGE=${LINUX_IMAGE:-"quay.io/footloose/ubuntu18.04"}
 export PRESERVE_CLUSTER=${PRESERVE_CLUSTER:-""}
+export DISABLE_TELEMETRY=true
 
 
 function createCluster() {


### PR DESCRIPTION
Signed-off-by: Jussi Nummelin <jnummelin@mirantis.com>

The `--disable-telemetry` was defined as string flag, thus making the expected bool flag usage badly broken. This also adds `DISABLE_TELEMETRY` env to set it and now also exercises it during smokes. (although setting it is pointless as smokes do NOT have the Segment token set at all in any case, but proves it's working still)

Fixes #121 

Obsoletes #123 