### PR TITLE
Stop generating and uploading sha256 files for releases

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -50,3 +50,22 @@ jobs:
           TAG_NAME: ${{ steps.branch_name.outputs.TAG_NAME }}
         run: make upload
 
+      - name: "Read sha256sums"
+        uses: andstor/file-reader-action@v1
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # This token is provided by Actions
+        with:
+          path: "bin/checksums.txt"
+
+      - name: Update sha256sums to github release
+        uses: tubone24/update_release@v1.2.0
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # This token is provided by Actions
+          TAG_NAME: ${{ steps.branch_name.outputs.TAG_NAME }}
+        with:
+          is_append_body: |
+            \### SHA256 checksums
+            ```
+            ${{ steps.read_sums.outputs.contents }}
+            ```
+
+

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -62,7 +62,8 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # This token is provided by Actions
           TAG_NAME: ${{ steps.branch_name.outputs.TAG_NAME }}
         with:
-          is_append_body: |
+          is_append_body: true
+          body: |
             \### SHA256 checksums
             ```
             ${{ steps.read_sums.outputs.contents }}

--- a/Makefile
+++ b/Makefile
@@ -29,8 +29,11 @@ bin/k0sctl-darwin-arm64: $(GO_SRCS)
 
 bins := k0sctl-linux-x64 k0sctl-linux-arm64 k0sctl-linux-arm k0sctl-win-x64.exe k0sctl-darwin-x64 k0sctl-darwin-arm64
 
+bin/checksums.txt: $(addprefix bin/,$(bins))
+	sha256sum -b $(addprefix bin/,$(bins)) | sed 's/bin\///' > $@
+
 .PHONY: build-all
-build-all: $(addprefix bin/,$(bins) $(checksums))
+build-all: $(addprefix bin/,$(bins)) bin/checksums.txt
 
 k0sctl: $(GO_SRCS)
 	go build $(BUILD_FLAGS) -o k0sctl main.go
@@ -56,7 +59,7 @@ upload-%: bin/% $(github_release)
 		--file "$<"; \
 
 .PHONY: upload
-upload: $(addprefix upload-,$(bins))
+upload: $(addprefix upload-,$(bins) $(checksums))
 
 smoketests := smoke-basic smoke-files smoke-upgrade smoke-reset smoke-os-override smoke-init smoke-backup-restore
 .PHONY: $(smoketests)

--- a/Makefile
+++ b/Makefile
@@ -27,12 +27,7 @@ bin/k0sctl-darwin-x64: $(GO_SRCS)
 bin/k0sctl-darwin-arm64: $(GO_SRCS)
 	GOOS=darwin GOARCH=arm64 go build $(BUILD_FLAGS) -o bin/k0sctl-darwin-arm64 main.go
 
-bin/%.sha256: bin/%
-	sha256sum -b $< | sed 's/bin\///' > $@.tmp
-	mv $@.tmp $@
-
 bins := k0sctl-linux-x64 k0sctl-linux-arm64 k0sctl-linux-arm k0sctl-win-x64.exe k0sctl-darwin-x64 k0sctl-darwin-arm64
-checksums := $(addsuffix .sha256,$(bins))
 
 .PHONY: build-all
 build-all: $(addprefix bin/,$(bins) $(checksums))
@@ -61,7 +56,7 @@ upload-%: bin/% $(github_release)
 		--file "$<"; \
 
 .PHONY: upload
-upload: $(addprefix upload-,$(bins) $(checksums))
+upload: $(addprefix upload-,$(bins))
 
 smoketests := smoke-basic smoke-files smoke-upgrade smoke-reset smoke-os-override smoke-init smoke-backup-restore
 .PHONY: $(smoketests)


### PR DESCRIPTION
Fixes #265 

If they're actually needed for something, there could just be a single file containing checksums for all binaries instead of cluttering the asset list with the .sha256's.
