### PR TITLE
Check if k0s version has the ability to take/restore backups

### DIFF
--- a/phase/backup.go
+++ b/phase/backup.go
@@ -33,6 +33,11 @@ func (p *Backup) Prepare(config *config.Cluster) error {
 	if leader.Metadata.K0sRunningVersion == "" {
 		return fmt.Errorf("failed to find a running controller")
 	}
+
+	if leader.Exec(leader.Configurer.K0sCmdf("backup --help")) != nil {
+		return fmt.Errorf("the version of k0s on the host does not support taking backups")
+	}
+
 	p.leader = leader
 	return nil
 }

--- a/phase/restore.go
+++ b/phase/restore.go
@@ -30,6 +30,11 @@ func (p *Restore) Prepare(config *config.Cluster) error {
 	log.Debugf("restore from: %s", p.RestoreFrom)
 	p.Config = config
 	p.leader = p.Config.Spec.K0sLeader()
+
+	if p.leader.Exec(p.leader.Configurer.K0sCmdf("restore --help")) != nil {
+		return fmt.Errorf("the version of k0s on the host does not support restoring backups")
+	}
+
 	log.Debugf("restore leader: %s", p.leader)
 	log.Debugf("restore leader state: %+v", p.leader.Metadata)
 	return nil

--- a/phase/restore.go
+++ b/phase/restore.go
@@ -31,7 +31,7 @@ func (p *Restore) Prepare(config *config.Cluster) error {
 	p.Config = config
 	p.leader = p.Config.Spec.K0sLeader()
 
-	if p.leader.Exec(p.leader.Configurer.K0sCmdf("restore --help")) != nil {
+	if p.RestoreFrom != "" && p.leader.Exec(p.leader.Configurer.K0sCmdf("restore --help")) != nil {
 		return fmt.Errorf("the version of k0s on the host does not support restoring backups")
 	}
 


### PR DESCRIPTION
Simplistic check done via `k0s backup --help` / `k0s restore --help` to give a meaningful error when backup operations can't be performed on the k0s version.

```shell
root@host0:~# k0s backup --help && echo yes
Back-Up k0s configuration. Must be run as root (or with sudo)

Usage:
  k0s backup [flags]
...
yes
root@host0:~# k0s jackup --help && echo yes
Error: unknown command "jackup" for "k0s"
Run 'k0s --help' for usage.
2021-06-17 06:34:54.685468 I | unknown command "jackup" for "k0s"
root@host0:~#
```
