### PR TITLE
Omit empty OS from init output

### DIFF
--- a/config/cluster/host.go
+++ b/config/cluster/host.go
@@ -27,7 +27,7 @@ type Host struct {
 	K0sBinaryPath    string            `yaml:"k0sBinaryPath,omitempty"`
 	InstallFlags     Flags             `yaml:"installFlags,omitempty"`
 	Files            []UploadFile      `yaml:"files,omitempty"`
-	OSIDOverride     string            `yaml:"os"`
+	OSIDOverride     string            `yaml:"os,omitempty"`
 
 	Metadata   HostMetadata `yaml:"-"`
 	Configurer configurer   `yaml:"-"`


### PR DESCRIPTION
#117 added the OS field but didn't add "omitempty", so `k0sctl init` now outputs an empty string for them.

```yaml
# $ k0sctl init
apiVersion: k0sctl.k0sproject.io/v1beta1
kind: Cluster
metadata:
  name: k0s-cluster
spec:
  hosts:
  - ssh:
      address: 10.0.0.1
      user: root
      port: 22
      keyPath: /Users/kimmo/.ssh/id_rsa
    role: controller
    os: "" # <====
  - ssh:
      address: 10.0.0.2
      user: root
      port: 22
      keyPath: /Users/kimmo/.ssh/id_rsa
    role: worker
    os: "" # <====
  k0s:
    version: 1.21.0+k0s.0
```

