### PR TITLE
Only display last error when failing after multiple retries

### DIFF
--- a/config/cluster/host.go
+++ b/config/cluster/host.go
@@ -317,6 +317,7 @@ func (h *Host) WaitKubeNodeReady(node *Host) error {
 		retry.MaxJitter(time.Second*2),
 		retry.Delay(time.Second*3),
 		retry.Attempts(120),
+		retry.LastErrorOnly(true),
 	)
 }
 
@@ -357,6 +358,7 @@ func (h *Host) WaitHTTPStatus(url string, expected ...int) error {
 		retry.MaxJitter(time.Second*2),
 		retry.Delay(time.Second*3),
 		retry.Attempts(60),
+		retry.LastErrorOnly(true),
 	)
 }
 
@@ -373,6 +375,7 @@ func (h *Host) WaitK0sServiceRunning() error {
 		retry.MaxJitter(time.Second*2),
 		retry.Delay(time.Second*3),
 		retry.Attempts(60),
+		retry.LastErrorOnly(true),
 	)
 }
 
@@ -392,6 +395,7 @@ func (h *Host) WaitK0sServiceStopped() error {
 		retry.MaxJitter(time.Second*2),
 		retry.Delay(time.Second*3),
 		retry.Attempts(60),
+		retry.LastErrorOnly(true),
 	)
 }
 

--- a/config/cluster/k0s.go
+++ b/config/cluster/k0s.go
@@ -68,6 +68,7 @@ func (k K0s) GenerateToken(h *Host, role string, expiry time.Duration) (token st
 		retry.MaxJitter(time.Second*2),
 		retry.Delay(time.Second*3),
 		retry.Attempts(60),
+		retry.LastErrorOnly(true),
 	)
 	return
 }

--- a/phase/connect.go
+++ b/phase/connect.go
@@ -42,6 +42,7 @@ func (p *Connect) Run() error {
 			retry.MaxJitter(time.Second*2),
 			retry.Delay(time.Second*3),
 			retry.Attempts(retries),
+			retry.LastErrorOnly(true),
 		)
 
 		if err != nil {


### PR DESCRIPTION
When logs like these are pasted to github (outside of a backticked code block):

```
#97: failed to parse status from kubectl output
#98: failed to parse status from kubectl output
#99: failed to parse status from kubectl output
#100: failed to parse status from kubectl output
#101: failed to parse status from kubectl output
#102: failed to parse status from kubectl output
#103: failed to parse status from kubectl output
#104: failed to parse status from kubectl output
```

You get a load of references to issues and PR's ("xxx mentioned this PR in issue # 97").

Also it's a lot easier on the eyes.
