### PR TITLE
Switch config validator to ozzo-validate

### DIFF
--- a/cmd/flags.go
+++ b/cmd/flags.go
@@ -116,8 +116,13 @@ func initConfig(ctx *cli.Context) error {
 		return err
 	}
 
+	m, err := yaml.Marshal(c)
+	if err == nil {
+		log.Tracef("unmarshaled configuration:\n%s", m)
+	}
+
 	if err := c.Validate(); err != nil {
-		return err
+		return fmt.Errorf("configuration validation failed: %w", err)
 	}
 
 	ctx.Context = context.WithValue(ctx.Context, ctxConfigKey{}, c)

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -238,7 +238,7 @@ var initCommand = &cli.Command{
 			Metadata:   &v1beta1.ClusterMetadata{Name: ctx.String("cluster-name")},
 			Spec: &cluster.Spec{
 				Hosts: buildHosts(addresses, ctx.Int("controller-count"), ctx.String("user"), ctx.String("key-path")),
-				K0s:   cluster.K0s{},
+				K0s:   &cluster.K0s{},
 			},
 		}
 

--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,6 @@ require (
 	github.com/creasty/defaults v1.5.2
 	github.com/denisbrodbeck/machineid v1.0.1
 	github.com/gammazero/workerpool v1.1.2
-	github.com/go-playground/validator/v10 v10.9.0
 	github.com/gofrs/uuid v4.0.0+incompatible // indirect
 	github.com/hashicorp/go-version v1.3.0
 	github.com/k0sproject/dig v0.2.0
@@ -40,8 +39,14 @@ require (
 )
 
 require (
+	github.com/go-ozzo/ozzo-validation/v4 v4.3.0
+	github.com/go-playground/validator/v10 v10.9.0
+)
+
+require (
 	github.com/acarl005/stripansi v0.0.0-20180116102854-5a71ef0e047d // indirect
 	github.com/alessio/shellescape v1.4.1 // indirect
+	github.com/asaskevich/govalidator v0.0.0-20200108200545-475eaeb16496 // indirect
 	github.com/cpuguy83/go-md2man/v2 v2.0.1 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/gammazero/deque v0.1.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -62,6 +62,8 @@ github.com/acarl005/stripansi v0.0.0-20180116102854-5a71ef0e047d/go.mod h1:asat6
 github.com/alessio/shellescape v1.4.1 h1:V7yhSDDn8LP4lc4jS8pFkt0zCnzVJlG5JXy9BVKJUX0=
 github.com/alessio/shellescape v1.4.1/go.mod h1:PZAiSCk0LJaZkiCSkPv8qIobYglO3FPpyFjDCtHLS30=
 github.com/asaskevich/govalidator v0.0.0-20190424111038-f61b66f89f4a/go.mod h1:lB+ZfQJz7igIIfQNfa7Ml4HSf2uFQQRzpGGRXenZAgY=
+github.com/asaskevich/govalidator v0.0.0-20200108200545-475eaeb16496 h1:zV3ejI06GQ59hwDQAvmK1qxOQGB3WuVTRoY0okPTAv0=
+github.com/asaskevich/govalidator v0.0.0-20200108200545-475eaeb16496/go.mod h1:oGkLhpf+kjZl6xBf758TQhh5XrAeiJv/7FRz/2spLIg=
 github.com/avast/retry-go v3.0.0+incompatible h1:4SOWQ7Qs+oroOTQOYnAHqelpCO0biHSxpiH9JdtuBj0=
 github.com/avast/retry-go v3.0.0+incompatible/go.mod h1:XtSnn+n/sHqQIpZ10K1qAevBhOOCWBLXXy3hyiqqBrY=
 github.com/bmatcuk/doublestar/v4 v4.0.2 h1:X0krlUVAVmtr2cRoTqR8aDMrDqnB36ht8wpWTiQ3jsA=
@@ -113,6 +115,8 @@ github.com/go-logr/logr v1.1.0/go.mod h1:jdQByPbusPIv2/zmleS9BjJVeZ6kBagPoEUsqbV
 github.com/go-openapi/jsonpointer v0.19.3/go.mod h1:Pl9vOtqEWErmShwVjC8pYs9cog34VGT37dQOVbmoatg=
 github.com/go-openapi/jsonreference v0.19.3/go.mod h1:rjx6GuL8TTa9VaixXglHmQmIL98+wF9xc8zWvFonSJ8=
 github.com/go-openapi/swag v0.19.5/go.mod h1:POnQmlKehdgb5mhVOsnJFsivZCEZ/vjK9gh66Z9tfKk=
+github.com/go-ozzo/ozzo-validation/v4 v4.3.0 h1:byhDUpfEwjsVQb1vBunvIjh2BHQ9ead57VkAEY4V+Es=
+github.com/go-ozzo/ozzo-validation/v4 v4.3.0/go.mod h1:2NKgrcHl3z6cJs+3Oo940FPRiTzuqKbvfrL2RxCj6Ew=
 github.com/go-playground/assert/v2 v2.0.1 h1:MsBgLAaY856+nPRTKrp3/OZK38U/wa0CcBYNjji3q3A=
 github.com/go-playground/assert/v2 v2.0.1/go.mod h1:VDjEfimB/XKnb+ZQfWdccd7VUvScMdVu0Titje2rxJ4=
 github.com/go-playground/locales v0.14.0 h1:u50s323jtVGugKlcYeyzC0etD1HifMjqmJqb8WugfUU=

--- a/pkg/apis/k0sctl.k0sproject.io/v1beta1/cluster.go
+++ b/pkg/apis/k0sctl.k0sproject.io/v1beta1/cluster.go
@@ -1,12 +1,8 @@
 package v1beta1
 
 import (
-	"fmt"
-
-	validator "github.com/go-playground/validator/v10"
-	"github.com/hashicorp/go-version"
+	validation "github.com/go-ozzo/ozzo-validation/v4"
 	"github.com/k0sproject/k0sctl/pkg/apis/k0sctl.k0sproject.io/v1beta1/cluster"
-	log "github.com/sirupsen/logrus"
 )
 
 // APIVersion is the current api version
@@ -19,8 +15,8 @@ type ClusterMetadata struct {
 
 // Cluster describes launchpad.yaml configuration
 type Cluster struct {
-	APIVersion string           `yaml:"apiVersion" validate:"required,apiversionmatch"`
-	Kind       string           `yaml:"kind" validate:"required,oneof=cluster Cluster"`
+	APIVersion string           `yaml:"apiVersion"`
+	Kind       string           `yaml:"kind"`
 	Metadata   *ClusterMetadata `yaml:"metadata"`
 	Spec       *cluster.Spec    `yaml:"spec"`
 }
@@ -44,70 +40,10 @@ func (c *Cluster) UnmarshalYAML(unmarshal func(interface{}) error) error {
 
 // Validate performs a configuration sanity check
 func (c *Cluster) Validate() error {
-	validator := validator.New()
-	validator.RegisterStructValidation(validateMinK0sVersion, cluster.K0s{})
-	if err := validator.RegisterValidation("apiversionmatch", validateAPIVersion); err != nil {
-		return err
-	}
-	validator.RegisterStructValidation(validateHostCounts, cluster.Spec{})
-	return validator.Struct(c)
-}
-
-func validateHostCounts(sl validator.StructLevel) {
-	spec, ok := sl.Current().Interface().(cluster.Spec)
-	if !ok {
-		return
-	}
-
-	if len(spec.Hosts) == 0 {
-		sl.ReportError(spec, "hosts", "", "no hosts in configuration", "")
-		return
-	}
-
-	var hasSingle bool
-	for _, h := range spec.Hosts {
-		if h.InstallFlags.Get("--single") != "" && h.Role != "single" {
-			log.Warnf("%s: changed role from '%s' to 'single' because '--single' defined in installFlags", h, h.Role)
-			h.Role = "single"
-		}
-
-		if h.InstallFlags.Get("--enable-worker") != "" && h.Role != "controller+worker" {
-			log.Warnf("%s: changed role from '%s' to 'controller+worker' because '--enable-workloads' defined in installFlags", h, h.Role)
-			h.Role = "controller+worker"
-		}
-
-		if h.Role == "single" {
-			hasSingle = true
-			break
-		}
-	}
-
-	if hasSingle && len(spec.Hosts) > 1 {
-		sl.ReportError(spec, "hosts", "", "contains a host with role: single but multiple hosts defined", "")
-	}
-
-	if len(spec.Hosts.Controllers()) == 0 {
-		sl.ReportError(spec, "hosts", "", "contains no controller nodes", "")
-	}
-}
-
-func validateAPIVersion(fl validator.FieldLevel) bool {
-	return fl.Field().String() == APIVersion
-}
-
-func validateMinK0sVersion(sl validator.StructLevel) {
-	if k0s, ok := sl.Current().Interface().(cluster.K0s); ok {
-		v, err := version.NewVersion(k0s.Version)
-		if err != nil {
-			sl.ReportError(k0s.Version, "version", "", "invalid version", "")
-			return
-		}
-		min, err := version.NewVersion(cluster.K0sMinVersion)
-		if err != nil {
-			panic("invalid k0s minversion")
-		}
-		if v.LessThan(min) {
-			sl.ReportError(k0s.Version, "version", "", fmt.Sprintf("minimum k0s version is %s", cluster.K0sMinVersion), "")
-		}
-	}
+	validation.ErrorTag = "yaml"
+	return validation.ValidateStruct(c,
+		validation.Field(&c.APIVersion, validation.Required, validation.In(APIVersion).Error("must equal "+APIVersion)),
+		validation.Field(&c.Kind, validation.Required, validation.In("cluster", "Cluster").Error("must equal Cluster")),
+		validation.Field(&c.Spec),
+	)
 }

--- a/pkg/apis/k0sctl.k0sproject.io/v1beta1/cluster/hosts.go
+++ b/pkg/apis/k0sctl.k0sproject.io/v1beta1/cluster/hosts.go
@@ -9,28 +9,56 @@ import (
 //Hosts are destnation hosts
 type Hosts []*Host
 
+func (hosts Hosts) Validate() error {
+	if len(hosts) == 0 {
+		return fmt.Errorf("at least one host required")
+	}
+
+	if len(hosts) > 1 {
+		hostmap := make(map[string]struct{}, len(hosts))
+		for idx, h := range hosts {
+			if err := h.Validate(); err != nil {
+				return fmt.Errorf("host #%d: %v", idx+1, err)
+			}
+			if h.Role == "single" {
+				return fmt.Errorf("%d hosts defined but includes a host with role 'single': %s", len(hosts), h)
+			}
+			if _, ok := hostmap[h.String()]; ok {
+				return fmt.Errorf("%s: is not unique", h)
+			}
+			hostmap[h.String()] = struct{}{}
+		}
+	}
+
+	if len(hosts.Controllers()) < 1 {
+		return fmt.Errorf("no hosts with a controller role defined")
+	}
+
+	return nil
+}
+
 // First returns the first host
-func (hosts *Hosts) First() *Host {
-	if len(*hosts) == 0 {
+func (hosts Hosts) First() *Host {
+	if len(hosts) == 0 {
 		return nil
 	}
-	return (*hosts)[0]
+	return (hosts)[0]
 }
 
 // Last returns the last host
-func (hosts *Hosts) Last() *Host {
-	c := len(*hosts) - 1
+func (hosts Hosts) Last() *Host {
+	c := len(hosts) - 1
 
 	if c < 0 {
 		return nil
 	}
 
-	return (*hosts)[c]
+	return hosts[c]
 }
 
 // Find returns the first matching Host. The finder function should return true for a Host matching the criteria.
-func (hosts *Hosts) Find(filter func(h *Host) bool) *Host {
-	for _, h := range *hosts {
+func (hosts Hosts) Find(filter func(h *Host) bool) *Host {
+	for _, h := range hosts {
 		if filter(h) {
 			return (h)
 		}
@@ -39,10 +67,10 @@ func (hosts *Hosts) Find(filter func(h *Host) bool) *Host {
 }
 
 // Filter returns a filtered list of Hosts. The filter function should return true for hosts matching the criteria.
-func (hosts *Hosts) Filter(filter func(h *Host) bool) Hosts {
-	result := make(Hosts, 0, len(*hosts))
+func (hosts Hosts) Filter(filter func(h *Host) bool) Hosts {
+	result := make(Hosts, 0, len(hosts))
 
-	for _, h := range *hosts {
+	for _, h := range hosts {
 		if filter(h) {
 			result = append(result, h)
 		}
@@ -52,25 +80,25 @@ func (hosts *Hosts) Filter(filter func(h *Host) bool) Hosts {
 }
 
 // WithRole returns a ltered list of Hosts that have the given role
-func (hosts *Hosts) WithRole(s string) Hosts {
+func (hosts Hosts) WithRole(s string) Hosts {
 	return hosts.Filter(func(h *Host) bool {
 		return h.Role == s
 	})
 }
 
 // Controllers returns hosts with the role "controller"
-func (hosts *Hosts) Controllers() Hosts {
+func (hosts Hosts) Controllers() Hosts {
 	return hosts.Filter(func(h *Host) bool { return h.IsController() })
 }
 
 // Workers returns hosts with the role "worker"
-func (hosts *Hosts) Workers() Hosts {
+func (hosts Hosts) Workers() Hosts {
 	return hosts.WithRole("worker")
 }
 
 // ParallelEach runs a function (or multiple functions chained) on every Host parallelly.
 // Any errors will be concatenated and returned.
-func (hosts *Hosts) ParallelEach(filter ...func(h *Host) error) error {
+func (hosts Hosts) ParallelEach(filter ...func(h *Host) error) error {
 	var wg sync.WaitGroup
 	var errors []string
 	type erritem struct {
@@ -80,9 +108,9 @@ func (hosts *Hosts) ParallelEach(filter ...func(h *Host) error) error {
 	ec := make(chan erritem, 1)
 
 	for _, f := range filter {
-		wg.Add(len(*hosts))
+		wg.Add(len(hosts))
 
-		for _, h := range *hosts {
+		for _, h := range hosts {
 			go func(h *Host) {
 				ec <- erritem{h.String(), f(h)}
 			}(h)

--- a/pkg/apis/k0sctl.k0sproject.io/v1beta1/cluster/spec.go
+++ b/pkg/apis/k0sctl.k0sproject.io/v1beta1/cluster/spec.go
@@ -4,12 +4,13 @@ import (
 	"fmt"
 
 	"github.com/creasty/defaults"
+	validation "github.com/go-ozzo/ozzo-validation/v4"
 )
 
 // Spec defines cluster config spec section
 type Spec struct {
-	Hosts Hosts `yaml:"hosts" validate:"required,dive,min=1"`
-	K0s   K0s   `yaml:"k0s"`
+	Hosts Hosts `yaml:"hosts"`
+	K0s   *K0s  `yaml:"k0s"`
 
 	k0sLeader *Host
 }
@@ -47,6 +48,14 @@ func (s *Spec) K0sLeader() *Host {
 	}
 
 	return s.k0sLeader
+}
+
+func (s *Spec) Validate() error {
+	return validation.ValidateStruct(s,
+		validation.Field(&s.Hosts, validation.Required),
+		validation.Field(&s.Hosts),
+		validation.Field(&s.K0s),
+	)
 }
 
 // KubeAPIURL returns an url to the cluster's kube api

--- a/pkg/apis/k0sctl.k0sproject.io/v1beta1/cluster/uploadfile.go
+++ b/pkg/apis/k0sctl.k0sproject.io/v1beta1/cluster/uploadfile.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 
 	"github.com/bmatcuk/doublestar/v4"
+	validation "github.com/go-ozzo/ozzo-validation/v4"
 	log "github.com/sirupsen/logrus"
 )
 
@@ -19,8 +20,8 @@ type LocalFile struct {
 // UploadFile describes a file to be uploaded for the host
 type UploadFile struct {
 	Name            string       `yaml:"name,omitempty"`
-	Source          string       `yaml:"src" validate:"required"`
-	DestinationDir  string       `yaml:"dstDir" validate:"required"`
+	Source          string       `yaml:"src"`
+	DestinationDir  string       `yaml:"dstDir"`
 	DestinationFile string       `yaml:"dst"`
 	PermMode        interface{}  `yaml:"perm"`
 	DirPermMode     interface{}  `yaml:"dirPerm"`
@@ -30,6 +31,14 @@ type UploadFile struct {
 	DirPermString   string       `yaml:"-"`
 	Sources         []*LocalFile `yaml:"-"`
 	Base            string       `yaml:"-"`
+}
+
+func (u UploadFile) Validate() error {
+	return validation.ValidateStruct(&u,
+		validation.Field(&u.Source, validation.Required),
+		validation.Field(&u.DestinationFile, validation.Required.When(u.DestinationDir == "").Error("dst or dstdir required")),
+		validation.Field(&u.DestinationDir, validation.Required.When(u.DestinationFile == "").Error("dst or dstdir required")),
+	)
 }
 
 // converts string or integer value to octal string for chmod

--- a/pkg/apis/k0sctl.k0sproject.io/v1beta1/cluster_test.go
+++ b/pkg/apis/k0sctl.k0sproject.io/v1beta1/cluster_test.go
@@ -13,7 +13,7 @@ func TestAPIVersionValidation(t *testing.T) {
 		Kind:       "cluster",
 	}
 
-	require.EqualError(t, cfg.Validate(), "Key: 'Cluster.APIVersion' Error:Field validation for 'APIVersion' failed on the 'apiversionmatch' tag")
+	require.EqualError(t, cfg.Validate(), "apiVersion: must equal k0sctl.k0sproject.io/v1beta1.")
 	cfg.APIVersion = APIVersion
 	require.NoError(t, cfg.Validate())
 }
@@ -23,7 +23,7 @@ func TestK0sVersionValidation(t *testing.T) {
 		APIVersion: APIVersion,
 		Kind:       "cluster",
 		Spec: &cluster.Spec{
-			K0s: cluster.K0s{
+			K0s: &cluster.K0s{
 				Version: "0.1.0",
 			},
 			Hosts: cluster.Hosts{
@@ -34,7 +34,7 @@ func TestK0sVersionValidation(t *testing.T) {
 
 	err := cfg.Validate()
 	require.Error(t, err)
-	require.Contains(t, err.Error(), "minimum k0s version")
+	require.Contains(t, err.Error(), "minimum supported k0s version")
 	cfg.Spec.K0s.Version = cluster.K0sMinVersion
 	require.NoError(t, cfg.Validate())
 }


### PR DESCRIPTION
https://github.com/go-ozzo/ozzo-validation has prettier error messages and the custom validations are a bit easier to write. 

The https://github.com/go-playground/validator is still used for the [rig](https://github.com/k0sproject/rig) options.

A prerequisite for validating the dynamic config support in #270 
