### PR TITLE
Release via goreleaser

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -38,7 +38,7 @@ jobs:
     - name: Test
       run: make test
 
-    - name: Cache the compiled binary for further testing
+    - name: Store the compiled binary for further testing
       uses: actions/upload-artifact@v2
       with:
         name: binary
@@ -73,6 +73,9 @@ jobs:
         uses: actions/download-artifact@v2
         with:
           name: binary
+
+      - name: Make the binary executable
+        run: chmod +x k0sctl
 
       - name: K0sctl cache
         uses: actions/cache@v2
@@ -118,6 +121,9 @@ jobs:
         with:
           name: binary
 
+      - name: Make the binary executable
+        run: chmod +x k0sctl
+
       - name: K0sctl cache
         uses: actions/cache@v2
         with:
@@ -161,6 +167,9 @@ jobs:
         with:
           name: binary
 
+      - name: Make the binary executable
+        run: chmod +x k0sctl
+
       - name: K0sctl cache
         uses: actions/cache@v2
         with:
@@ -202,6 +211,9 @@ jobs:
         with:
           name: binary
 
+      - name: Make the binary executable
+        run: chmod +x k0sctl
+
       - name: Run smoke tests
         env:
           LINUX_IMAGE: ${{ matrix.image }}
@@ -230,6 +242,9 @@ jobs:
         with:
           name: binary
 
+      - name: Make the binary executable
+        run: chmod +x k0sctl
+
       - name: Run smoke tests
         env:
           LINUX_IMAGE: ${{ matrix.image }}
@@ -253,6 +268,9 @@ jobs:
         uses: actions/download-artifact@v2
         with:
           name: binary
+
+      - name: Make the binary executable
+        run: chmod +x k0sctl
 
       - name: K0sctl cache
         uses: actions/cache@v2

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -27,10 +27,10 @@ jobs:
           ${{ runner.os }}-go-
 
     - name: Run golangci-lint
-        uses: golangci/golangci-lint-action@v2
-        with:
-          version: v1.42
-          args: --verbose
+      uses: golangci/golangci-lint-action@v2
+      with:
+        version: v1.42
+        args: --verbose
 
     - name: Build
       run: make k0sctl

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -27,23 +27,23 @@ jobs:
           ${{ runner.os }}-go-
 
     - name: Run golangci-lint
-      uses: golangci/golangci-lint-action@v2.3.0
-      with:
-        version: v1.35.2
+        uses: golangci/golangci-lint-action@v2
+        with:
+          version: v1.42
+          args: --verbose
 
     - name: Build
       run: make k0sctl
 
     - name: Test
-      run: go test -v ./...
+      run: make test
 
     - name: Cache the compiled binary for further testing
-      uses: actions/cache@v2
-      id: cache-compiled-binary
+      uses: actions/upload-artifact@v2
       with:
-        path: |
-          k0sctl
-        key: build-${{ github.run_id }}
+        name: binary
+        path: k0sctl
+        retention-days: 5
 
     - name: Build all
       run: make build-all
@@ -54,7 +54,6 @@ jobs:
         image:
           - quay.io/footloose/ubuntu18.04
           - quay.io/footloose/centos7
-            #- quay.io/footloose/amazonlinux2
           - quay.io/footloose/debian10
           - quay.io/footloose/fedora29
     name: Basic 1+1 smoke
@@ -71,12 +70,9 @@ jobs:
           go-version: 1.17
 
       - name: Restore the compiled binary for smoke testing
-        uses: actions/cache@v2
-        id: restore-compiled-binary
+        uses: actions/download-artifact@v2
         with:
-          path: |
-            k0sctl
-          key: build-${{ github.run_id }}
+          name: binary
 
       - name: K0sctl cache
         uses: actions/cache@v2
@@ -118,12 +114,9 @@ jobs:
           go-version: 1.17
 
       - name: Restore the compiled binary for smoke testing
-        uses: actions/cache@v2
-        id: restore-compiled-binary
+        uses: actions/download-artifact@v2
         with:
-          path: |
-            k0sctl
-          key: build-${{ github.run_id }}
+          name: binary
 
       - name: K0sctl cache
         uses: actions/cache@v2
@@ -164,12 +157,9 @@ jobs:
           go-version: 1.17
 
       - name: Restore the compiled binary for smoke testing
-        uses: actions/cache@v2
-        id: restore-compiled-binary
+        uses: actions/download-artifact@v2
         with:
-          path: |
-            k0sctl
-          key: build-${{ github.run_id }}
+          name: binary
 
       - name: K0sctl cache
         uses: actions/cache@v2
@@ -179,13 +169,6 @@ jobs:
             ~/.k0sctl/cache
             !*.log
           key: k0sctl-cache
-
-      - name: Old k0sctl cache
-        uses: actions/cache@v2
-        with:
-          path: |
-            ~/.cache
-          key: k0sctl-040-cache
 
       - name: Docker Layer Caching For Footloose
         uses: satackey/action-docker-layer-caching@v0.0.11
@@ -214,13 +197,10 @@ jobs:
         with:
           go-version: 1.17
 
-      - name: Restore compiled binary for smoke testing
-        uses: actions/cache@v2
-        id: restore-compiled-binary
+      - name: Restore the compiled binary for smoke testing
+        uses: actions/download-artifact@v2
         with:
-          path: |
-            k0sctl
-          key: build-${{ github.run_id }}
+          name: binary
 
       - name: Run smoke tests
         env:
@@ -245,13 +225,10 @@ jobs:
         with:
           go-version: 1.17
 
-      - name: Restore compiled binary for smoke testing
-        uses: actions/cache@v2
-        id: restore-compiled-binary
+      - name: Restore the compiled binary for smoke testing
+        uses: actions/download-artifact@v2
         with:
-          path: |
-            k0sctl
-          key: build-${{ github.run_id }}
+          name: binary
 
       - name: Run smoke tests
         env:
@@ -273,12 +250,9 @@ jobs:
           go-version: 1.17
 
       - name: Restore the compiled binary for smoke testing
-        uses: actions/cache@v2
-        id: restore-compiled-binary
+        uses: actions/download-artifact@v2
         with:
-          path: |
-            k0sctl
-          key: build-${{ github.run_id }}
+          name: binary
 
       - name: K0sctl cache
         uses: actions/cache@v2

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -45,8 +45,8 @@ jobs:
           k0sctl
         key: build-${{ github.run_id }}
 
-    - name: Build windows
-      run: make bin/k0sctl-win-x64.exe
+    - name: Build all
+      run: make build-all
 
   smoke-basic:
     strategy:
@@ -101,7 +101,7 @@ jobs:
       - name: Run smoke tests
         env:
           LINUX_IMAGE: ${{ matrix.image }}
-        run: make smoke-basic
+        run: make -C smoke-test basic
 
   smoke-os-override:
     name: OS override smoke test
@@ -139,7 +139,7 @@ jobs:
         continue-on-error: true
 
       - name: Run OS override smoke test
-        run: make smoke-os-override
+        run: make -C smoke-test os-override
 
   smoke-upgrade:
     strategy:
@@ -194,7 +194,7 @@ jobs:
       - name: Run smoke tests
         env:
           LINUX_IMAGE: ${{ matrix.image }}
-        run: make smoke-upgrade
+        run: make -C smoke-test upgrade
 
   smoke-reset:
     strategy:
@@ -225,7 +225,7 @@ jobs:
       - name: Run smoke tests
         env:
           LINUX_IMAGE: ${{ matrix.image }}
-        run: make smoke-reset
+        run: make -C smoke-test reset
 
   smoke-backup-restore:
     strategy:
@@ -256,7 +256,7 @@ jobs:
       - name: Run smoke tests
         env:
           LINUX_IMAGE: ${{ matrix.image }}
-        run: make smoke-backup-restore
+        run: make -C smoke-test backup-restore
 
   smoke-init:
     name: Init sub-command smoke test
@@ -294,4 +294,4 @@ jobs:
         continue-on-error: true
 
       - name: Run init smoke test
-        run: make smoke-init
+        run: make -C smoke-test init

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -13,40 +13,16 @@ jobs:
       - name: Check out code into the Go module directory
         uses: actions/checkout@v2
 
-      # Ugly hack to get the tag name
-      # github.ref gives the full reference like refs.tags.v0.0.1-beta1
-      - name: Branch name
-        id: branch_name
-        run: |
-          echo ::set-output name=TAG_NAME::${GITHUB_REF#refs/tags/}
-
       - name: Set up Go
         uses: actions/setup-go@v2
         with:
           go-version: 1.17
 
-      - name: Build bins
-        id: build_bins
-        env:
-          SEGMENT_WRITE_KEY: ${{ secrets.SEGMENT_WRITE_KEY }}
-          TAG_NAME: ${{ steps.branch_name.outputs.TAG_NAME }}
-        run: make build-all
-
-      - name: Create Release in Github
-        id: create_release
-        uses: actions/create-release@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # This token is provided by Actions
+      - name: Run GoReleaser
+        uses: goreleaser/goreleaser-action@v2
         with:
-          tag_name: ${{ github.ref }}
-          release_name: ${{ github.ref }}
-          draft: true # So we can manually edit before publishing
-          prerelease: ${{ contains(github.ref, '-') }} # v0.1.2-beta1, 1.2.3-rc1
-
-      - name: Upload artifacts
-        id: upload
+          version: latest
+          args: release --rm-dist
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # This token is provided by Actions
-          TAG_NAME: ${{ steps.branch_name.outputs.TAG_NAME }}
-        run: make upload
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,0 +1,49 @@
+project_name: k0sctl
+
+env:
+  - CGO_ENABLED=0
+
+snapshot:
+  name_template: '{{ .Tag }}-SNAPSHOT'
+
+before:
+  hooks:
+    - go mod tidy
+
+dist: bin
+
+builds:
+  - flags:
+      - -trimpath
+      - -a
+      - -installsuffix
+    tags:
+      - netgo
+      - static_build
+    ldflags:
+      - -s -w
+      - -X github.com/k0sproject/k0sctl/version.Environment={{ if .IsSnapshot }}development{{ else }}production{{ end }}
+      - -X github.com/k0sproject/k0sctl/version.GitCommit={{.ShortCommit}}
+      - -X github.com/k0sproject/k0sctl/version.Version={{ if .IsSnapshot }}dev{{ else }}{{.Version}}{{ end }}
+      - -extldflags '-static'
+    goos:
+      - linux
+      - windows
+      - darwin
+    ignore:
+      - goos: windows
+        goarch: arm64
+      - goos: windows
+        goarch: arm
+    goarch:
+      - amd64
+      - arm64
+      - arm
+
+archives:
+  - format: binary
+    name_template: '{{ .ProjectName }}-{{ .Os }}-{{ .Arch }}'
+    replacements:
+      windows: win
+      arm6: arm
+      amd64: x64

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,10 @@
 GO_SRCS := $(shell find . -type f -name '*.go' -a ! -name 'zz_generated*')
+GOARCH ?= $(shell go env GOARCH)
+GOOS ?= $(shell go env GOOS)
 
-k0sctl: $(GO_SRCS)
-	go build $(BUILD_FLAGS) -o k0sctl main.go
+k0sctl: $(GO_SRCS) .goreleaser.yml $(goreleaser)
+	$(goreleaser) build --single-target --snapshot --rm-dist
+	mv bin/k0sctl_$(GOOS)_$(GOARCH)/k0sctl .
 
 .PHONY: clean
 clean:
@@ -31,7 +34,6 @@ $(goreleaser):
 .PHONY: lint
 lint: $(golint)
 	$(golint) run ./...
-
 
 .PHONY: build-all
 build-all: $(goreleaser)

--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,16 @@ GOARCH ?= $(shell go env GOARCH)
 GOOS ?= $(shell go env GOOS)
 PREFIX = /usr/local
 
+goreleaser := $(shell which goreleaser)
+ifeq ($(goreleaser),)
+goreleaser := $(shell go env GOPATH)/bin/goreleaser
+endif
+
+golint := $(shell which golangci-lint)
+ifeq ($(golint),)
+golint := $(shell go env GOPATH)/bin/golangci-lint
+endif
+
 k0sctl: $(GO_SRCS) .goreleaser.yml $(goreleaser)
 	$(goreleaser) build --single-target --snapshot --rm-dist
 	mv bin/k0sctl_$(GOOS)_$(GOARCH)/k0sctl .
@@ -12,18 +22,8 @@ k0sctl: $(GO_SRCS) .goreleaser.yml $(goreleaser)
 clean:
 	rm -rf bin/
 
-golint := $(shell which golangci-lint)
-ifeq ($(golint),)
-golint := $(shell go env GOPATH)/bin/golangci-lint
-endif
-
 $(golint):
 	go get github.com/golangci/golangci-lint/cmd/golangci-lint@v1.31.0
-
-goreleaser := $(shell which goreleaser)
-ifeq ($(goreleaser),)
-goreleaser := $(shell go env GOPATH)/bin/goreleaser
-endif
 
 $(goreleaser):
 	go install github.com/goreleaser/goreleaser@latest

--- a/Makefile
+++ b/Makefile
@@ -1,41 +1,4 @@
 GO_SRCS := $(shell find . -type f -name '*.go' -a ! -name 'zz_generated*')
-GIT_COMMIT = $(shell git rev-parse --short=7 HEAD)
-K0SCTL_VERSION ?= $(or ${TAG_NAME},dev)
-ifdef TAG_NAME
-	ENVIRONMENT = "production"
-endif
-ENVIRONMENT ?= "development"
-
-LD_FLAGS = -s -w -X github.com/k0sproject/k0sctl/version.Environment=$(ENVIRONMENT) -X github.com/k0sproject/k0sctl/version.GitCommit=$(GIT_COMMIT) -X github.com/k0sproject/k0sctl/version.Version=$(K0SCTL_VERSION)
-BUILD_FLAGS = -trimpath -a -tags "netgo static_build" -installsuffix netgo -ldflags "$(LD_FLAGS) -extldflags '-static'"
-
-bin/k0sctl-linux-x64: $(GO_SRCS)
-	GOOS=linux GOARCH=amd64 go build $(BUILD_FLAGS) -o bin/k0sctl-linux-x64 main.go
-
-bin/k0sctl-linux-arm64: $(GO_SRCS)
-	GOOS=linux GOARCH=arm64 go build $(BUILD_FLAGS) -o bin/k0sctl-linux-arm64 main.go
-
-bin/k0sctl-linux-arm: $(GO_SRCS)
-	GOOS=linux GOARCH=arm go build $(BUILD_FLAGS) -o bin/k0sctl-linux-arm main.go
-
-bin/k0sctl-win-x64.exe: $(GO_SRCS)
-	GOOS=windows GOARCH=amd64 go build $(BUILD_FLAGS) -o bin/k0sctl-win-x64.exe main.go
-
-bin/k0sctl-darwin-x64: $(GO_SRCS)
-	GOOS=darwin GOARCH=amd64 go build $(BUILD_FLAGS) -o bin/k0sctl-darwin-x64 main.go
-
-bin/k0sctl-darwin-arm64: $(GO_SRCS)
-	GOOS=darwin GOARCH=arm64 go build $(BUILD_FLAGS) -o bin/k0sctl-darwin-arm64 main.go
-
-bin/%.sha256: bin/%
-	sha256sum -b $< | sed 's/bin\///' > $@.tmp
-	mv $@.tmp $@
-
-bins := k0sctl-linux-x64 k0sctl-linux-arm64 k0sctl-linux-arm k0sctl-win-x64.exe k0sctl-darwin-x64 k0sctl-darwin-arm64
-checksums := $(addsuffix .sha256,$(bins))
-
-.PHONY: build-all
-build-all: $(addprefix bin/,$(bins) $(checksums))
 
 k0sctl: $(GO_SRCS)
 	go build $(BUILD_FLAGS) -o k0sctl main.go
@@ -43,25 +6,6 @@ k0sctl: $(GO_SRCS)
 .PHONY: clean
 clean:
 	rm -rf bin/
-
-github_release := $(shell which github-release)
-ifeq ($(github_release),)
-github_release := $(shell go env GOPATH)/bin/github-release
-endif
-
-$(github_release):
-	go get github.com/github-release/github-release/...@v0.10.0
-
-upload-%: bin/% $(github_release)
-	$(github_release) upload \
-		--user k0sproject \
-		--repo k0sctl \
-		--tag "${TAG_NAME}" \
-		--name "`basename $<`" \
-		--file "$<"; \
-
-.PHONY: upload
-upload: $(addprefix upload-,$(bins) $(checksums))
 
 smoketests := smoke-basic smoke-upgrade smoke-reset smoke-os-override smoke-init smoke-backup-restore
 .PHONY: $(smoketests)
@@ -76,6 +20,19 @@ endif
 $(golint):
 	go get github.com/golangci/golangci-lint/cmd/golangci-lint@v1.31.0
 
+goreleaser := $(shell which goreleaser)
+ifeq ($(goreleaser),)
+goreleaser := $(shell go env GOPATH)/bin/goreleaser
+endif
+
+$(goreleaser):
+	go install github.com/goreleaser/goreleaser@latest
+
 .PHONY: lint
 lint: $(golint)
 	$(golint) run ./...
+
+
+.PHONY: build-all
+build-all: $(goreleaser)
+	$(goreleaser) build --snapshot --rm-dist

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,8 @@
-GO_SRCS := $(shell find . -type f -name '*.go' -a ! -name 'zz_generated*')
+GO_SRCS := $(shell find . -type f -name '*.go' -a ! \( -name 'zz_generated*' -o -name '*_test.go' \))
+GO_TESTS := $(shell find . -type f -name '*_test.go')
 GOARCH ?= $(shell go env GOARCH)
 GOOS ?= $(shell go env GOOS)
+PREFIX = /usr/local
 
 k0sctl: $(GO_SRCS) .goreleaser.yml $(goreleaser)
 	$(goreleaser) build --single-target --snapshot --rm-dist
@@ -9,11 +11,6 @@ k0sctl: $(GO_SRCS) .goreleaser.yml $(goreleaser)
 .PHONY: clean
 clean:
 	rm -rf bin/
-
-smoketests := smoke-basic smoke-upgrade smoke-reset smoke-os-override smoke-init smoke-backup-restore
-.PHONY: $(smoketests)
-$(smoketests): k0sctl
-	$(MAKE) -C smoke-test $@
 
 golint := $(shell which golangci-lint)
 ifeq ($(golint),)
@@ -38,3 +35,17 @@ lint: $(golint)
 .PHONY: build-all
 build-all: $(goreleaser)
 	$(goreleaser) build --snapshot --rm-dist
+
+gotest := $(shell which gotest)
+ifeq ($(gotest),)
+gotest := go test
+endif
+
+.PHONY: test
+test: $(GO_SRCS) $(GO_TESTS)
+	$(gotest) -v ./...
+
+.PHONY: install
+install: k0sctl
+	install -d $(DESTDIR)$(PREFIX)/bin/
+	install -m 755 k0sctl $(DESTDIR)$(PREFIX)/bin/

--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,7 @@ clean:
 	rm -rf bin/ k0sctl
 
 $(golint):
-	go get github.com/golangci/golangci-lint/cmd/golangci-lint@v1.31.0
+	go install github.com/golangci/golangci-lint/cmd/golangci-lint@latest
 
 $(goreleaser):
 	go install github.com/goreleaser/goreleaser@latest

--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@ k0sctl: $(GO_SRCS) .goreleaser.yml $(goreleaser)
 
 .PHONY: clean
 clean:
-	rm -rf bin/
+	rm -rf bin/ k0sctl
 
 $(golint):
 	go get github.com/golangci/golangci-lint/cmd/golangci-lint@v1.31.0

--- a/smoke-test/Makefile
+++ b/smoke-test/Makefile
@@ -1,4 +1,3 @@
-
 footloose := $(shell which footloose)
 ifeq ($(footloose),)
 footloose := $(shell go env GOPATH)/bin/footloose
@@ -9,27 +8,26 @@ ifeq ($(envsubst),)
 $(error 'envsubst' NOT found in path, please install it and re-run)
 endif
 
+basic: $(footloose) id_rsa_k0s
+	./smoke-basic.sh
+
 $(footloose):
 	go get github.com/weaveworks/footloose/...@0.6.3
 
 id_rsa_k0s:
 	ssh-keygen -t rsa -f ./id_rsa_k0s -N ""
 
-
-smoke-basic: $(footloose) id_rsa_k0s
-	./smoke-basic.sh
-
-smoke-init: $(footloose) id_rsa_k0s
+init: $(footloose) id_rsa_k0s
 	./smoke-init.sh
 
-smoke-upgrade: $(footloose) id_rsa_k0s
+upgrade: $(footloose) id_rsa_k0s
 	./smoke-upgrade.sh
 
-smoke-reset: $(footloose) id_rsa_k0s
+reset: $(footloose) id_rsa_k0s
 	./smoke-reset.sh
 
-smoke-os-override: $(footloose) id_rsa_k0s
+os-override: $(footloose) id_rsa_k0s
 	FOOTLOOSE_TEMPLATE=footloose.yaml.osoverride.tpl OS_RELEASE_PATH=$(realpath os-release) OS_OVERRIDE="ubuntu" ./smoke-basic.sh
 
-smoke-backup-restore: $(footloose) id_rsa_k0s
+backup-restore: $(footloose) id_rsa_k0s
 	./smoke-backup-restore.sh

--- a/smoke-test/Makefile
+++ b/smoke-test/Makefile
@@ -12,7 +12,7 @@ basic: $(footloose) id_rsa_k0s
 	./smoke-basic.sh
 
 $(footloose):
-	go get github.com/weaveworks/footloose/...@0.6.3
+	go install github.com/weaveworks/footloose/...@0.6.3
 
 id_rsa_k0s:
 	ssh-keygen -t rsa -f ./id_rsa_k0s -N ""


### PR DESCRIPTION
Signed-off-by: Engin Diri <engin.diri@mail.schwarz>

Fixes #250 

Hi everyone,

here the implementation of goreleaser.

I tried to keep everything as the same like in the Makefile. So in some cases i rewrote the defalt naming for e.g. `amd64` to `x64` or `windows` to `win`.

The only thing, what will change is, that the checksum is now in a txt file in the release and not as .sha256 file.

I also changed the release action to use the goreleaser action.

Looking forward for you feedback.

 