### PR TITLE
Use worker's private address as kubelet's node-ip

### DIFF
--- a/config/cluster/host.go
+++ b/config/cluster/host.go
@@ -197,11 +197,11 @@ func (h *Host) K0sInstallCommand() string {
 	if !h.IsController() && h.PrivateAddress != "" {
 		// set worker's private address to --node-ip in --extra-kubelet-args
 		var extra Flags
-		if old := flags.GetValue("--extra-kubelet-args"); old != "" {
+		if old := flags.GetValue("--kubelet-extra-args"); old != "" {
 			extra = Flags{unQE(old)}
 		}
 		extra.AddUnlessExist(fmt.Sprintf("--node-ip=%s", h.PrivateAddress))
-		flags.AddOrReplace(fmt.Sprintf("--extra-kubelet-args=%s", strconv.Quote(extra.Join())))
+		flags.AddOrReplace(fmt.Sprintf("--kubelet-extra-args=%s", strconv.Quote(extra.Join())))
 	}
 
 	return h.Configurer.K0sCmdf("install %s %s", role, flags.Join())

--- a/config/cluster/host.go
+++ b/config/cluster/host.go
@@ -3,6 +3,8 @@ package cluster
 import (
 	"encoding/json"
 	"fmt"
+	"regexp"
+	"strconv"
 	"strings"
 	"time"
 
@@ -162,6 +164,18 @@ func (h *Host) K0sConfigPath() string {
 	return h.Configurer.K0sConfigPath()
 }
 
+// unquote + unescape a string
+func unQE(s string) string {
+	unq, err := strconv.Unquote(s)
+	if err != nil {
+		return s
+	}
+
+	c := string(s[0])                                           // string was quoted, c now has the quote char
+	re := regexp.MustCompile(fmt.Sprintf(`(?:^|[^\\])\\%s`, c)) // replace \" with " (remove escaped quotes inside quoted string)
+	return string(re.ReplaceAllString(unq, c))
+}
+
 // K0sInstallCommand returns a full command that will install k0s service with necessary flags
 func (h *Host) K0sInstallCommand() string {
 	role := h.Role
@@ -178,6 +192,16 @@ func (h *Host) K0sInstallCommand() string {
 
 	if h.IsController() {
 		flags.AddUnlessExist(fmt.Sprintf(`--config "%s"`, h.K0sConfigPath()))
+	}
+
+	if !h.IsController() && h.PrivateAddress != "" {
+		// set worker's private address to --node-ip in --extra-kubelet-args
+		var extra Flags
+		if old := flags.GetValue("--extra-kubelet-args"); old != "" {
+			extra = Flags{unQE(old)}
+		}
+		extra.AddUnlessExist(fmt.Sprintf("--node-ip=%s", h.PrivateAddress))
+		flags.AddOrReplace(fmt.Sprintf("--extra-kubelet-args=%s", strconv.Quote(extra.Join())))
 	}
 
 	return h.Configurer.K0sCmdf("install %s %s", role, flags.Join())

--- a/config/cluster/host_test.go
+++ b/config/cluster/host_test.go
@@ -58,6 +58,12 @@ func TestK0sConfigPath(t *testing.T) {
 	require.Equal(t, "from-install-short-flag", h.K0sConfigPath())
 }
 
+func TestUnQE(t *testing.T) {
+	require.Equal(t, `hello`, unQE(`hello`))
+	require.Equal(t, `hello`, unQE(`"hello"`))
+	require.Equal(t, `hello "world"`, unQE(`"hello \"world\""`))
+}
+
 func TestK0sInstallCommand(t *testing.T) {
 	h := Host{Role: "worker"}
 	h.Configurer = &mockconfigurer{}
@@ -75,4 +81,10 @@ func TestK0sInstallCommand(t *testing.T) {
 	require.Equal(t, `k0s install controller --enable-worker --config "from-configurer"`, h.K0sInstallCommand())
 	h.Metadata.IsK0sLeader = false
 	require.Equal(t, `k0s install controller --enable-worker --token-file "from-configurer" --config "from-configurer"`, h.K0sInstallCommand())
+
+	h.Role = "worker"
+	h.PrivateAddress = "10.0.0.9"
+	require.Equal(t, `k0s install worker --token-file "from-configurer" --extra-kubelet-args="--node-ip=10.0.0.9"`, h.K0sInstallCommand())
+	h.InstallFlags = []string{`--extra-kubelet-args="--foo bar"`}
+	require.Equal(t, `k0s install worker --extra-kubelet-args="--foo bar --node-ip=10.0.0.9" --token-file "from-configurer"`, h.K0sInstallCommand())
 }

--- a/config/cluster/host_test.go
+++ b/config/cluster/host_test.go
@@ -85,6 +85,6 @@ func TestK0sInstallCommand(t *testing.T) {
 	h.Role = "worker"
 	h.PrivateAddress = "10.0.0.9"
 	require.Equal(t, `k0s install worker --token-file "from-configurer" --kubelet-extra-args="--node-ip=10.0.0.9"`, h.K0sInstallCommand())
-	h.InstallFlags = []string{`--extra-kubelet-args="--foo bar"`}
+	h.InstallFlags = []string{`--kubelet-extra-args="--foo bar"`}
 	require.Equal(t, `k0s install worker --kubelet-extra-args="--foo bar --node-ip=10.0.0.9" --token-file "from-configurer"`, h.K0sInstallCommand())
 }

--- a/config/cluster/host_test.go
+++ b/config/cluster/host_test.go
@@ -84,7 +84,7 @@ func TestK0sInstallCommand(t *testing.T) {
 
 	h.Role = "worker"
 	h.PrivateAddress = "10.0.0.9"
-	require.Equal(t, `k0s install worker --token-file "from-configurer" --extra-kubelet-args="--node-ip=10.0.0.9"`, h.K0sInstallCommand())
+	require.Equal(t, `k0s install worker --token-file "from-configurer" --kubelet-extra-args="--node-ip=10.0.0.9"`, h.K0sInstallCommand())
 	h.InstallFlags = []string{`--extra-kubelet-args="--foo bar"`}
-	require.Equal(t, `k0s install worker --extra-kubelet-args="--foo bar --node-ip=10.0.0.9" --token-file "from-configurer"`, h.K0sInstallCommand())
+	require.Equal(t, `k0s install worker --kubelet-extra-args="--foo bar --node-ip=10.0.0.9" --token-file "from-configurer"`, h.K0sInstallCommand())
 }

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.16
 require (
 	github.com/AlecAivazis/survey/v2 v2.2.8
 	github.com/Masterminds/semver v1.5.0
+	github.com/alessio/shellescape v1.4.1
 	github.com/avast/retry-go v3.0.0+incompatible
 	github.com/bmizerany/assert v0.0.0-20160611221934-b7ed37b82869 // indirect
 	github.com/creasty/defaults v1.5.1

--- a/phase/gather_facts.go
+++ b/phase/gather_facts.go
@@ -34,20 +34,18 @@ func (p *GatherFacts) investigateHost(h *cluster.Host) error {
 
 	h.Metadata.Hostname = h.Configurer.Hostname(h)
 
-	if h.IsController() {
-		if h.PrivateAddress == "" {
-			if h.PrivateInterface == "" {
-				if iface, err := h.Configurer.PrivateInterface(h); err == nil {
-					h.PrivateInterface = iface
-					log.Infof("%s: discovered %s as private interface", h, iface)
-				}
+	if h.PrivateAddress == "" {
+		if h.PrivateInterface == "" {
+			if iface, err := h.Configurer.PrivateInterface(h); err == nil {
+				h.PrivateInterface = iface
+				log.Infof("%s: discovered %s as private interface", h, iface)
 			}
+		}
 
-			if h.PrivateInterface != "" {
-				if addr, err := h.Configurer.PrivateAddress(h, h.PrivateInterface, h.Address()); err == nil {
-					h.PrivateAddress = addr
-					log.Infof("%s: discovered %s as private address", h, addr)
-				}
+		if h.PrivateInterface != "" {
+			if addr, err := h.Configurer.PrivateAddress(h, h.PrivateInterface, h.Address()); err == nil {
+				h.PrivateAddress = addr
+				log.Infof("%s: discovered %s as private address", h, addr)
 			}
 		}
 	}


### PR DESCRIPTION
Fixes #179 

As mentioned in the issue, k0sctl should automatically set the `--extra-kubelet-args="--node-ip x.x.x.x"` for workers having a private address.

The private address is now auto-discovered during Gather Facts for workers too.
