### PR TITLE
Fix apply without K0sBinaryPath always performing an upgrade

### DIFF
--- a/phase/gather_k0s_facts.go
+++ b/phase/gather_k0s_facts.go
@@ -124,7 +124,7 @@ func (p *GatherK0sFacts) needsUpgrade(h *cluster.Host) bool {
 	// If supplimental files or a k0s binary have been specified explicitly,
 	// always upgrade.  This covers the scenario where a user moves from a
 	// default-install cluster to one fed by OCI image bundles (ie. airgap)
-	if len(h.Files) != 0 || len(h.K0sBinaryPath) != 0 {
+	if len(h.Files) > 0 || h.K0sBinaryPath != "" {
 		return true
 	}
 

--- a/phase/gather_k0s_facts.go
+++ b/phase/gather_k0s_facts.go
@@ -124,7 +124,7 @@ func (p *GatherK0sFacts) needsUpgrade(h *cluster.Host) bool {
 	// If supplimental files or a k0s binary have been specified explicitly,
 	// always upgrade.  This covers the scenario where a user moves from a
 	// default-install cluster to one fed by OCI image bundles (ie. airgap)
-	if len(h.Files) != 0 || len(h.K0sBinaryPath) == 0 {
+	if len(h.Files) != 0 || len(h.K0sBinaryPath) != 0 {
 		return true
 	}
 


### PR DESCRIPTION
Hi,

If I don't set `K0sBinaryPath` then `apply` will always upgrade. I don't think this is the intended behavior.