### PR TITLE
Avoid losing custom SANs for non-leader controllers

### DIFF
--- a/phase/configure_k0s.go
+++ b/phase/configure_k0s.go
@@ -172,7 +172,7 @@ func (p *ConfigureK0s) configFor(h *cluster.Host) (string, error) {
 	addUnlessExist(&sans, "127.0.0.1")
 	cfg.DigMapping("spec", "api")["sans"] = sans
 
-	if cfg.Dig("spec", "storage", "etcd", "peerAddress") != nil {
+	if cfg.Dig("spec", "storage", "etcd", "peerAddress") != nil || h.PrivateAddress != "" {
 		cfg.DigMapping("spec", "storage", "etcd")["peerAddress"] = addr
 	}
 

--- a/phase/configure_k0s.go
+++ b/phase/configure_k0s.go
@@ -153,12 +153,17 @@ func (p *ConfigureK0s) configFor(h *cluster.Host) (string, error) {
 	cfg.DigMapping("spec", "api")["address"] = addr
 	addUnlessExist(&sans, addr)
 
-	oldsans, ok := cfg.Dig("spec", "api", "sans").([]interface{})
-	if ok {
+	oldsans := cfg.Dig("spec", "api", "sans")
+	switch oldsans := oldsans.(type) {
+	case []interface{}:
 		for _, v := range oldsans {
 			if s, ok := v.(string); ok {
 				addUnlessExist(&sans, s)
 			}
+		}
+	case []string:
+		for _, v := range oldsans {
+			addUnlessExist(&sans, v)
 		}
 	}
 


### PR DESCRIPTION
## Context
I want my cluster to only use IPs from the internal network of my cloud provider (Hetzner) to be able to stop the public interface of my control plane's load balancer. But I also want the public IP of my load balancer in the certificate, just in case.

## Problem
When I add my load balancer public IP in `spec.api.sans`, it's added only in the init controller and not in all of them. After some debugging, it seems the issues is that `cfg.Dig("spec", "api", "sans")` is either a `[]interface{}` or a `[]string`.

## Solution
Handle both types. I was too lazy to try understanding the `Dig` thing, so a better solution may exist.

