### PR TITLE
Overwrite instead of delete the token-file after joining a cluster

### DIFF
--- a/phase/install_controllers.go
+++ b/phase/install_controllers.go
@@ -78,7 +78,7 @@ func (p *InstallControllers) Run() error {
 		}
 
 		defer func() {
-			if err := h.Configurer.WriteFile(h, h.K0sJoinTokenPath(), "# already joined", "0600"); err != nil {
+			if err := h.Configurer.WriteFile(h, h.K0sJoinTokenPath(), "# overwritten by k0sctl after join\n", "0600"); err != nil {
 				log.Warnf("%s: failed to overwrite the join token file at %s", h, h.K0sJoinTokenPath())
 			}
 		}()

--- a/phase/install_workers.go
+++ b/phase/install_workers.go
@@ -99,7 +99,7 @@ func (p *InstallWorkers) Run() error {
 
 		if !NoWait {
 			defer func() {
-				if err := h.Configurer.WriteFile(h, h.K0sJoinTokenPath(), "# already joined", "0600"); err != nil {
+				if err := h.Configurer.WriteFile(h, h.K0sJoinTokenPath(), "# overwritten by k0sctl after join\n", "0600"); err != nil {
 					log.Warnf("%s: failed to overwrite the join token file at %s", h, h.K0sJoinTokenPath())
 				}
 			}()


### PR DESCRIPTION
Closes #256 (alternative)

Instead of leaving an invalidated token laying around, overwrite the token file with message `# already joined`.

Fixes a bug where k0sctl would delete the token-file after the node has joined to a cluster, which will make k0s fail to start because it still expects to find the file.
