### PR TITLE
Retry worker network connection test

### DIFF
--- a/phase/install_workers.go
+++ b/phase/install_workers.go
@@ -56,7 +56,7 @@ func (p *InstallWorkers) Run() error {
 
 	err := p.hosts.ParallelEach(func(h *cluster.Host) error {
 		log.Infof("%s: validating api connection to %s", h, url)
-		if err := h.CheckHTTPStatus(healthz, 200, 401); err != nil {
+		if err := h.WaitHTTPStatus(healthz, 200, 401); err != nil {
 			return fmt.Errorf("failed to connect from worker to kubernetes api at %s - check networking", url)
 		}
 		return nil


### PR DESCRIPTION
Fixes #220 by changing the check to use `WaitHTTPStatus` instead of `CheckHTTP`.
