### PR TITLE
Drop ioutil imports (deprecated)

### DIFF
--- a/cmd/flags.go
+++ b/cmd/flags.go
@@ -3,7 +3,6 @@ package cmd
 import (
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"path"
 	"path/filepath"
@@ -76,7 +75,7 @@ func initConfig(ctx *cli.Context) error {
 	}
 	defer file.Close()
 
-	content, err := ioutil.ReadAll(file)
+	content, err := io.ReadAll(file)
 	if err != nil {
 		return err
 	}
@@ -117,7 +116,7 @@ func initAnalytics(ctx *cli.Context) error {
 // initLogging initializes the logger
 func initLogging(ctx *cli.Context) error {
 	log.SetLevel(log.TraceLevel)
-	log.SetOutput(ioutil.Discard)
+	log.SetOutput(io.Discard)
 	initScreenLogger(logLevelFromCtx(ctx, log.InfoLevel))
 	rig.SetLogger(log.StandardLogger())
 	return initFileLogger()
@@ -127,7 +126,7 @@ func initLogging(ctx *cli.Context) error {
 // TODO too similar to initLogging
 func initSilentLogging(ctx *cli.Context) error {
 	log.SetLevel(log.TraceLevel)
-	log.SetOutput(ioutil.Discard)
+	log.SetOutput(io.Discard)
 	initScreenLogger(logLevelFromCtx(ctx, log.FatalLevel))
 	rig.SetLogger(log.StandardLogger())
 	return initFileLogger()

--- a/integration/github/github.go
+++ b/integration/github/github.go
@@ -3,7 +3,7 @@ package github
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"sort"
 	"strings"
@@ -115,7 +115,7 @@ func unmarshalURLBody(url string, o interface{}) error {
 		return fmt.Errorf("backend returned http %d for %s", resp.StatusCode, url)
 	}
 
-	body, err := ioutil.ReadAll(resp.Body)
+	body, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return err
 	}

--- a/phase/download_binaries.go
+++ b/phase/download_binaries.go
@@ -3,7 +3,6 @@ package phase
 import (
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"os"
 
@@ -112,7 +111,7 @@ func (b binary) url() string {
 func (b binary) downloadTo(path string) error {
 	log.Infof("downloading k0s version %s binary for %s-%s", b.version, b.os, b.arch)
 
-	f, err := ioutil.TempFile("", "k0s")
+	f, err := os.CreateTemp("", "k0s")
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Cleaning up the ioutil imports. Go 1.16 still has them, but they're going to be removed, presumably in the next version.
