### PR TITLE
Fix nil panic when config has no spec.k0s

### DIFF
--- a/pkg/apis/k0sctl.k0sproject.io/v1beta1/cluster/spec.go
+++ b/pkg/apis/k0sctl.k0sproject.io/v1beta1/cluster/spec.go
@@ -19,6 +19,7 @@ type Spec struct {
 func (s *Spec) UnmarshalYAML(unmarshal func(interface{}) error) error {
 	type spec Spec
 	ys := (*spec)(s)
+	ys.K0s = &K0s{}
 
 	if err := unmarshal(ys); err != nil {
 		return err


### PR DESCRIPTION
Signed-off-by: Kimmo Lehto <klehto@mirantis.com>

#276 caused a nil panic to occur when config `spec.k0s` is left out.
