### PR TITLE
Check if a k0sctl upgrade is available

### DIFF
--- a/cmd/apply.go
+++ b/cmd/apply.go
@@ -39,12 +39,10 @@ var applyCommand = &cli.Command{
 		traceFlag,
 		redactFlag,
 		analyticsFlag,
+		upgradeCheckFlag,
 	},
-	Before: actions(initLogging, initConfig, displayLogo, initAnalytics, displayCopyright),
-	After: func(ctx *cli.Context) error {
-		analytics.Client.Close()
-		return nil
-	},
+	Before: actions(initLogging, startCheckUpgrade, initConfig, displayLogo, initAnalytics, displayCopyright),
+	After:  actions(reportCheckUpgrade, closeAnalytics),
 	Action: func(ctx *cli.Context) error {
 		start := time.Now()
 		phase.NoWait = ctx.Bool("no-wait")

--- a/cmd/backup.go
+++ b/cmd/backup.go
@@ -20,12 +20,10 @@ var backupCommand = &cli.Command{
 		traceFlag,
 		redactFlag,
 		analyticsFlag,
+		upgradeCheckFlag,
 	},
-	Before: actions(initLogging, initConfig, displayLogo, initAnalytics, displayCopyright),
-	After: func(ctx *cli.Context) error {
-		analytics.Client.Close()
-		return nil
-	},
+	Before: actions(initLogging, startCheckUpgrade, initConfig, displayLogo, initAnalytics, displayCopyright, reportCheckUpgrade),
+	After:  actions(reportCheckUpgrade, closeAnalytics),
 	Action: func(ctx *cli.Context) error {
 		start := time.Now()
 

--- a/cmd/reset.go
+++ b/cmd/reset.go
@@ -24,17 +24,15 @@ var resetCommand = &cli.Command{
 		traceFlag,
 		redactFlag,
 		analyticsFlag,
+		upgradeCheckFlag,
 		&cli.BoolFlag{
 			Name:    "force",
 			Usage:   "Don't ask for confirmation",
 			Aliases: []string{"f"},
 		},
 	},
-	Before: actions(initLogging, initConfig, initAnalytics, displayCopyright),
-	After: func(ctx *cli.Context) error {
-		analytics.Client.Close()
-		return nil
-	},
+	Before: actions(initLogging, startCheckUpgrade, initConfig, initAnalytics, displayCopyright, reportCheckUpgrade),
+	After:  actions(reportCheckUpgrade, closeAnalytics),
 	Action: func(ctx *cli.Context) error {
 		if !ctx.Bool("force") {
 			if !isatty.IsTerminal(os.Stdout.Fd()) {

--- a/integration/github/github.go
+++ b/integration/github/github.go
@@ -28,6 +28,18 @@ type Release struct {
 	Assets     []Asset `json:"assets"`
 }
 
+func (r *Release) IsNewer(b string) bool {
+	this, err := version.NewVersion(r.TagName)
+	if err != nil {
+		return false
+	}
+	other, err := version.NewVersion(b)
+	if err != nil {
+		return false
+	}
+	return this.GreaterThan(other)
+}
+
 // LatestK0sBinaryURL returns the url for the latest k0s release by arch and os
 func LatestK0sBinaryURL(arch, osKind string, preok bool) (string, error) {
 	r, err := LatestRelease("k0sproject/k0s", preok)


### PR DESCRIPTION
Checks github for a newer k0sctl release. 

If current version is pre, also a newer pre-release of k0sctl will trigger an upgrade notification.

The github response is cached for an hour to avoid getting temporary github API bans.
