### PR TITLE
Use new k0s `config validate` syntax

### DIFF
--- a/phase/configure_k0s.go
+++ b/phase/configure_k0s.go
@@ -47,7 +47,7 @@ func (p *ConfigureK0s) Run() error {
 
 func (p *ConfigureK0s) validateConfig(h *cluster.Host) error {
 	log.Infof("%s: validating configuration", h)
-	output, err := h.ExecOutput(h.Configurer.K0sCmdf(`validate config --config "%s"`, h.K0sConfigPath()), exec.Sudo(h))
+	output, err := h.ExecOutput(h.Configurer.K0sCmdf(`config validate --config "%s"`, h.K0sConfigPath()), exec.Sudo(h))
 	if err != nil {
 		return fmt.Errorf("spec.k0s.config fails validation:\n%s", output)
 	}


### PR DESCRIPTION
Using the latest version of both k0s and k0sctl, when using `k0sctl apply ...` validation fails due to error message saying to use the new syntax.