### PR TITLE
Update upgrade smoke-test versions

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -79,7 +79,7 @@ jobs:
           - quay.io/footloose/centos7
             #- quay.io/footloose/amazonlinux2
           - quay.io/footloose/debian10
-          - quay.io/footloose/fedora29
+            # - quay.io/footloose/fedora29
     name: Basic 1+1 smoke
     needs: build
     runs-on: ubuntu-latest

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -159,8 +159,10 @@ jobs:
           #- quay.io/footloose/amazonlinux2
           #- quay.io/footloose/debian10
           #- quay.io/footloose/fedora29
-          #
-    name: Upgrade 0.10 --> 0.11
+        k0s_from:
+          - 0.11.0
+          - v1.21.6+k0s.0
+    name: Upgrade
     needs: build
     runs-on: ubuntu-latest
 
@@ -182,6 +184,7 @@ jobs:
       - name: Run smoke tests
         env:
           LINUX_IMAGE: ${{ matrix.image }}
+          K0S_FROM:  ${{ matrix.k0s_from }}
         run: make smoke-upgrade
 
   smoke-reset:

--- a/phase/disconnect.go
+++ b/phase/disconnect.go
@@ -2,7 +2,6 @@ package phase
 
 import (
 	"github.com/k0sproject/k0sctl/pkg/apis/k0sctl.k0sproject.io/v1beta1/cluster"
-	"github.com/k0sproject/rig/exec"
 )
 
 // Disconnect disconnects from the hosts
@@ -18,7 +17,6 @@ func (p *Disconnect) Title() string {
 // Run the phase
 func (p *Disconnect) Run() error {
 	return p.Config.Spec.Hosts.ParallelEach(func(h *cluster.Host) error {
-		_ = h.Exec("ps -ef", exec.Sudo(h), exec.StreamOutput())
 		h.Disconnect()
 		return nil
 	})

--- a/smoke-test/smoke-reset.sh
+++ b/smoke-test/smoke-reset.sh
@@ -9,5 +9,8 @@ trap cleanup EXIT
 
 deleteCluster
 createCluster
-../k0sctl apply --config "${K0SCTL_CONFIG}" --debug --trace
-../k0sctl reset --config "${K0SCTL_CONFIG}" --debug --trace --force
+echo "* Applying"
+../k0sctl apply --config "${K0SCTL_CONFIG}" --debug
+echo "* Resetting"
+../k0sctl reset --config "${K0SCTL_CONFIG}" --debug --force
+echo "* Done, cleaning up"

--- a/smoke-test/smoke-upgrade.sh
+++ b/smoke-test/smoke-upgrade.sh
@@ -16,6 +16,11 @@ K0S_VERSION="${K0S_FROM}"
 ../k0sctl apply --config "${K0SCTL_CONFIG}" --debug
 
 # Create config with blank version (to use latest) and apply as upgrade
-sed -e -i '/[:space:]*version:/d' "${K0SCTL_CONFIG}"
-cat "${K0SCTL_CONFIG}"
+
+if [ "${UNAME}" = "Darwin" ]; then
+  SEDOPTS="-i -e"
+else
+  SEDOPTS="-i"
+fi
+sed ${SEDOPTS} '/[:space:]*version:/d' "${K0SCTL_CONFIG}"
 ../k0sctl apply --config "${K0SCTL_CONFIG}" --debug

--- a/smoke-test/smoke-upgrade.sh
+++ b/smoke-test/smoke-upgrade.sh
@@ -12,10 +12,10 @@ deleteCluster
 createCluster
 
 # Create config with older version and apply
-K0S_VERSION="1.20.6+k0s.0"
+K0S_VERSION="${K0S_FROM}"
 ../k0sctl apply --config "${K0SCTL_CONFIG}" --debug
 
-# Create config with newer version and apply as upgrade
-K0S_VERSION="1.21.1+k0s.0"
+# Create config with blank version (to use latest) and apply as upgrade
+K0S_VERSION=""
 ../k0sctl apply --config "${K0SCTL_CONFIG}" --debug
 ../k0sctl kubeconfig --config "${K0SCTL_CONFIG}" | grep -v -- "-data"

--- a/smoke-test/smoke-upgrade.sh
+++ b/smoke-test/smoke-upgrade.sh
@@ -17,4 +17,5 @@ K0S_VERSION="${K0S_FROM}"
 
 # Create config with blank version (to use latest) and apply as upgrade
 sed -e -i '/[:space:]*version:/d' "${K0SCTL_CONFIG}"
+cat "${K0SCTL_CONFIG}"
 ../k0sctl apply --config "${K0SCTL_CONFIG}" --debug

--- a/smoke-test/smoke-upgrade.sh
+++ b/smoke-test/smoke-upgrade.sh
@@ -13,14 +13,11 @@ createCluster
 
 # Create config with older version and apply
 K0S_VERSION="${K0S_FROM}"
+echo "Installing ${K0S_VERSION}"
 ../k0sctl apply --config "${K0SCTL_CONFIG}" --debug
 
 # Create config with blank version (to use latest) and apply as upgrade
+K0S_VERSION="$(curl https://api.github.com/repos/k0sproject/k0s/releases | grep tag_name | cut -d"\"" -f4 | grep "+k0s" | sed -r 's/^(v[0-9]+\.[0-9]+\.[0-9]+)\+/\19999+/g' | sort -r -t "." -k1,5n | head -1 | sed 's/9999//')"
 
-if [ "${UNAME}" = "Darwin" ]; then
-  SEDOPTS="-i -e"
-else
-  SEDOPTS="-i"
-fi
-sed ${SEDOPTS} '/[[:space:]]*version:/d' "${K0SCTL_CONFIG}"
+echo "Upgrading to ${K0S_VERSION}"
 ../k0sctl apply --config "${K0SCTL_CONFIG}" --debug

--- a/smoke-test/smoke-upgrade.sh
+++ b/smoke-test/smoke-upgrade.sh
@@ -16,6 +16,5 @@ K0S_VERSION="${K0S_FROM}"
 ../k0sctl apply --config "${K0SCTL_CONFIG}" --debug
 
 # Create config with blank version (to use latest) and apply as upgrade
-K0S_VERSION=""
+sed -e -i '/[:space:]*version:/d' "${K0SCTL_CONFIG}"
 ../k0sctl apply --config "${K0SCTL_CONFIG}" --debug
-../k0sctl kubeconfig --config "${K0SCTL_CONFIG}" | grep -v -- "-data"

--- a/smoke-test/smoke-upgrade.sh
+++ b/smoke-test/smoke-upgrade.sh
@@ -22,5 +22,5 @@ if [ "${UNAME}" = "Darwin" ]; then
 else
   SEDOPTS="-i"
 fi
-sed ${SEDOPTS} '/[:space:]*version:/d' "${K0SCTL_CONFIG}"
+sed ${SEDOPTS} '/[[:space:]]*version:/d' "${K0SCTL_CONFIG}"
 ../k0sctl apply --config "${K0SCTL_CONFIG}" --debug


### PR DESCRIPTION
The workflow name was something like `0.10.0 --> 0.11.0` but the version tested was `1.2x.x --> 1.2x.x`.

Now it has a matrix for the first-pass version and will always upgrade to `latest`.
