### PR TITLE
Allow OCI bundles or k0s binary definitions to trigger upgrades.

### DIFF
--- a/phase/gather_k0s_facts.go
+++ b/phase/gather_k0s_facts.go
@@ -120,6 +120,13 @@ func (p *GatherK0sFacts) investigateK0s(h *cluster.Host) error {
 }
 
 func (p *GatherK0sFacts) needsUpgrade(h *cluster.Host) bool {
+	// If supplimental files or a k0s binary have been specified explicitly,
+	// always upgrade.  This covers the scenario where a user moves from a
+	// default-install cluster to one fed by OCI image bundles (ie. airgap)
+	if len(h.Files) != 0 || len(h.K0sBinaryPath) == 0 {
+		return true
+	}
+
 	target, err := semver.NewVersion(p.Config.Spec.K0s.Version)
 	if err != nil {
 		log.Warnf("%s: failed to parse target version: %s", h, err.Error())


### PR DESCRIPTION
This addresses a scenario where a default k0s cluster receives its next `k0sctl apply` update with either a new k0s binary or OCI image bundle.  Previously, this would not appear as an upgrade and the nodes k0s* services would need to be restarted manually.

Signed-off-by: Shane Jarych <sjarych@mirantis.com>