### PR TITLE
Add --no-redact for debugging purposes

### DIFF
--- a/cmd/apply.go
+++ b/cmd/apply.go
@@ -38,6 +38,7 @@ var applyCommand = &cli.Command{
 		},
 		debugFlag,
 		traceFlag,
+		redactFlag,
 		analyticsFlag,
 	},
 	Before: actions(initLogging, initConfig, displayLogo, initAnalytics, displayCopyright),

--- a/cmd/backup.go
+++ b/cmd/backup.go
@@ -19,6 +19,7 @@ var backupCommand = &cli.Command{
 		configFlag,
 		debugFlag,
 		traceFlag,
+		redactFlag,
 		analyticsFlag,
 	},
 	Before: actions(initLogging, initConfig, displayLogo, initAnalytics, displayCopyright),

--- a/cmd/kubeconfig.go
+++ b/cmd/kubeconfig.go
@@ -16,6 +16,7 @@ var kubeconfigCommand = &cli.Command{
 		configFlag,
 		debugFlag,
 		traceFlag,
+		redactFlag,
 		analyticsFlag,
 	},
 	Before: actions(initSilentLogging, initConfig, initAnalytics),

--- a/cmd/reset.go
+++ b/cmd/reset.go
@@ -23,6 +23,7 @@ var resetCommand = &cli.Command{
 		configFlag,
 		debugFlag,
 		traceFlag,
+		redactFlag,
 		analyticsFlag,
 		&cli.BoolFlag{
 			Name:    "force",

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -11,6 +11,7 @@ var App = &cli.App{
 	Flags: []cli.Flag{
 		debugFlag,
 		traceFlag,
+		redactFlag,
 	},
 	Commands: []*cli.Command{
 		versionCommand,

--- a/phase/restore.go
+++ b/phase/restore.go
@@ -28,7 +28,7 @@ func (p *Restore) ShouldRun() bool {
 
 // Prepare the phase
 func (p *Restore) Prepare(config *config.Cluster) error {
-	log.Debugf("restore from: %s", p.RestoreFrom)
+	log.Tracef("restore from: %s", p.RestoreFrom)
 	p.Config = config
 	p.leader = p.Config.Spec.K0sLeader()
 
@@ -36,8 +36,8 @@ func (p *Restore) Prepare(config *config.Cluster) error {
 		return fmt.Errorf("the version of k0s on the host does not support restoring backups")
 	}
 
-	log.Debugf("restore leader: %s", p.leader)
-	log.Debugf("restore leader state: %+v", p.leader.Metadata)
+	log.Tracef("restore leader: %s", p.leader)
+	log.Tracef("restore leader state: %+v", p.leader.Metadata)
 	return nil
 }
 


### PR DESCRIPTION
Disables the logging / output feature that replaces sensitive strings with `[REDACTED]`.

Also makes the log level "trace" when both `--debug` and `--trace` used together, it ignored the `--trace` when both were used.

