### PR TITLE
Unhide the --disable-telemetry switch

### DIFF
--- a/cmd/flags.go
+++ b/cmd/flags.go
@@ -54,7 +54,6 @@ var (
 	analyticsFlag = &cli.BoolFlag{
 		Name:    "disable-telemetry",
 		EnvVars: []string{"DISABLE_TELEMETRY"},
-		Hidden:  true,
 	}
 
 	Colorize = aurora.NewAurora(false)


### PR DESCRIPTION
Fixes #217 

Changes the `--disable-telemetry` flag from hidden to visible.
