### PR TITLE
Use kubectl embedded in k0s

### DIFF
--- a/config/cluster/host.go
+++ b/config/cluster/host.go
@@ -60,7 +60,6 @@ type configurer interface {
 	DeleteFile(os.Host, string) error
 	CommandExist(os.Host, string) bool
 	Hostname(os.Host) string
-	InstallKubectl(os.Host) error
 	KubectlCmdf(string, ...interface{}) string
 	KubeconfigPath() string
 	IsContainer(os.Host) bool

--- a/configurer/linux.go
+++ b/configurer/linux.go
@@ -111,7 +111,7 @@ func (l Linux) KubeconfigPath() string {
 
 // KubectlCmdf returns a command line in sprintf manner for running kubectl on the host using the kubeconfig from KubeconfigPath
 func (l Linux) KubectlCmdf(s string, args ...interface{}) string {
-	return fmt.Sprintf(`sudo kubectl --kubeconfig "%s" %s`, l.KubeconfigPath(), fmt.Sprintf(s, args...))
+	return fmt.Sprintf(`sudo k0s kubectl --kubeconfig "%s" %s`, l.KubeconfigPath(), fmt.Sprintf(s, args...))
 }
 
 // HTTPStatus makes a HTTP GET request to the url and returns the status code or an error

--- a/configurer/linux/alpine.go
+++ b/configurer/linux/alpine.go
@@ -14,23 +14,6 @@ type BaseLinux struct {
 	configurer.Linux
 }
 
-var kubectlInstallScript = []string{
-	`curl -LO "https://dl.k8s.io/release/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/linux/amd64/kubectl"`,
-	`curl -LO "https://dl.k8s.io/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/linux/amd64/kubectl.sha256"`,
-	`echo "$(<kubectl.sha256) kubectl" | sha256sum --check`,
-	`sudo install -o root -g root -m 0755 kubectl /usr/local/bin/kubectl`,
-}
-
-// InstallKubectl installs kubectl using the curl method
-func (l BaseLinux) InstallKubectl(h os.Host) error {
-	for _, c := range kubectlInstallScript {
-		if err := h.Exec(c); err != nil {
-			return err
-		}
-	}
-	return nil
-}
-
 // Alpine provides OS support for Alpine Linux
 type Alpine struct {
 	os.Linux
@@ -51,11 +34,6 @@ func init() {
 // InstallPackage installs packages via slackpkg
 func (l Alpine) InstallPackage(h os.Host, pkg ...string) error {
 	return h.Execf("sudo apk add --update %s", strings.Join(pkg, " "))
-}
-
-// InstallKubectl installs kubectl using the alpine edge/testing repo
-func (l Alpine) InstallKubectl(h os.Host) error {
-	return l.InstallPackage(h, "--repository https://dl-cdn.alpinelinux.org/alpine/edge/testing kubectl")
 }
 
 func (l Alpine) Prepare(h os.Host) error {

--- a/configurer/linux/debian.go
+++ b/configurer/linux/debian.go
@@ -3,7 +3,6 @@ package linux
 import (
 	"github.com/k0sproject/k0sctl/configurer"
 	"github.com/k0sproject/rig"
-	"github.com/k0sproject/rig/os"
 	"github.com/k0sproject/rig/os/linux"
 	"github.com/k0sproject/rig/os/registry"
 )
@@ -23,23 +22,4 @@ func init() {
 			return &Debian{}
 		},
 	)
-}
-
-// InstallKubectl installs kubectl using the gcloud kubernetes repo
-func (c Debian) InstallKubectl(h os.Host) error {
-	if err := c.InstallPackage(h, "apt-transport-https", "gnupg2"); err != nil {
-		return err
-	}
-
-	err := h.Exec(`curl -s https://packages.cloud.google.com/apt/doc/apt-key.gpg | sudo apt-key add -`)
-	if err != nil {
-		return err
-	}
-
-	err = h.Exec(`sudo test -e /etc/apt/sources.list.d/kubernetes.list || (echo "deb https://apt.kubernetes.io/ kubernetes-xenial main" | sudo tee -a /etc/apt/sources.list.d/kubernetes.list)`)
-	if err != nil {
-		return err
-	}
-
-	return c.InstallPackage(h, "kubectl")
 }

--- a/configurer/linux/enterpriselinux.go
+++ b/configurer/linux/enterpriselinux.go
@@ -2,7 +2,6 @@ package linux
 
 import (
 	"github.com/k0sproject/k0sctl/configurer"
-	"github.com/k0sproject/rig/os"
 	"github.com/k0sproject/rig/os/linux"
 )
 
@@ -10,22 +9,4 @@ import (
 type EnterpriseLinux struct {
 	linux.EnterpriseLinux
 	configurer.Linux
-}
-
-// InstallKubectl installs kubectl using the gcloud kubernetes repo
-func (c EnterpriseLinux) InstallKubectl(h os.Host) error {
-	err := c.WriteFile(h, "/etc/yum.repos.d/kubernetes.repo", `[kubernetes]
-name=Kubernetes
-baseurl=https://packages.cloud.google.com/yum/repos/kubernetes-el7-x86_64
-enabled=1
-gpgcheck=1
-repo_gpgcheck=1
-gpgkey=https://packages.cloud.google.com/yum/doc/yum-key.gpg https://packages.cloud.google.com/yum/doc/rpm-package-key.gpg
-`, "0644")
-
-	if err != nil {
-		return err
-	}
-
-	return c.InstallPackage(h, "kubectl")
 }

--- a/phase/prepare_hosts.go
+++ b/phase/prepare_hosts.go
@@ -58,13 +58,6 @@ func (p *PrepareHosts) prepareHost(h *cluster.Host) error {
 		}
 	}
 
-	if h.IsController() && !h.Configurer.CommandExist(h, "kubectl") {
-		log.Infof("%s: installing kubectl", h)
-		if err := h.Configurer.InstallKubectl(h); err != nil {
-			return err
-		}
-	}
-
 	if h.Configurer.IsContainer(h) {
 		log.Infof("%s: is a container, applying a fix", h)
 		if err := h.Configurer.FixContainer(h); err != nil {


### PR DESCRIPTION
Use the kubectl embedded in k0s instead of downloading from network.
This solve issue with air-gap installs.

Signed-off-by: Natanael Copa <ncopa@mirantis.com>