### PR TITLE
Ignore k0s reset error exit for k0s <= 1.22.3+k0s.0

### DIFF
--- a/cmd/flags.go
+++ b/cmd/flags.go
@@ -403,9 +403,17 @@ func reportCheckUpgrade(ctx *cli.Context) error {
 	}
 
 	log.Tracef("waiting for upgrade check response")
-
-	if release := <-upgradeChan; release != nil {
-		fmt.Println(Colorize.BrightCyan(fmt.Sprintf("A new version %s of k0sctl is available: %s", release.TagName, release.URL)))
+	var release *github.Release
+	select {
+	case release = <-upgradeChan:
+		log.Tracef("upgrade check response received")
+		if release == nil {
+			log.Tracef("no upgrade available")
+		} else {
+			fmt.Println(Colorize.BrightCyan(fmt.Sprintf("A new version %s of k0sctl is available: %s", release.TagName, release.URL)))
+		}
+	case <-time.After(5 * time.Second):
+		log.Tracef("upgrade check timed out")
 	}
 
 	return nil

--- a/phase/disconnect.go
+++ b/phase/disconnect.go
@@ -2,6 +2,7 @@ package phase
 
 import (
 	"github.com/k0sproject/k0sctl/pkg/apis/k0sctl.k0sproject.io/v1beta1/cluster"
+	"github.com/k0sproject/rig/exec"
 )
 
 // Disconnect disconnects from the hosts
@@ -17,6 +18,7 @@ func (p *Disconnect) Title() string {
 // Run the phase
 func (p *Disconnect) Run() error {
 	return p.Config.Spec.Hosts.ParallelEach(func(h *cluster.Host) error {
+		_ = h.Exec("ps -ef", exec.Sudo(h), exec.StreamOutput())
 		h.Disconnect()
 		return nil
 	})

--- a/phase/reset.go
+++ b/phase/reset.go
@@ -2,6 +2,7 @@ package phase
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/Masterminds/semver"
 	"github.com/k0sproject/k0sctl/pkg/apis/k0sctl.k0sproject.io/v1beta1"
@@ -65,6 +66,14 @@ func (p *Reset) Run() error {
 		}
 
 		log.Infof("%s: running k0s reset", h)
-		return h.Exec(h.Configurer.K0sCmdf("reset"), exec.Sudo(h))
+		out, err := h.ExecOutput(h.Configurer.K0sCmdf("reset"), exec.Sudo(h))
+		if err != nil {
+			log.Warnf("%s: k0s reported failure: %v", h, err)
+			if strings.Contains(out, "k0s cleanup operations done") {
+				return nil
+			}
+		}
+
+		return err
 	})
 }

--- a/phase/reset.go
+++ b/phase/reset.go
@@ -67,9 +67,11 @@ func (p *Reset) Run() error {
 
 		log.Infof("%s: running k0s reset", h)
 		out, err := h.ExecOutput(h.Configurer.K0sCmdf("reset"), exec.Sudo(h))
+		c, _ := semver.NewConstraint("<= 1.22.3+k0s.0")
+		running, _ := semver.NewVersion(h.Metadata.K0sBinaryVersion)
 		if err != nil {
 			log.Warnf("%s: k0s reported failure: %v", h, err)
-			if strings.Contains(out, "k0s cleanup operations done") {
+			if c.Check(running) && strings.Contains(out, "k0s cleanup operations done") {
 				return nil
 			}
 		}

--- a/smoke-test/smoke-reset.sh
+++ b/smoke-test/smoke-reset.sh
@@ -9,9 +9,5 @@ trap cleanup EXIT
 
 deleteCluster
 createCluster
-../k0sctl init
 ../k0sctl apply --config "${K0SCTL_CONFIG}" --debug --trace
 ../k0sctl reset --config "${K0SCTL_CONFIG}" --debug --trace --force
-echo "came back?"
-echo "or did it?"
-exit 0

--- a/smoke-test/smoke-reset.sh
+++ b/smoke-test/smoke-reset.sh
@@ -10,5 +10,8 @@ trap cleanup EXIT
 deleteCluster
 createCluster
 ../k0sctl init
-../k0sctl apply --config "${K0SCTL_CONFIG}" --debug
-../k0sctl reset --config "${K0SCTL_CONFIG}" --debug --force
+../k0sctl apply --config "${K0SCTL_CONFIG}" --debug --trace
+../k0sctl reset --config "${K0SCTL_CONFIG}" --debug --trace --force
+echo "came back?"
+echo "or did it?"
+exit 0


### PR DESCRIPTION
Let's see if this fixes smokes.

I think this needs to be version constrained, the next release of k0s should have a fix for the error exit on success.

Fixes #285 also.
