### PR TITLE
Perform a dnf update on Fedora

### DIFF
--- a/configurer/linux/enterpriselinux/fedora.go
+++ b/configurer/linux/enterpriselinux/fedora.go
@@ -4,6 +4,8 @@ import (
 	"github.com/k0sproject/k0sctl/configurer"
 	k0slinux "github.com/k0sproject/k0sctl/configurer/linux"
 	"github.com/k0sproject/rig"
+	"github.com/k0sproject/rig/exec"
+	"github.com/k0sproject/rig/os"
 	"github.com/k0sproject/rig/os/registry"
 )
 
@@ -22,4 +24,8 @@ func init() {
 			return Fedora{}
 		},
 	)
+}
+
+func (l Fedora) Prepare(h os.Host) error {
+	return h.Exec("dnf update --refresh", exec.Sudo(h))
 }


### PR DESCRIPTION
Performs a `dnf update --refresh` on Fedora to avoid `Failed to synchronize cache for repo 'fedora-modular'`