### PR TITLE
Fix single role issues

### DIFF
--- a/config/cluster/host.go
+++ b/config/cluster/host.go
@@ -244,10 +244,12 @@ func (h *Host) IsController() bool {
 
 // K0sServiceName returns correct service name
 func (h *Host) K0sServiceName() string {
-	if h.Role == "controller+worker" {
+	switch h.Role {
+	case "controller", "controller+worker", "single":
 		return "k0scontroller"
+	default:
+		return "k0sworker"
 	}
-	return "k0s" + h.Role
 }
 
 // UpdateK0sBinary updates the binary on the host either by downloading or uploading, based on the config

--- a/phase/gather_k0s_facts.go
+++ b/phase/gather_k0s_facts.go
@@ -26,6 +26,15 @@ type k0sstatus struct {
 	K0sVars       dig.Mapping `json:"K0sVars"`
 }
 
+func (k *k0sstatus) isSingle() bool {
+	for _, a := range k.Args {
+		if a == "--single=true" {
+			return true
+		}
+	}
+	return false
+}
+
 // GatherK0sFacts gathers information about hosts, such as if k0s is already up and running
 type GatherK0sFacts struct {
 	GenericPhase
@@ -101,7 +110,11 @@ func (p *GatherK0sFacts) investigateK0s(h *cluster.Host) error {
 		status.Role = "controller+worker"
 	case "controller":
 		if status.Workloads {
-			status.Role = "controller+worker"
+			if status.isSingle() {
+				status.Role = "single"
+			} else {
+				status.Role = "controller+worker"
+			}
 		}
 	}
 


### PR DESCRIPTION
- `k0ssingle` service name was being used
- Role change detection problems because anything with `workloads: true` was being considered `controller+worker`.
