### PR TITLE
Check connection to kube-api before worker installation

### DIFF
--- a/config/cluster/spec.go
+++ b/config/cluster/spec.go
@@ -49,13 +49,13 @@ func (s *Spec) K0sLeader() *Host {
 	return s.k0sLeader
 }
 
-// KubeAPIURL returns an address to the cluster's kube api url
+// KubeAPIURL returns an url to the cluster's kube api
 func (s *Spec) KubeAPIURL() string {
-	leader := s.K0sLeader()
 	var caddr string
-	if a, ok := s.K0s.Config.Dig("spec", "api", "externalAddress").(string); ok {
+	if a := s.K0s.Config.DigString("spec", "api", "externalAddress"); a != "" {
 		caddr = a
 	} else {
+		leader := s.K0sLeader()
 		if leader.PrivateAddress != "" {
 			caddr = leader.PrivateAddress
 		} else {
@@ -68,5 +68,5 @@ func (s *Spec) KubeAPIURL() string {
 		cport = p
 	}
 
-	return fmt.Sprintf("https://%s:%d/", caddr, cport)
+	return fmt.Sprintf("https://%s:%d", caddr, cport)
 }

--- a/config/cluster/spec.go
+++ b/config/cluster/spec.go
@@ -1,6 +1,10 @@
 package cluster
 
-import "github.com/creasty/defaults"
+import (
+	"fmt"
+
+	"github.com/creasty/defaults"
+)
 
 // Spec defines cluster config spec section
 type Spec struct {
@@ -43,4 +47,26 @@ func (s *Spec) K0sLeader() *Host {
 	}
 
 	return s.k0sLeader
+}
+
+// KubeAPIURL returns an address to the cluster's kube api url
+func (s *Spec) KubeAPIURL() string {
+	leader := s.K0sLeader()
+	var caddr string
+	if a, ok := s.K0s.Config.Dig("spec", "api", "externalAddress").(string); ok {
+		caddr = a
+	} else {
+		if leader.PrivateAddress != "" {
+			caddr = leader.PrivateAddress
+		} else {
+			caddr = leader.Address()
+		}
+	}
+
+	cport := 6443
+	if p, ok := s.K0s.Config.Dig("spec", "api", "port").(int); ok {
+		cport = p
+	}
+
+	return fmt.Sprintf("https://%s:%d/", caddr, cport)
 }

--- a/phase/install_workers.go
+++ b/phase/install_workers.go
@@ -52,10 +52,10 @@ func (p *InstallWorkers) CleanUp() {
 // Run the phase
 func (p *InstallWorkers) Run() error {
 	url := p.Config.Spec.KubeAPIURL()
-	healthz := url + "healthz"
+	healthz := fmt.Sprintf("%s/healthz", url)
 
 	err := p.hosts.ParallelEach(func(h *cluster.Host) error {
-		log.Infof("%s: validating api connection to controller at %s", h, url)
+		log.Infof("%s: validating api connection to %s", h, url)
 		if err := h.CheckHTTPStatus(healthz, 200, 401); err != nil {
 			return fmt.Errorf("failed to connect from worker to kubernetes api at %s - check networking", url)
 		}

--- a/phase/install_workers.go
+++ b/phase/install_workers.go
@@ -56,7 +56,7 @@ func (p *InstallWorkers) Run() error {
 
 	err := p.hosts.ParallelEach(func(h *cluster.Host) error {
 		log.Infof("%s: validating api connection to controller at %s", h, url)
-		if err := h.CheckHTTPStatus(healthz, 200); err != nil {
+		if err := h.CheckHTTPStatus(healthz, 200, 401); err != nil {
 			return fmt.Errorf("failed to connect from worker to kubernetes api at %s - check networking", url)
 		}
 		return nil


### PR DESCRIPTION
Fixes #197 

Checks the kube api `/healthz` from worker before proceeding to install worker. This will give out less misleading error messages and faster bail-outs when there is some kind of networking configuration problem preventing the workers from communicating with the kube api. 
