### PR TITLE
Write files directly to destination when caching k0s binaries

### DIFF
--- a/phase/download_binaries.go
+++ b/phase/download_binaries.go
@@ -124,7 +124,7 @@ func (b binary) downloadTo(path string) error {
 		if err != nil {
 			err = os.Remove(path)
 			if err != nil {
-				log.Warnf("failed to remove broken download at %s: %w", path, err)
+				log.Warnf("failed to remove broken download at %s: %s", path, err.Error())
 			}
 		}
 	}()


### PR DESCRIPTION
Fixes #239 

When caching k0s binaries for `uploadBinary: true`, the file was first downloaded to a temp path from `mktemp` and then moved to the final location using `os.Rename` which does not work when they're not on the same volume. This PR makes the download skip creating a temp file and instead downloads directly to the target location.
