### PR TITLE
Improve node join timeout error message

### DIFF
--- a/config/cluster/host.go
+++ b/config/cluster/host.go
@@ -277,7 +277,7 @@ func (h *Host) WaitKubeNodeReady(node *Host) error {
 				return err
 			}
 			if !status {
-				return fmt.Errorf("%s: node %s did not become ready", h, node.Metadata.Hostname)
+				return fmt.Errorf("%s: node %s status not reported as ready", h, node.Metadata.Hostname)
 			}
 			return nil
 		},

--- a/config/cluster/host.go
+++ b/config/cluster/host.go
@@ -257,13 +257,15 @@ func (h *Host) KubeNodeReady(node *Host) (bool, error) {
 	}
 	for _, i := range status.Items {
 		for _, c := range i.Status.Conditions {
+			log.Debugf("%s: node status condition %s = %s", node, c.Type, c.Status)
 			if c.Type == "Ready" {
 				return c.Status == "True", nil
 			}
 		}
 	}
 
-	return false, fmt.Errorf("failed to parse status from kubectl output")
+	log.Debugf("%s: failed to find Ready=True state in kubectl output", node)
+	return false, nil
 }
 
 // WaitKubeNodeReady blocks until node becomes ready. TODO should probably use Context


### PR DESCRIPTION
Addresses the misleading error message reported in #150 and #178

The `KubeNodeReady` should not report an error but `false` when the `kubectl` output was parsed correctly without finding a `Ready==True` status condition.

This caused the error message to state `failed to parse status from kubectl output` when in reality, it just gave up on waiting. The message now in this case will become: `10.2.3.4: node foo status not reported as ready`.
