### PR TITLE
Use private address as etcd peerAddress when defined

### DIFF
--- a/phase/configure_k0s.go
+++ b/phase/configure_k0s.go
@@ -172,7 +172,7 @@ func (p *ConfigureK0s) configFor(h *cluster.Host) (string, error) {
 	addUnlessExist(&sans, "127.0.0.1")
 	cfg.DigMapping("spec", "api")["sans"] = sans
 
-	if cfg.Dig("spec", "storage", "etcd", "peerAddress") != nil {
+	if cfg.Dig("spec", "storage", "etcd", "peerAddress") != nil || h.PrivateAddress != "" {
 		cfg.DigMapping("spec", "storage", "etcd")["peerAddress"] = addr
 	}
 


### PR DESCRIPTION
Relates to #168.

Another option would be to always set etcd's peerAddress with the value of addr. I'm open to suggestions.