### PR TITLE
Fix terraform output command in hetzner example

### DIFF
--- a/examples/hetzner-tf/README.md
+++ b/examples/hetzner-tf/README.md
@@ -5,9 +5,10 @@ This directory provides an example flow with `k0sctl` tool together with Terrafo
 ## Prerequisites
 - You need an account and API token for Hetzner
 - Terraform installed
+- k0sctl installed
 
 ## Steps
 Create terraform.tfvars file with needed details. You can use the provided terraform.tfvars.example as a baseline.
-- terraform init
-- terraform apply
-- terraform output k0s_cluster | k0sctl apply --config -
+- `terraform init`
+- `terraform apply`
+- `terraform output -raw k0s_cluster | k0sctl apply --config -`


### PR DESCRIPTION
As the `terraform output` command needs the `-raw` flag to only output the yaml, the README.md in the hetzner-tf example has changed