### PR TITLE
Fix spec.api.sans inconsistency

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,6 @@ go 1.16
 require (
 	github.com/AlecAivazis/survey/v2 v2.2.8
 	github.com/Masterminds/semver v1.5.0
-	github.com/alessio/shellescape v1.4.1
 	github.com/avast/retry-go v3.0.0+incompatible
 	github.com/bmizerany/assert v0.0.0-20160611221934-b7ed37b82869 // indirect
 	github.com/creasty/defaults v1.5.1
@@ -13,7 +12,7 @@ require (
 	github.com/gammazero/workerpool v1.1.1
 	github.com/go-playground/validator/v10 v10.4.1
 	github.com/hashicorp/go-version v1.2.1
-	github.com/k0sproject/dig v0.1.1
+	github.com/k0sproject/dig v0.2.0
 	github.com/k0sproject/rig v0.3.23
 	github.com/logrusorgru/aurora v2.0.3+incompatible
 	github.com/mattn/go-isatty v0.0.12

--- a/go.sum
+++ b/go.sum
@@ -147,8 +147,8 @@ github.com/json-iterator/go v1.1.10 h1:Kz6Cvnvv2wGdaG/V8yMvfkmNiXq9Ya2KUv4rouJJr
 github.com/json-iterator/go v1.1.10/go.mod h1:KdQUCv79m/52Kvf8AW2vK1V8akMuk1QjK/uOdHXbAo4=
 github.com/jstemmer/go-junit-report v0.0.0-20190106144839-af01ea7f8024/go.mod h1:6v2b51hI/fHJwM22ozAgKL4VKDeJcHhJFhtBdhmNjmU=
 github.com/jstemmer/go-junit-report v0.9.1/go.mod h1:Brl9GWCQeLvo8nXZwPNNblvFj/XSXhF0NWZEnDohbsk=
-github.com/k0sproject/dig v0.1.1 h1:TmNoZtsCXF3jDzwSSEEwKjjD7fG5IyG0p8uvK+z1Wyo=
-github.com/k0sproject/dig v0.1.1/go.mod h1:rBcqaQlJpcKdt2x/OE/lPvhGU50u/e95CSm5g/r4s78=
+github.com/k0sproject/dig v0.2.0 h1:cNxEIl96g9kqSMfPSZLhpnZ0P8bWXKv08nxvsMHop5w=
+github.com/k0sproject/dig v0.2.0/go.mod h1:rBcqaQlJpcKdt2x/OE/lPvhGU50u/e95CSm5g/r4s78=
 github.com/k0sproject/rig v0.3.23 h1:jmGxX8nuT0GNrjmjCCQIASaSPg5g26gYJjdPMo6Mu2Y=
 github.com/k0sproject/rig v0.3.23/go.mod h1:6BgqiLQMw5SCMrysZ42ORzyXd3NOyr9KDEa2UGYphdY=
 github.com/kballard/go-shellquote v0.0.0-20180428030007-95032a82bc51 h1:Z9n2FFNUXsshfwJMBgNA0RU6/i7WVaAegv3PtuIHPMs=

--- a/phase/configure_k0s.go
+++ b/phase/configure_k0s.go
@@ -40,13 +40,8 @@ func (p *ConfigureK0s) Run() error {
 		p.SetProp("default-config", false)
 	}
 
-	for _, h := range p.Config.Spec.Hosts.Controllers() {
-		if err := p.configureK0s(h); err != nil {
-			return err
-		}
-	}
-
-	return nil
+	controllers := p.Config.Spec.Hosts.Controllers()
+	return controllers.ParallelEach(p.configureK0s)
 }
 
 func (p *ConfigureK0s) validateConfig(h *cluster.Host) error {
@@ -140,7 +135,7 @@ func addUnlessExist(slice *[]string, s string) {
 }
 
 func (p *ConfigureK0s) configFor(h *cluster.Host) (string, error) {
-	cfg := p.Config.Spec.K0s.Config
+	cfg := p.Config.Spec.K0s.Config.Dup()
 
 	var sans []string
 


### PR DESCRIPTION
Fixes #188  (hopefully)

Seems each iteration over the controllers modify the same copy of `p.Config.Spec.K0s.Config`, which, assumedly, causes the problem reported in the issue.
