### PR TITLE
Wait for k0s service to stop before running k0s reset

### DIFF
--- a/phase/reset.go
+++ b/phase/reset.go
@@ -58,6 +58,10 @@ func (p *Reset) Run() error {
 			if err := h.Configurer.StopService(h, h.K0sServiceName()); err != nil {
 				return err
 			}
+			log.Infof("%s: waiting for k0s to stop", h)
+			if err := h.WaitK0sServiceStopped(); err != nil {
+				return err
+			}
 		}
 
 		log.Infof("%s: running k0s reset", h)


### PR DESCRIPTION
Fixes #216 

Makes k0sctl wait for the k0s service to stop before running k0s reset.
