### PR TITLE
Use k0s config create/validate instead of the deprecated subcommands

### DIFF
--- a/README.md
+++ b/README.md
@@ -445,4 +445,4 @@ The version of k0s to deploy. When left out, k0sctl will default to using the la
 
 Embedded k0s cluster configuration. See [k0s configuration documentation](https://docs.k0sproject.io/main/configuration/) for details.
 
-When left out, the output of `k0s default-config` will be used.
+When left out, the output of `k0s config create` will be used.


### PR DESCRIPTION
Fixes #292 
Closes #293 (alternative)

When applicable:

* Use `k0s config create` instead of `k0s default-config`
* Use `k0s config validate` instead of `k0s validate config`
