### PR TITLE
Improve k0sctl init usefulness by accepting a list of addresses

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -223,3 +223,41 @@ jobs:
         env:
           LINUX_IMAGE: ${{ matrix.image }}
         run: make smoke-reset
+
+  smoke-init:
+    name: Init sub-command smoke test
+    needs: build
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out code into the Go module directory
+        uses: actions/checkout@v2
+
+      - name: Set up Go
+        uses: actions/setup-go@v2
+        with:
+          go-version: 1.16
+
+      - name: Restore the compiled binary for smoke testing
+        uses: actions/cache@v2
+        id: restore-compiled-binary
+        with:
+          path: |
+            k0sctl
+          key: build-${{ github.run_id }}
+
+      - name: K0sctl cache
+        uses: actions/cache@v2
+        with:
+          path: |
+            /var/cache/k0sctl
+            ~/.k0sctl/cache
+            !*.log
+          key: k0sctl-cache
+
+      - name: Docker Layer Caching For Footloose
+        uses: satackey/action-docker-layer-caching@v0.0.11
+        continue-on-error: true
+
+      - name: Run init smoke test
+        run: make smoke-init

--- a/Makefile
+++ b/Makefile
@@ -9,30 +9,17 @@ ENVIRONMENT ?= "development"
 LD_FLAGS = -s -w -X github.com/k0sproject/k0sctl/version.Environment=$(ENVIRONMENT) -X github.com/k0sproject/k0sctl/integration/segment.WriteKey=$(SEGMENT_WRITE_KEY) -X github.com/k0sproject/k0sctl/version.GitCommit=$(GIT_COMMIT) -X github.com/k0sproject/k0sctl/version.Version=$(K0SCTL_VERSION)
 BUILD_FLAGS = -trimpath -a -tags "netgo static_build" -installsuffix netgo -ldflags "$(LD_FLAGS) -extldflags '-static'"
 
-BUILDER_IMAGE = k0sctl-builder
-GO = docker run --rm -v "$(CURDIR)":/go/src/github.com/k0sproject/k0sctl \
-	-w "/go/src/github.com/k0sproject/k0sctl" \
-	-e GOPATH\
-	-e GOOS \
-	-e GOARCH \
-	-e GOEXE \
-	$(BUILDER_IMAGE)
-gosrc = $(wildcard *.go */*.go */*/*.go */*/*/*.go)
-
-builder:
-	docker build -t $(BUILDER_IMAGE) -f Dockerfile.builder .
-
 bin/k0sctl-linux-x64: $(GO_SRCS)
-	GOOS=linux GOARCH=amd64 $(GO) build $(BUILD_FLAGS) -o bin/k0sctl-linux-x64 main.go
+	GOOS=linux GOARCH=amd64 go build $(BUILD_FLAGS) -o bin/k0sctl-linux-x64 main.go
 
 bin/k0sctl-win-x64.exe: $(GO_SRCS)
-	GOOS=windows GOARCH=amd64 $(GO) build $(BUILD_FLAGS) -o bin/k0sctl-win-x64.exe main.go
+	GOOS=windows GOARCH=amd64 go build $(BUILD_FLAGS) -o bin/k0sctl-win-x64.exe main.go
 
-bin/k0sctl-darwin-x64: builder
-	GOOS=darwin GOARCH=amd64 $(GO) go build $(BUILD_FLAGS) -o bin/k0sctl-darwin-x64 main.go
+bin/k0sctl-darwin-x64: $(GO_SRCS)
+	GOOS=darwin GOARCH=amd64 go build $(BUILD_FLAGS) -o bin/k0sctl-darwin-x64 main.go
 
-bin/k0sctl-darwin-arm64: builder
-	GOOS=darwin GOARCH=arm64 $(GO) go build $(BUILD_FLAGS) -o bin/k0sctl-darwin-arm64 main.go
+bin/k0sctl-darwin-arm64: $(GO_SRCS)
+	GOOS=darwin GOARCH=arm64 go build $(BUILD_FLAGS) -o bin/k0sctl-darwin-arm64 main.go
 
 bin/%.sha256: bin/%
 	sha256sum -b $< | sed 's/bin\///' > $@.tmp
@@ -45,7 +32,7 @@ checksums := $(addsuffix .sha256,$(bins))
 build-all: $(addprefix bin/,$(bins) $(checksums))
 
 k0sctl: $(GO_SRCS)
-	$(GO) build $(BUILD_FLAGS) -o k0sctl main.go
+	go build $(BUILD_FLAGS) -o k0sctl main.go
 
 .PHONY: clean
 clean:

--- a/README.md
+++ b/README.md
@@ -85,7 +85,25 @@ If the configuration cluster version `spec.k0s.version` is greater than the vers
 
 ### `k0sctl init`
 
-Generate a configuration template. Use `--k0s` to include an example `spec.k0s.config` k0s configuration block.
+Generate a configuration template. Use `--k0s` to include an example `spec.k0s.config` k0s configuration block. You can also supply a list of host addresses via arguments or stdin.
+
+Output a minimal configuration template:
+
+```sh
+$ k0sctl init > k0sctl.yaml
+```
+
+Output an example configuration with a default k0s config:
+
+```sh
+$ kosctl init --k0s > k0sctl.yaml
+```
+
+Create a configuration from a list of host addresses and pipe it to k0sctl apply:
+
+```sh
+$ k0sctl init 10.0.0.1 10.0.0.2 ubuntu@10.0.0.3:8022 | k0sctl apply --config -
+```
 
 ### `k0sctl reset`
 

--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ $ k0sctl init > k0sctl.yaml
 Output an example configuration with a default k0s config:
 
 ```sh
-$ kosctl init --k0s > k0sctl.yaml
+$ k0sctl init --k0s > k0sctl.yaml
 ```
 
 Create a configuration from a list of host addresses and pipe it to k0sctl apply:

--- a/cmd/apply.go
+++ b/cmd/apply.go
@@ -39,6 +39,7 @@ var applyCommand = &cli.Command{
 	Action: func(ctx *cli.Context) error {
 		start := time.Now()
 		content := ctx.String("config")
+		log.Debugf("Loaded configuration:\n%s", content)
 
 		c := config.Cluster{}
 		if err := yaml.UnmarshalStrict([]byte(content), &c); err != nil {

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -138,7 +138,7 @@ func hostFromAddress(addr, role, user, keypath string) *cluster.Host {
 		host.SSH.KeyPath = keypath
 	}
 
-	defaults.Set(host)
+	_ = defaults.Set(host)
 
 	return host
 }

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -199,9 +199,7 @@ var initCommand = &cli.Command{
 		}
 
 		// Read addresses from args
-		for _, a := range ctx.Args().Slice() {
-			addresses = append(addresses, a)
-		}
+		addresses = append(addresses, ctx.Args().Slice()...)
 
 		role := "controller"
 		for i, a := range addresses {

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -1,7 +1,10 @@
 package cmd
 
 import (
+	"bufio"
 	"os"
+	"strconv"
+	"strings"
 
 	"github.com/creasty/defaults"
 	"github.com/k0sproject/dig"
@@ -80,40 +83,151 @@ telemetry:
   enabled: true
 `)
 
+var defaultHosts = cluster.Hosts{
+	&cluster.Host{
+		Connection: rig.Connection{
+			SSH: &rig.SSH{
+				Address: "10.0.0.1",
+			},
+		},
+		Role: "controller",
+	},
+	&cluster.Host{
+		Connection: rig.Connection{
+			SSH: &rig.SSH{
+				Address: "10.0.0.2",
+			},
+		},
+		Role: "worker",
+	},
+}
+
+func hostFromAddress(addr, role, user, keypath string) *cluster.Host {
+	port := 22
+
+	if idx := strings.Index(addr, "@"); idx > 0 {
+		user = addr[:idx]
+		addr = addr[idx+1:]
+	}
+
+	if idx := strings.Index(addr, ":"); idx > 0 {
+		pstr := addr[idx+1:]
+		if p, err := strconv.Atoi(pstr); err == nil {
+			port = p
+		}
+		addr = addr[:idx]
+	}
+
+	host := &cluster.Host{
+		Connection: rig.Connection{
+			SSH: &rig.SSH{
+				Address: addr,
+				Port:    port,
+			},
+		},
+	}
+	if role != "" {
+		host.Role = role
+	} else {
+		host.Role = "worker"
+	}
+	if user != "" {
+		host.SSH.User = user
+	}
+	if keypath != "" {
+		host.SSH.KeyPath = keypath
+	}
+
+	return host
+}
+
 var initCommand = &cli.Command{
-	Name:  "init",
-	Usage: "Create a configuration template",
+	Name:        "init",
+	Usage:       "Create a configuration template",
+	Description: "Outputs a new k0sctl configuration. When a list of addresses are provided, hosts are generated into the configuration. The list of addresses can also be provided via stdin.",
+	ArgsUsage:   "[[user@]address[:port] ...]",
 	Flags: []cli.Flag{
 		&cli.BoolFlag{
 			Name:  "k0s",
 			Usage: "Include a skeleton k0s config section",
 		},
+		&cli.StringFlag{
+			Name:    "cluster-name",
+			Usage:   "Cluster name",
+			Aliases: []string{"n"},
+			Value:   "k0s-cluster",
+		},
+		&cli.IntFlag{
+			Name:    "controller-count",
+			Usage:   "The number of controllers to create when addresses are given",
+			Aliases: []string{"C"},
+			Value:   1,
+		},
+		&cli.StringFlag{
+			Name:    "user",
+			Usage:   "Host user when addresses given",
+			Aliases: []string{"u"},
+		},
+		&cli.StringFlag{
+			Name:    "key-path",
+			Usage:   "Host key path when addresses given",
+			Aliases: []string{"i"},
+		},
 	},
 	Action: func(ctx *cli.Context) error {
+
+		var hosts cluster.Hosts
+		var addresses []string
+
+		// Read addresses from stdin
+		stat, err := os.Stdin.Stat()
+		if err == nil {
+			if (stat.Mode() & os.ModeCharDevice) == 0 {
+				rd := bufio.NewReader(os.Stdin)
+				for {
+					row, _, err := rd.ReadLine()
+					if err != nil {
+						break
+					}
+					addresses = append(addresses, string(row))
+				}
+				if err != nil {
+					return err
+				}
+
+			}
+		}
+
+		// Read addresses from args
+		for _, a := range ctx.Args().Slice() {
+			addresses = append(addresses, a)
+		}
+
+		role := "controller"
+		for i, a := range addresses {
+			a = strings.TrimSpace(a)
+			if a == "" {
+				continue
+			}
+
+			if i > ctx.Int("controller-count")-1 {
+				role = "worker"
+			}
+
+			hosts = append(hosts, hostFromAddress(a, role, ctx.String("user"), ctx.String("key-path")))
+		}
+
+		if len(hosts) == 0 {
+			hosts = defaultHosts
+		}
+
 		cfg := config.Cluster{
 			APIVersion: config.APIVersion,
 			Kind:       "Cluster",
-			Metadata:   &config.ClusterMetadata{},
+			Metadata:   &config.ClusterMetadata{Name: ctx.String("cluster-name")},
 			Spec: &cluster.Spec{
-				Hosts: cluster.Hosts{
-					&cluster.Host{
-						Connection: rig.Connection{
-							SSH: &rig.SSH{
-								Address: "10.0.0.1",
-							},
-						},
-						Role: "controller",
-					},
-					&cluster.Host{
-						Connection: rig.Connection{
-							SSH: &rig.SSH{
-								Address: "10.0.0.2",
-							},
-						},
-						Role: "worker",
-					},
-				},
-				K0s: cluster.K0s{},
+				Hosts: hosts,
+				K0s:   cluster.K0s{},
 			},
 		}
 

--- a/cmd/init_test.go
+++ b/cmd/init_test.go
@@ -1,0 +1,47 @@
+package cmd
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestBuildHosts(t *testing.T) {
+	addresses := []string{
+		"10.0.0.1",
+		"",
+		"10.0.0.2",
+		"10.0.0.3",
+	}
+	hosts := buildHosts(addresses, 1, "test", "foo")
+	require.Len(t, hosts, 3)
+	require.Len(t, hosts.Controllers(), 1)
+	require.Len(t, hosts.Workers(), 2)
+	require.Equal(t, "test", hosts.First().SSH.User)
+	require.Equal(t, "foo", hosts.First().SSH.KeyPath)
+
+	hosts = buildHosts(addresses, 2, "", "")
+	require.Len(t, hosts, 3)
+	require.Len(t, hosts.Controllers(), 2)
+	require.Len(t, hosts.Workers(), 1)
+	require.Equal(t, "root", hosts.First().SSH.User)
+	require.True(t, strings.HasSuffix(hosts.First().SSH.KeyPath, "/.ssh/id_rsa"))
+}
+
+func TestBuildHostsWithComments(t *testing.T) {
+	addresses := []string{
+		"# controllers",
+		"10.0.0.1",
+		"# workers",
+		"10.0.0.2# second worker",
+		"10.0.0.3 # last worker",
+	}
+	hosts := buildHosts(addresses, 1, "", "")
+	require.Len(t, hosts, 3)
+	require.Len(t, hosts.Controllers(), 1)
+	require.Len(t, hosts.Workers(), 2)
+	require.Equal(t, "10.0.0.1", hosts[0].Address())
+	require.Equal(t, "10.0.0.2", hosts[1].Address())
+	require.Equal(t, "10.0.0.3", hosts[2].Address())
+}

--- a/smoke-test/Makefile
+++ b/smoke-test/Makefile
@@ -19,6 +19,9 @@ id_rsa_k0s:
 smoke-basic: $(footloose) id_rsa_k0s
 	./smoke-basic.sh
 
+smoke-init: $(footloose) id_rsa_k0s
+	./smoke-init.sh
+
 smoke-upgrade: $(footloose) id_rsa_k0s
 	./smoke-upgrade.sh
 

--- a/smoke-test/smoke-basic.sh
+++ b/smoke-test/smoke-basic.sh
@@ -9,6 +9,5 @@ trap cleanup EXIT
 
 deleteCluster
 createCluster
-../k0sctl init
 ../k0sctl apply --config ${K0SCTL_YAML} --debug
 ../k0sctl kubeconfig --config ${K0SCTL_YAML} | grep -v -- "-data"

--- a/smoke-test/smoke-init.sh
+++ b/smoke-test/smoke-init.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+set -e
+
+. ./smoke.common.sh
+trap cleanup EXIT
+
+deleteCluster
+createCluster
+footloose status | grep -v NAME | awk '{print $5 ":" $4}'|sed 's/}//' | ../k0sctl init --keypath ./id_rsa_k0s | ../k0sctl apply --config - --debug

--- a/smoke-test/smoke-init.sh
+++ b/smoke-test/smoke-init.sh
@@ -7,4 +7,4 @@ trap cleanup EXIT
 
 deleteCluster
 createCluster
-footloose status | grep -v NAME | awk '{print $5 ":" $4}'|sed 's/}//' | ../k0sctl init --keypath ./id_rsa_k0s | ../k0sctl apply --config - --debug
+footloose status | grep -v NAME | awk '{print $5 ":" $4}'|sed 's/}//' | ../k0sctl init --key-path ./id_rsa_k0s | ../k0sctl apply --config - --debug

--- a/smoke-test/smoke-init.sh
+++ b/smoke-test/smoke-init.sh
@@ -7,4 +7,4 @@ trap cleanup EXIT
 
 deleteCluster
 createCluster
-footloose status | grep -v NAME | awk '{print $5 ":" $4}'|sed 's/}//' | ../k0sctl init --key-path ./id_rsa_k0s | ../k0sctl apply --config - --debug
+../k0sctl init --key-path ./id_rsa_k0s 127.0.0.1:9022 root@127.0.0.1:9023 | ../k0sctl apply --config - --debug


### PR DESCRIPTION
Trying to make `k0sctl init` a bit more useful and the output actually to be usable as-is when you provide some bits of data.

Addresses can be set via `k0sctl init address1 address2 address3` or  via stdin: `somecommand | k0sctl init`.

The addresses can be:
- just an address
- user@address
- address:ssh_port
- user@address:ssh_port

With the parameter `--controller-count` you can set how many of those hosts are going to be controllers. An alternative would be to use something like `--controllers="address1,address2,..." --workers="address3,address4.."` but that would then be difficult if stdin is accepted 🤔 .

The keypath, default user and cluster name can be set via flags.

Example:
```shell
$ $ go run . init --user admin --cluster-name k0s-r0x --key-path ~/.ssh/id_rsa 10.0.0.1 10.0.0.2:8022 upuntu@10.0.0.3:9022
```
==>
```yaml
apiVersion: k0sctl.k0sproject.io/v1beta1
kind: Cluster
metadata:
  name: k0s-r0x
spec:
  hosts:
  - ssh:
      address: 10.0.0.1
      user: admin
      port: 22
      keyPath: /Users/kimmo/.ssh/id_rsa
    role: controller
    os: ""
  - ssh:
      address: 10.0.0.2
      user: admin
      port: 8022
      keyPath: /Users/kimmo/.ssh/id_rsa
    role: worker
    os: ""
  - ssh:
      address: 10.0.0.3
      user: upuntu
      port: 9022
      keyPath: /Users/kimmo/.ssh/id_rsa
    role: worker
    os: ""
  k0s:
    version: 1.21.0+k0s.0
```