### PR TITLE
Persist k0sctl configuration as a configmap on cluster

### DIFF
--- a/cmd/apply.go
+++ b/cmd/apply.go
@@ -89,6 +89,7 @@ var applyCommand = &cli.Command{
 			&phase.UpgradeWorkers{
 				NoDrain: ctx.Bool("no-drain"),
 			},
+			&phase.SaveConfig{},
 			&phase.RunHooks{Stage: "after", Action: "apply"},
 			&phase.Disconnect{},
 		)

--- a/config/k0sctl_config_map.go
+++ b/config/k0sctl_config_map.go
@@ -1,0 +1,48 @@
+package config
+
+import (
+	"fmt"
+
+	"github.com/k0sproject/k0sctl/config/cluster"
+	"github.com/k0sproject/rig/exec"
+	"gopkg.in/yaml.v2"
+)
+
+type K0sctlConfigMap struct {
+	APIVersion string `yaml:"apiVersion"`
+	Kind       string `yaml:"kind"`
+	Metadata   struct {
+		Name string `yaml:"name"`
+	} `yaml:"metadata"`
+	Data struct {
+		Config string `yaml:"config"`
+	} `yaml:"data"`
+	Config *Cluster `yaml:"-"`
+}
+
+func (k *K0sctlConfigMap) Save(h *cluster.Host) error {
+	plain, err := yaml.Marshal(k)
+	if err != nil {
+		return err
+	}
+	return h.Exec(h.Configurer.K0sCmdf("kubectl apply --namespace kube-system -f -"), exec.Sudo(h), exec.Stdin(string(plain)))
+}
+
+func LoadK0sctlConfigMap(h *cluster.Host) (*K0sctlConfigMap, error) {
+	out, err := h.ExecOutput(h.Configurer.K0sCmdf("kubectl get configmap --namespace kube-system -o yaml k0sctl"), exec.Sudo(h))
+	if err != nil {
+		return nil, fmt.Errorf("no previous k0sctl configuration found: %w", err)
+	}
+
+	cm := &K0sctlConfigMap{}
+	if err := yaml.Unmarshal([]byte(out), cm); err != nil {
+		return nil, err
+	}
+
+	c := &Cluster{}
+	if err := yaml.Unmarshal([]byte(cm.Data.Config), c); err != nil {
+		return nil, err
+	}
+
+	return cm, nil
+}

--- a/phase/save_config.go
+++ b/phase/save_config.go
@@ -1,0 +1,20 @@
+package phase
+
+// SaveConfig writes the k0sctl configuration to a configmap on the cluster
+type SaveConfig struct {
+	GenericPhase
+}
+
+// Title returns the phase title
+func (p *SaveConfig) Title() string {
+	return "Save k0sctl configuration"
+}
+
+// Run the phase
+func (p *SaveConfig) Run() error {
+	cm, err := p.Config.ConfigMap()
+	if err != nil {
+		return err
+	}
+	return cm.Save(p.Config.Spec.K0sLeader())
+}


### PR DESCRIPTION
Saves the k0sctl configuration after a succesfull apply as `k0sctl` ConfigMap in the `kube-system` namespace.

This can be used for #175 and possibly for pruning.
