### PR TITLE
AWS Terraform update to disable source dest check

### DIFF
--- a/examples/aws-tf/main.tf
+++ b/examples/aws-tf/main.tf
@@ -3,7 +3,7 @@ terraform {
 }
 
 provider "aws" {
-  region = "eu-west-1"
+  region = "eu-north-1"
 }
 
 resource "tls_private_key" "k0sctl" {
@@ -83,7 +83,7 @@ locals {
         }
       ]
       k0s = {
-        version = "0.12.1"
+        version = "0.13.1"
       }
     }
   }

--- a/examples/aws-tf/variables.tf
+++ b/examples/aws-tf/variables.tf
@@ -15,5 +15,5 @@ variable "worker_count" {
 
 variable "cluster_flavor" {
   type    = string
-  default = "t2.large"
+  default = "t3.large"
 }

--- a/examples/aws-tf/worker.tf
+++ b/examples/aws-tf/worker.tf
@@ -8,6 +8,7 @@ resource "aws_instance" "cluster-workers" {
   key_name                    = aws_key_pair.cluster-key.key_name
   vpc_security_group_ids      = [aws_security_group.cluster_allow_ssh.id]
   associate_public_ip_address = true
+  source_dest_check = false
 
   root_block_device {
     volume_type = "gp2"


### PR DESCRIPTION
This is to fix the connectivity between nodes, to avoid AWS dropping packets in multi-node clusters.

Signed-off-by: mviitanen <mviitanen@mirantis.com>