### PR TITLE
Do not remove the token file after join

### DIFF
--- a/phase/install_controllers.go
+++ b/phase/install_controllers.go
@@ -77,12 +77,6 @@ func (p *InstallControllers) Run() error {
 			return err
 		}
 
-		defer func() {
-			if err := h.Configurer.DeleteFile(h, h.K0sJoinTokenPath()); err != nil {
-				log.Warnf("%s: failed to clean up the join token file at %s", h, h.K0sJoinTokenPath())
-			}
-		}()
-
 		log.Infof("%s: installing k0s controller", h)
 		if err := h.Exec(h.K0sInstallCommand()); err != nil {
 			return err

--- a/phase/install_workers.go
+++ b/phase/install_workers.go
@@ -97,14 +97,6 @@ func (p *InstallWorkers) Run() error {
 			return err
 		}
 
-		if !NoWait {
-			defer func() {
-				if err := h.Configurer.DeleteFile(h, h.K0sJoinTokenPath()); err != nil {
-					log.Warnf("%s: failed to clean up the join token file at %s", h, h.K0sJoinTokenPath())
-				}
-			}()
-		}
-
 		if sp, err := h.Configurer.ServiceScriptPath(h, h.K0sServiceName()); err == nil {
 			if h.Configurer.ServiceIsRunning(h, h.K0sServiceName()) {
 				log.Infof("%s: stopping service", h)


### PR DESCRIPTION
Apparently k0s fails to start if `--token-file` points to a non-existent file, even though the token isn't needed if the node has already joined.
