### PR TITLE
Fix ETCD_UNSUPPORTED_ARCH on arm32

### DIFF
--- a/configurer/linux.go
+++ b/configurer/linux.go
@@ -32,7 +32,7 @@ func (l Linux) Arch(h os.Host) (string, error) {
 		return "amd64", nil
 	case "aarch64":
 		return "arm64", nil
-	case "armv7l", "armv8l":
+	case "armv7l", "armv8l", "aarch32", "arm32", "armhfp", "arm-32":
 		return "arm", nil
 	default:
 		return arch, nil

--- a/phase/arm_prepare.go
+++ b/phase/arm_prepare.go
@@ -44,16 +44,8 @@ func (p *PrepareArm) Run() error {
 }
 
 func (p *PrepareArm) etcdUnsupportedArch(h *cluster.Host) error {
-	var arch string
-	switch h.Metadata.Arch {
-	case "aarch32", "arm32", "armv7l", "armhfp", "arm-32":
-		arch = "arm32"
-	default:
-		arch = "arm64"
-	}
-
-	log.Warnf("%s: enabling ETCD_UNSUPPORTED_ARCH=%s override - you may encounter problems with etcd", h, arch)
-	h.Environment["ETCD_UNSUPPORTED_ARCH"] = arch
+	log.Warnf("%s: enabling ETCD_UNSUPPORTED_ARCH=%s override - you may encounter problems with etcd", h, h.Metadata.Arch)
+	h.Environment["ETCD_UNSUPPORTED_ARCH"] = h.Metadata.Arch
 
 	return nil
 }


### PR DESCRIPTION
Fixes #222 

Looks like the architecture "normalization" was done in two places, causing the `Prepare ARM` phase to incorrectly detect the architecture for `ETCD_UNSUPPORTED_ARCH`.

Also, seems like it should actually set `ETCD_UNSUPPORTED_ARCH=arm` instead of `arm32`.