### PR TITLE
Fix OS detection override for missing or incomplete os-release file

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -17,7 +17,7 @@ require (
 	github.com/gofrs/uuid v4.0.0+incompatible // indirect
 	github.com/hashicorp/go-version v1.3.0
 	github.com/k0sproject/dig v0.2.0
-	github.com/k0sproject/rig v0.4.6
+	github.com/k0sproject/rig v0.4.7
 	github.com/logrusorgru/aurora v2.0.3+incompatible
 	github.com/masterzen/simplexml v0.0.0-20190410153822-31eea3082786 // indirect
 	github.com/masterzen/winrm v0.0.0-20210623064412-3b76017826b0 // indirect
@@ -39,13 +39,13 @@ require (
 )
 
 require (
+	github.com/alessio/shellescape v1.4.1
 	github.com/go-ozzo/ozzo-validation/v4 v4.3.0
 	github.com/go-playground/validator/v10 v10.9.0
 )
 
 require (
 	github.com/acarl005/stripansi v0.0.0-20180116102854-5a71ef0e047d // indirect
-	github.com/alessio/shellescape v1.4.1 // indirect
 	github.com/asaskevich/govalidator v0.0.0-20200108200545-475eaeb16496 // indirect
 	github.com/cpuguy83/go-md2man/v2 v2.0.1 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -212,8 +212,8 @@ github.com/jstemmer/go-junit-report v0.0.0-20190106144839-af01ea7f8024/go.mod h1
 github.com/jstemmer/go-junit-report v0.9.1/go.mod h1:Brl9GWCQeLvo8nXZwPNNblvFj/XSXhF0NWZEnDohbsk=
 github.com/k0sproject/dig v0.2.0 h1:cNxEIl96g9kqSMfPSZLhpnZ0P8bWXKv08nxvsMHop5w=
 github.com/k0sproject/dig v0.2.0/go.mod h1:rBcqaQlJpcKdt2x/OE/lPvhGU50u/e95CSm5g/r4s78=
-github.com/k0sproject/rig v0.4.6 h1:3qR0gNmhsa+6XZLYim/4zpN7+bZWLABYHdzBOCPS/54=
-github.com/k0sproject/rig v0.4.6/go.mod h1:4FKfoqz5HOE8v8pJ0K8BCvWw3ypB2vJINkAY4P+yTpo=
+github.com/k0sproject/rig v0.4.7 h1:ijTypz6X8HwZIpV2csrLTYhtZvpOrYpP3evv08jVwMg=
+github.com/k0sproject/rig v0.4.7/go.mod h1:4FKfoqz5HOE8v8pJ0K8BCvWw3ypB2vJINkAY4P+yTpo=
 github.com/kballard/go-shellquote v0.0.0-20180428030007-95032a82bc51 h1:Z9n2FFNUXsshfwJMBgNA0RU6/i7WVaAegv3PtuIHPMs=
 github.com/kballard/go-shellquote v0.0.0-20180428030007-95032a82bc51/go.mod h1:CzGEWj7cYgsdH8dAjBGEr58BoE7ScuLd+fwFZ44+/x8=
 github.com/kisielk/errcheck v1.5.0/go.mod h1:pFxgyoBC7bSaBwPgfKdkLd5X25qrDl4LWUI2bnpBCr8=

--- a/phase/detect_os.go
+++ b/phase/detect_os.go
@@ -27,8 +27,7 @@ func (p *DetectOS) Title() string {
 func (p *DetectOS) Run() error {
 	return p.Config.Spec.Hosts.ParallelEach(func(h *cluster.Host) error {
 		if h.OSIDOverride != "" {
-			log.Infof("%s: overriding OS to %s", h, h.OSIDOverride)
-			h.OSVersion.ID = h.OSIDOverride
+			log.Infof("%s: OS ID has been manually set to %s", h, h.OSIDOverride)
 		}
 		if err := h.ResolveConfigurer(); err != nil {
 			p.SetProp("missing-support", h.OSVersion.String())

--- a/pkg/apis/k0sctl.k0sproject.io/v1beta1/cluster/host.go
+++ b/pkg/apis/k0sctl.k0sproject.io/v1beta1/cluster/host.go
@@ -42,6 +42,10 @@ type Host struct {
 }
 
 func (h *Host) SetDefaults() {
+	if h.OSIDOverride != "" {
+		h.OSVersion = &rig.OSVersion{ID: h.OSIDOverride}
+	}
+
 	_ = defaults.Set(h.Connection)
 
 	if h.InstallFlags.Get("--single") != "" && h.InstallFlags.GetValue("--single") != "false" && h.Role != "single" {
@@ -165,7 +169,7 @@ func (h *Host) Protocol() string {
 
 // ResolveConfigurer assigns a rig-style configurer to the Host (see configurer/)
 func (h *Host) ResolveConfigurer() error {
-	bf, err := registry.GetOSModuleBuilder(h.OSVersion)
+	bf, err := registry.GetOSModuleBuilder(*h.OSVersion)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Signed-off-by: Kimmo Lehto <klehto@mirantis.com>

Fixes #289 
Fixes #288 

Upgrades rig to 0.4.7 which allows skipping the initial OSVersion resolving by pre-setting `h.OSVersion`.
