### PR TITLE
Fix k0s config generation

### DIFF
--- a/phase/configure_k0s.go
+++ b/phase/configure_k0s.go
@@ -177,7 +177,7 @@ func (p *ConfigureK0s) configFor(h *cluster.Host) (string, error) {
 		cfg.DigMapping("spec", "storage", "etcd")["peerAddress"] = addr
 	}
 
-	c, err := yaml.Marshal(p.Config.Spec.K0s.Config)
+	c, err := yaml.Marshal(cfg)
 	if err != nil {
 		return "", err
 	}


### PR DESCRIPTION
Hi,

I just broke one cluster rerunning `apply` on a cluster with the latest commit on `main`.
I believe this fix the issue. (Not my cluster :sweat_smile:)