### PR TITLE
Replace sudo -i with sudo -s to fix nil panic on linux

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -15,7 +15,7 @@ require (
 	github.com/go-playground/validator/v10 v10.4.1
 	github.com/hashicorp/go-version v1.2.1
 	github.com/k0sproject/dig v0.1.1
-	github.com/k0sproject/rig v0.3.18
+	github.com/k0sproject/rig v0.3.19
 	github.com/logrusorgru/aurora v2.0.3+incompatible
 	github.com/mattn/go-isatty v0.0.12
 	github.com/segmentio/analytics-go v3.1.0+incompatible

--- a/go.sum
+++ b/go.sum
@@ -149,8 +149,8 @@ github.com/jstemmer/go-junit-report v0.0.0-20190106144839-af01ea7f8024/go.mod h1
 github.com/jstemmer/go-junit-report v0.9.1/go.mod h1:Brl9GWCQeLvo8nXZwPNNblvFj/XSXhF0NWZEnDohbsk=
 github.com/k0sproject/dig v0.1.1 h1:TmNoZtsCXF3jDzwSSEEwKjjD7fG5IyG0p8uvK+z1Wyo=
 github.com/k0sproject/dig v0.1.1/go.mod h1:rBcqaQlJpcKdt2x/OE/lPvhGU50u/e95CSm5g/r4s78=
-github.com/k0sproject/rig v0.3.18 h1:JPHhAKniasN3Jc9w5IGeqiZicVznBNmxKLM6GpNM5M0=
-github.com/k0sproject/rig v0.3.18/go.mod h1:2FBHQkR4t9VveNzFF4iNuMGx9T171kKPNuS2PFunASI=
+github.com/k0sproject/rig v0.3.19 h1:0CCme57hvuGYV7zjdvObJuGCMW4KPlbW+S4JXbb88yw=
+github.com/k0sproject/rig v0.3.19/go.mod h1:2FBHQkR4t9VveNzFF4iNuMGx9T171kKPNuS2PFunASI=
 github.com/kballard/go-shellquote v0.0.0-20180428030007-95032a82bc51 h1:Z9n2FFNUXsshfwJMBgNA0RU6/i7WVaAegv3PtuIHPMs=
 github.com/kballard/go-shellquote v0.0.0-20180428030007-95032a82bc51/go.mod h1:CzGEWj7cYgsdH8dAjBGEr58BoE7ScuLd+fwFZ44+/x8=
 github.com/kisielk/errcheck v1.2.0/go.mod h1:/BMXB+zMLi60iA8Vv6Ksmxu/1UDYcXs4uQLJ+jE2L00=


### PR DESCRIPTION
Updates rig to 0.3.19 to get a fix that changes usages of `sudo -i` to `sudo -s`.

Apparently, with `sudo -i`, on some Linux hosts, things like MOTD and other login messages will be included in the stdout of the command.

There is a slight possibility this breaks things for some hosts that do not add `/*sbin` to PATH during `sudo -s`.

Fixes #128
Fixes #130 
