### PR TITLE
Run PR tests only once

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -1,10 +1,6 @@
 name: Go
 
-on:
-  push:
-    branches-ignore:
-      - "main"
-  pull_request:
+on: [ pull_request ]
 
 jobs:
 


### PR DESCRIPTION
The workflow was running the tests both on push events and on pull_request events, making them run twice on PRs.
