### PR TITLE
Flip windows curl check logic

### DIFF
--- a/config/cluster/host.go
+++ b/config/cluster/host.go
@@ -372,7 +372,7 @@ func (h *Host) WaitK0sServiceRunning() error {
 func (h *Host) NeedCurl() bool {
 	// Windows does not need any packages for web requests
 	if h.Configurer.Kind() == "windows" {
-		return true
+		return false
 	}
 
 	// Controllers always need curl


### PR DESCRIPTION
Looks like the logic is backwards in the `Host.NeedCurl()` function for windows. 
