### PR TITLE
Improve smoke test CI workflow

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -6,6 +6,7 @@ jobs:
 
   build:
     runs-on: ubuntu-latest
+
     steps:
     - uses: actions/checkout@v2
 
@@ -37,22 +38,38 @@ jobs:
     - name: Test
       run: go test -v ./...
 
-    - name: Cache the compiled binary for further testing
+    - name: Stash the compiled binary for further testing
+      uses: actions/upload-artifact@v2
+      with:
+        name: k0sctl
+        path: k0sctl
+        retention-days: 2
+
+  build-all:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Set up Go
+      uses: actions/setup-go@v2
+      with:
+        go-version: 1.17
+
+    - name: Go modules cache
       uses: actions/cache@v2
-      id: cache-compiled-binary
       with:
         path: |
-          k0sctl
-        key: build-${{ github.run_id }}
+          ~/go/pkg/mod
+          ~/.cache/go-build
+          ~/Library/Caches/go-build
+          %LocalAppData%\go-build
+        key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+        restore-keys: |
+          ${{ runner.os }}-go-
 
     - name: Build all
       run: make build-all
-
-    - uses: actions/upload-artifact@v2
-      with:
-        name: k0sctl-linux-x64
-        path: bin/k0sctl-linux-x64
-        retention-days: 2
 
   smoke-basic:
     strategy:
@@ -68,41 +85,19 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - name: Check out code into the Go module directory
-        uses: actions/checkout@v2
-
+      - uses: actions/checkout@v2
       - name: Set up Go
         uses: actions/setup-go@v2
         with:
           go-version: 1.17
 
-      - name: Restore the compiled binary for smoke testing
-        uses: actions/cache@v2
-        id: restore-compiled-binary
-        with:
-          path: |
-            k0sctl
-          key: build-${{ github.run_id }}
-
-      - name: K0sctl cache
-        uses: actions/cache@v2
-        with:
-          path: |
-            /var/cache/k0sctl
-            ~/.k0sctl/cache
-            !*.log
-          key: k0sctl-cache
-
-      - name: Kubectl cache
-        uses: actions/cache@v2
-        with:
-          path: |
-            smoke-test/kubectl
-          key: kubectl-1.21.3
-
-      - name: Docker Layer Caching For Footloose
-        uses: satackey/action-docker-layer-caching@v0.0.11
-        continue-on-error: true
+      - {"name":"Go modules cache","uses":"actions/cache@v2","with":{"path":"~/go/pkg/mod\n~/.cache/go-build\n~/Library/Caches/go-build\n%LocalAppData%\\go-build\n","key":"${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}","restore-keys":"${{ runner.os }}-go-\n"}}
+      - {"name":"Compiled binary cache","uses":"actions/download-artifact@v2","with":{"name":"k0sctl","path":"."}}
+      - {"name":"Make executable","run":"chmod +x k0sctl"}
+      - {"name":"K0sctl cache","uses":"actions/cache@v2","with":{"path":"/var/cache/k0sctl\n~/.k0sctl/cache\n!*.log\n","key":"k0sctl-cache"}}
+      - {"name":"Kubectl cache","uses":"actions/cache@v2","with":{"path":"smoke-test/kubectl\n","key":"kubectl-1.21.3"}}
+      - {"name":"Go modules cache","uses":"actions/cache@v2","with":{"path":"~/go/pkg/mod\n~/.cache/go-build\n~/Library/Caches/go-build\n%LocalAppData%\\go-build\n","key":"${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}","restore-keys":"${{ runner.os }}-go-\n"}}
+      - {"name":"Docker Layer Caching For Footloose","uses":"satackey/action-docker-layer-caching@v0.0.11","continue-on-error":true}
 
       - name: Run smoke tests
         env:
@@ -115,34 +110,19 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - name: Check out code into the Go module directory
-        uses: actions/checkout@v2
-
+      - uses: actions/checkout@v2
       - name: Set up Go
         uses: actions/setup-go@v2
         with:
           go-version: 1.17
 
-      - name: Restore the compiled binary for smoke testing
-        uses: actions/cache@v2
-        id: restore-compiled-binary
-        with:
-          path: |
-            k0sctl
-          key: build-${{ github.run_id }}
-
-      - name: K0sctl cache
-        uses: actions/cache@v2
-        with:
-          path: |
-            /var/cache/k0sctl
-            ~/.k0sctl/cache
-            !*.log
-          key: k0sctl-cache
-
-      - name: Docker Layer Caching For Footloose
-        uses: satackey/action-docker-layer-caching@v0.0.11
-        continue-on-error: true
+      - {"name":"Go modules cache","uses":"actions/cache@v2","with":{"path":"~/go/pkg/mod\n~/.cache/go-build\n~/Library/Caches/go-build\n%LocalAppData%\\go-build\n","key":"${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}","restore-keys":"${{ runner.os }}-go-\n"}}
+      - {"name":"Compiled binary cache","uses":"actions/download-artifact@v2","with":{"name":"k0sctl","path":"."}}
+      - {"name":"Make executable","run":"chmod +x k0sctl"}
+      - {"name":"K0sctl cache","uses":"actions/cache@v2","with":{"path":"/var/cache/k0sctl\n~/.k0sctl/cache\n!*.log\n","key":"k0sctl-cache"}}
+      - {"name":"Kubectl cache","uses":"actions/cache@v2","with":{"path":"smoke-test/kubectl\n","key":"kubectl-1.21.3"}}
+      - {"name":"Go modules cache","uses":"actions/cache@v2","with":{"path":"~/go/pkg/mod\n~/.cache/go-build\n~/Library/Caches/go-build\n%LocalAppData%\\go-build\n","key":"${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}","restore-keys":"${{ runner.os }}-go-\n"}}
+      - {"name":"Docker Layer Caching For Footloose","uses":"satackey/action-docker-layer-caching@v0.0.11","continue-on-error":true}
 
       - name: Run smoke tests
         run: make smoke-files
@@ -153,34 +133,19 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - name: Check out code into the Go module directory
-        uses: actions/checkout@v2
-
+      - uses: actions/checkout@v2
       - name: Set up Go
         uses: actions/setup-go@v2
         with:
           go-version: 1.17
 
-      - name: Restore the compiled binary for smoke testing
-        uses: actions/cache@v2
-        id: restore-compiled-binary
-        with:
-          path: |
-            k0sctl
-          key: build-${{ github.run_id }}
-
-      - name: K0sctl cache
-        uses: actions/cache@v2
-        with:
-          path: |
-            /var/cache/k0sctl
-            ~/.k0sctl/cache
-            !*.log
-          key: k0sctl-cache
-
-      - name: Docker Layer Caching For Footloose
-        uses: satackey/action-docker-layer-caching@v0.0.11
-        continue-on-error: true
+      - {"name":"Go modules cache","uses":"actions/cache@v2","with":{"path":"~/go/pkg/mod\n~/.cache/go-build\n~/Library/Caches/go-build\n%LocalAppData%\\go-build\n","key":"${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}","restore-keys":"${{ runner.os }}-go-\n"}}
+      - {"name":"Compiled binary cache","uses":"actions/download-artifact@v2","with":{"name":"k0sctl","path":"."}}
+      - {"name":"Make executable","run":"chmod +x k0sctl"}
+      - {"name":"K0sctl cache","uses":"actions/cache@v2","with":{"path":"/var/cache/k0sctl\n~/.k0sctl/cache\n!*.log\n","key":"k0sctl-cache"}}
+      - {"name":"Kubectl cache","uses":"actions/cache@v2","with":{"path":"smoke-test/kubectl\n","key":"kubectl-1.21.3"}}
+      - {"name":"Go modules cache","uses":"actions/cache@v2","with":{"path":"~/go/pkg/mod\n~/.cache/go-build\n~/Library/Caches/go-build\n%LocalAppData%\\go-build\n","key":"${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}","restore-keys":"${{ runner.os }}-go-\n"}}
+      - {"name":"Docker Layer Caching For Footloose","uses":"satackey/action-docker-layer-caching@v0.0.11","continue-on-error":true}
 
       - name: Run OS override smoke test
         run: make smoke-os-override
@@ -194,46 +159,25 @@ jobs:
           #- quay.io/footloose/amazonlinux2
           #- quay.io/footloose/debian10
           #- quay.io/footloose/fedora29
+          #
     name: Upgrade 0.10 --> 0.11
     needs: build
     runs-on: ubuntu-latest
 
     steps:
-      - name: Check out code into the Go module directory
-        uses: actions/checkout@v2
-
+      - uses: actions/checkout@v2
       - name: Set up Go
         uses: actions/setup-go@v2
         with:
           go-version: 1.17
 
-      - name: Restore the compiled binary for smoke testing
-        uses: actions/cache@v2
-        id: restore-compiled-binary
-        with:
-          path: |
-            k0sctl
-          key: build-${{ github.run_id }}
-
-      - name: K0sctl cache
-        uses: actions/cache@v2
-        with:
-          path: |
-            /var/cache/k0sctl
-            ~/.k0sctl/cache
-            !*.log
-          key: k0sctl-cache
-
-      - name: Old k0sctl cache
-        uses: actions/cache@v2
-        with:
-          path: |
-            ~/.cache
-          key: k0sctl-040-cache
-
-      - name: Docker Layer Caching For Footloose
-        uses: satackey/action-docker-layer-caching@v0.0.11
-        continue-on-error: true
+      - {"name":"Go modules cache","uses":"actions/cache@v2","with":{"path":"~/go/pkg/mod\n~/.cache/go-build\n~/Library/Caches/go-build\n%LocalAppData%\\go-build\n","key":"${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}","restore-keys":"${{ runner.os }}-go-\n"}}
+      - {"name":"Compiled binary cache","uses":"actions/download-artifact@v2","with":{"name":"k0sctl","path":"."}}
+      - {"name":"Make executable","run":"chmod +x k0sctl"}
+      - {"name":"K0sctl cache","uses":"actions/cache@v2","with":{"path":"/var/cache/k0sctl\n~/.k0sctl/cache\n!*.log\n","key":"k0sctl-cache"}}
+      - {"name":"Kubectl cache","uses":"actions/cache@v2","with":{"path":"smoke-test/kubectl\n","key":"kubectl-1.21.3"}}
+      - {"name":"Go modules cache","uses":"actions/cache@v2","with":{"path":"~/go/pkg/mod\n~/.cache/go-build\n~/Library/Caches/go-build\n%LocalAppData%\\go-build\n","key":"${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}","restore-keys":"${{ runner.os }}-go-\n"}}
+      - {"name":"Docker Layer Caching For Footloose","uses":"satackey/action-docker-layer-caching@v0.0.11","continue-on-error":true}
 
       - name: Run smoke tests
         env:
@@ -246,25 +190,25 @@ jobs:
         image:
           - quay.io/footloose/ubuntu18.04
           - quay.io/footloose/centos7
+
     name: Apply + reset
     needs: build
     runs-on: ubuntu-latest
 
     steps:
-      - name: Check out code into the Go module directory
-        uses: actions/checkout@v2
+      - uses: actions/checkout@v2
       - name: Set up Go
         uses: actions/setup-go@v2
         with:
           go-version: 1.17
 
-      - name: Restore compiled binary for smoke testing
-        uses: actions/cache@v2
-        id: restore-compiled-binary
-        with:
-          path: |
-            k0sctl
-          key: build-${{ github.run_id }}
+      - {"name":"Go modules cache","uses":"actions/cache@v2","with":{"path":"~/go/pkg/mod\n~/.cache/go-build\n~/Library/Caches/go-build\n%LocalAppData%\\go-build\n","key":"${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}","restore-keys":"${{ runner.os }}-go-\n"}}
+      - {"name":"Compiled binary cache","uses":"actions/download-artifact@v2","with":{"name":"k0sctl","path":"."}}
+      - {"name":"Make executable","run":"chmod +x k0sctl"}
+      - {"name":"K0sctl cache","uses":"actions/cache@v2","with":{"path":"/var/cache/k0sctl\n~/.k0sctl/cache\n!*.log\n","key":"k0sctl-cache"}}
+      - {"name":"Kubectl cache","uses":"actions/cache@v2","with":{"path":"smoke-test/kubectl\n","key":"kubectl-1.21.3"}}
+      - {"name":"Go modules cache","uses":"actions/cache@v2","with":{"path":"~/go/pkg/mod\n~/.cache/go-build\n~/Library/Caches/go-build\n%LocalAppData%\\go-build\n","key":"${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}","restore-keys":"${{ runner.os }}-go-\n"}}
+      - {"name":"Docker Layer Caching For Footloose","uses":"satackey/action-docker-layer-caching@v0.0.11","continue-on-error":true}
 
       - name: Run smoke tests
         env:
@@ -277,25 +221,25 @@ jobs:
         image:
           - quay.io/footloose/ubuntu18.04
           - quay.io/footloose/centos7
+
     name: Apply + backup + reset + restore
     needs: build
     runs-on: ubuntu-latest
 
     steps:
-      - name: Check out code into the Go module directory
-        uses: actions/checkout@v2
+      - uses: actions/checkout@v2
       - name: Set up Go
         uses: actions/setup-go@v2
         with:
           go-version: 1.17
 
-      - name: Restore compiled binary for smoke testing
-        uses: actions/cache@v2
-        id: restore-compiled-binary
-        with:
-          path: |
-            k0sctl
-          key: build-${{ github.run_id }}
+      - {"name":"Go modules cache","uses":"actions/cache@v2","with":{"path":"~/go/pkg/mod\n~/.cache/go-build\n~/Library/Caches/go-build\n%LocalAppData%\\go-build\n","key":"${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}","restore-keys":"${{ runner.os }}-go-\n"}}
+      - {"name":"Compiled binary cache","uses":"actions/download-artifact@v2","with":{"name":"k0sctl","path":"."}}
+      - {"name":"Make executable","run":"chmod +x k0sctl"}
+      - {"name":"K0sctl cache","uses":"actions/cache@v2","with":{"path":"/var/cache/k0sctl\n~/.k0sctl/cache\n!*.log\n","key":"k0sctl-cache"}}
+      - {"name":"Kubectl cache","uses":"actions/cache@v2","with":{"path":"smoke-test/kubectl\n","key":"kubectl-1.21.3"}}
+      - {"name":"Go modules cache","uses":"actions/cache@v2","with":{"path":"~/go/pkg/mod\n~/.cache/go-build\n~/Library/Caches/go-build\n%LocalAppData%\\go-build\n","key":"${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}","restore-keys":"${{ runner.os }}-go-\n"}}
+      - {"name":"Docker Layer Caching For Footloose","uses":"satackey/action-docker-layer-caching@v0.0.11","continue-on-error":true}
 
       - name: Run smoke tests
         env:
@@ -308,34 +252,19 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - name: Check out code into the Go module directory
-        uses: actions/checkout@v2
-
+      - uses: actions/checkout@v2
       - name: Set up Go
         uses: actions/setup-go@v2
         with:
           go-version: 1.17
 
-      - name: Restore the compiled binary for smoke testing
-        uses: actions/cache@v2
-        id: restore-compiled-binary
-        with:
-          path: |
-            k0sctl
-          key: build-${{ github.run_id }}
-
-      - name: K0sctl cache
-        uses: actions/cache@v2
-        with:
-          path: |
-            /var/cache/k0sctl
-            ~/.k0sctl/cache
-            !*.log
-          key: k0sctl-cache
-
-      - name: Docker Layer Caching For Footloose
-        uses: satackey/action-docker-layer-caching@v0.0.11
-        continue-on-error: true
+      - {"name":"Go modules cache","uses":"actions/cache@v2","with":{"path":"~/go/pkg/mod\n~/.cache/go-build\n~/Library/Caches/go-build\n%LocalAppData%\\go-build\n","key":"${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}","restore-keys":"${{ runner.os }}-go-\n"}}
+      - {"name":"Compiled binary cache","uses":"actions/download-artifact@v2","with":{"name":"k0sctl","path":"."}}
+      - {"name":"Make executable","run":"chmod +x k0sctl"}
+      - {"name":"K0sctl cache","uses":"actions/cache@v2","with":{"path":"/var/cache/k0sctl\n~/.k0sctl/cache\n!*.log\n","key":"k0sctl-cache"}}
+      - {"name":"Kubectl cache","uses":"actions/cache@v2","with":{"path":"smoke-test/kubectl\n","key":"kubectl-1.21.3"}}
+      - {"name":"Go modules cache","uses":"actions/cache@v2","with":{"path":"~/go/pkg/mod\n~/.cache/go-build\n~/Library/Caches/go-build\n%LocalAppData%\\go-build\n","key":"${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}","restore-keys":"${{ runner.os }}-go-\n"}}
+      - {"name":"Docker Layer Caching For Footloose","uses":"satackey/action-docker-layer-caching@v0.0.11","continue-on-error":true}
 
       - name: Run init smoke test
         run: make smoke-init


### PR DESCRIPTION
 * Move long running "build all" to a separate flow
 * Use GH action artifacts instead of cache for getting the built binary
 * ~~Don't setup go for smoke-tests~~
 * Add the k0sctl cache (for caching k0s binaries) that was missing from a couple of the smoke tests
 
