### PR TITLE
Remove --config flag from token command

### DIFF
--- a/pkg/apis/k0sctl.k0sproject.io/v1beta1/cluster/k0s.go
+++ b/pkg/apis/k0sctl.k0sproject.io/v1beta1/cluster/k0s.go
@@ -92,9 +92,17 @@ func (k *K0s) SetDefaults() {
 
 // GenerateToken runs the k0s token create command
 func (k K0s) GenerateToken(h *Host, role string, expiry time.Duration) (token string, err error) {
+	var tokenCreateCmd string
+	out, err := h.ExecOutput(h.Configurer.K0sCmdf("token create --help"), exec.Sudo(h))
+	if err == nil && strings.Contains(out, "--config") {
+		tokenCreateCmd = fmt.Sprintf("token create --config %s --role %s --expiry %s", h.K0sConfigPath(), role, expiry.String())
+	} else {
+		tokenCreateCmd = fmt.Sprintf("token create --role %s --expiry %s", role, expiry.String())
+	}
+
 	err = retry.Do(
 		func() error {
-			output, err := h.ExecOutput(h.Configurer.K0sCmdf("token create --config %s --role %s --expiry %s", h.K0sConfigPath(), role, expiry.String()), exec.HideOutput(), exec.Sudo(h))
+			output, err := h.ExecOutput(h.Configurer.K0sCmdf(tokenCreateCmd), exec.HideOutput(), exec.Sudo(h))
 			if err != nil {
 				return err
 			}

--- a/pkg/apis/k0sctl.k0sproject.io/v1beta1/cluster/k0s.go
+++ b/pkg/apis/k0sctl.k0sproject.io/v1beta1/cluster/k0s.go
@@ -106,7 +106,7 @@ func (k K0s) GenerateToken(h *Host, role string, expiry time.Duration) (string, 
 	err = retry.Do(
 		func() error {
 			output, err := h.ExecOutput(h.Configurer.K0sCmdf("token create %s", k0sFlags.Join()), exec.HideOutput(), exec.Sudo(h))
-			if err == nil {
+			if err != nil {
 				return err
 			}
 			token = output

--- a/pkg/apis/k0sctl.k0sproject.io/v1beta1/cluster/k0s.go
+++ b/pkg/apis/k0sctl.k0sproject.io/v1beta1/cluster/k0s.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/Masterminds/semver"
+	"github.com/alessio/shellescape"
 	"github.com/avast/retry-go"
 	"github.com/creasty/defaults"
 	validation "github.com/go-ozzo/ozzo-validation/v4"
@@ -91,19 +92,21 @@ func (k *K0s) SetDefaults() {
 }
 
 // GenerateToken runs the k0s token create command
-func (k K0s) GenerateToken(h *Host, role string, expiry time.Duration) (token string, err error) {
-	var tokenCreateCmd string
+func (k K0s) GenerateToken(h *Host, role string, expiry time.Duration) (string, error) {
+	var k0sFlags Flags
+	k0sFlags.Add(fmt.Sprintf("--role %s", role))
+	k0sFlags.Add(fmt.Sprintf("--expiry %s", expiry))
+
 	out, err := h.ExecOutput(h.Configurer.K0sCmdf("token create --help"), exec.Sudo(h))
 	if err == nil && strings.Contains(out, "--config") {
-		tokenCreateCmd = fmt.Sprintf("token create --config %s --role %s --expiry %s", h.K0sConfigPath(), role, expiry.String())
-	} else {
-		tokenCreateCmd = fmt.Sprintf("token create --role %s --expiry %s", role, expiry.String())
+		k0sFlags.Add(fmt.Sprintf("--config %s", shellescape.Quote(h.K0sConfigPath())))
 	}
 
+	var token string
 	err = retry.Do(
 		func() error {
-			output, err := h.ExecOutput(h.Configurer.K0sCmdf(tokenCreateCmd), exec.HideOutput(), exec.Sudo(h))
-			if err != nil {
+			output, err := h.ExecOutput(h.Configurer.K0sCmdf("token create %s", k0sFlags.Join()), exec.HideOutput(), exec.Sudo(h))
+			if err == nil {
 				return err
 			}
 			token = output
@@ -115,7 +118,7 @@ func (k K0s) GenerateToken(h *Host, role string, expiry time.Duration) (token st
 		retry.Attempts(60),
 		retry.LastErrorOnly(true),
 	)
-	return
+	return token, err
 }
 
 // GetClusterID uses kubectl to fetch the kube-system namespace uid


### PR DESCRIPTION
This commit removes the config flag to comply with the changes in
https://github.com/k0sproject/k0s/pull/1409

Signed-off-by: Karen Almog <kalmog@mirantis.com>