### PR TITLE
Fix default config generation on older k0s versions

### DIFF
--- a/phase/configure_k0s.go
+++ b/phase/configure_k0s.go
@@ -33,6 +33,8 @@ func (p *ConfigureK0s) Run() error {
 		var cmd string
 		if leader.Exec(leader.Configurer.K0sCmdf("config create --help"), exec.Sudo(leader)) == nil {
 			cmd = leader.Configurer.K0sCmdf("config create")
+		} else {
+			cmd = leader.Configurer.K0sCmdf("default-config")
 		}
 
 		cfg, err := leader.ExecOutput(cmd, exec.Sudo(leader))


### PR DESCRIPTION
The code was only defining the default config output command when a version with `k0s token create` was used. The older versions with `k0s default-config` would have received an empty command.
