### PR TITLE
Move installFlags to correct location in example configuration.

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,18 +138,20 @@ metadata:
 spec:
   hosts:
   - role: controller
+    installFlags:
+    - --debug
     ssh:
       address: 10.0.0.1
       user: root
       port: 22
       keyPath: ~/.ssh/id_rsa
   - role: worker
+    installFlags:
+    - --debug
     ssh:
       address: 10.0.0.2
   k0s:
     version: 0.10.0
-    installFlags:
-    - --debug
     config:
       apiVersion: k0s.k0sproject.io/v1beta1
       kind: Cluster


### PR DESCRIPTION
The `installFlags` option in the README configuration example is currently in the wrong place, `spec.k0s` when it should be in `spec.hosts`. Using the configuration example as is results in errors:
```
FATA yaml: unmarshal errors:
  line 38: field installFlags not found in type cluster.k0s 
```
