### PR TITLE
Fix k0s version sorting

### DIFF
--- a/integration/github/github.go
+++ b/integration/github/github.go
@@ -93,26 +93,24 @@ func vCompare(a, b *version.Version) int {
 	if reflect.DeepEqual(segmentsSelf, segmentsOther) {
 		preSelf := a.Prerelease()
 		preOther := b.Prerelease()
-		if preSelf == preOther {
-			if strings.Contains(a.String(), "+") && strings.Contains(b.String(), "+") {
-				// go to plain string comparison
-				s := []string{
-					a.String(),
-					b.String(),
-				}
-				sort.Strings(s)
-				switch a.String() {
-				case s[0]:
-					return -1
-				case s[1]:
-					return 1
-				default:
-					return 0
-				}
+		if preSelf == preOther && strings.Contains(a.String(), "+") && strings.Contains(b.String(), "+") {
+			// go to plain string comparison
+			s := []string{
+				a.String(),
+				b.String(),
+			}
+			sort.Strings(s)
+			switch a.String() {
+			case s[0]:
+				return -1
+			case s[1]:
+				return 1
+			default:
+				return 0
 			}
 		}
 	}
-	// not the case of buildtag comparison, use original from version pkg
+	// not a case requiring buildtag comparison, use original from version pkg
 
 	return a.Compare(b)
 }

--- a/integration/github/github.go
+++ b/integration/github/github.go
@@ -93,8 +93,12 @@ func vCompare(a, b *version.Version) int {
 	}
 
 	if !strings.Contains(a.String(), "+") || !strings.Contains(b.String(), "+") {
-		// versions do not include build tags, use the version pkg result
-		return c
+		// both versions do not include build tags
+		if strings.Contains(a.String(), "+") {
+			// version A has a build tag, B doesn't, assume version A is newer.
+			return 1
+		}
+		return -1
 	}
 
 	// go to plain string comparison

--- a/integration/github/github.go
+++ b/integration/github/github.go
@@ -81,40 +81,23 @@ func (v versionCollection) Swap(i, j int) {
 // returns -1, 0, or 1 if this version is smaller, equal,
 // or larger than the other version, respectively.
 func vCompare(a, b *version.Version) int {
-	// A quick, efficient equality check
-	if a.String() == b.String() {
-		return 0
-	}
-
 	c := a.Compare(b)
 	if c != 0 {
 		// versions already differ enough to use the version pkg result
 		return c
 	}
 
-	if !strings.Contains(a.String(), "+") || !strings.Contains(b.String(), "+") {
-		// both versions do not include build tags
-		if strings.Contains(a.String(), "+") {
-			// version A has a build tag, B doesn't, assume version A is newer.
-			return 1
-		}
+	vA := a.String()
+
+	// go to plain string comparison
+	s := []string{vA, b.String()}
+	sort.Strings(s)
+
+	if vA == s[0] {
 		return -1
 	}
 
-	// go to plain string comparison
-	s := []string{
-		a.String(),
-		b.String(),
-	}
-	sort.Strings(s)
-	switch a.String() {
-	case s[0]:
-		return -1
-	case s[1]:
-		return 1
-	default:
-		return 0
-	}
+	return 1
 }
 
 // LatestRelease returns the semantically sorted latest version from github releases page for a repo.


### PR DESCRIPTION
Changes k0s version sorting to use alphabetical buildtag sorting if the versions are otherwise equal.

Fixes #166 

Before:

```
$ k0sctl version --k0s
1.21.2+k0s.0
```

After:

```
$ k0sctl version --k0s
1.21.2+k0s.1
```

