### PR TITLE
Add spec.k0s.dynamicConfig

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -127,6 +127,29 @@ jobs:
       - name: Run smoke tests
         run: make smoke-files
 
+  smoke-dynamic:
+    name: Basic dynamic config smoke
+    needs: build
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up Go
+        uses: actions/setup-go@v2
+        with:
+          go-version: 1.17
+
+      - {"name":"Go modules cache","uses":"actions/cache@v2","with":{"path":"~/go/pkg/mod\n~/.cache/go-build\n~/Library/Caches/go-build\n%LocalAppData%\\go-build\n","key":"${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}","restore-keys":"${{ runner.os }}-go-\n"}}
+      - {"name":"Compiled binary cache","uses":"actions/download-artifact@v2","with":{"name":"k0sctl","path":"."}}
+      - {"name":"Make executable","run":"chmod +x k0sctl"}
+      - {"name":"K0sctl cache","uses":"actions/cache@v2","with":{"path":"/var/cache/k0sctl\n~/.k0sctl/cache\n!*.log\n","key":"k0sctl-cache"}}
+      - {"name":"Kubectl cache","uses":"actions/cache@v2","with":{"path":"smoke-test/kubectl\n","key":"kubectl-1.21.3"}}
+      - {"name":"Go modules cache","uses":"actions/cache@v2","with":{"path":"~/go/pkg/mod\n~/.cache/go-build\n~/Library/Caches/go-build\n%LocalAppData%\\go-build\n","key":"${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}","restore-keys":"${{ runner.os }}-go-\n"}}
+      - {"name":"Docker Layer Caching For Footloose","uses":"satackey/action-docker-layer-caching@v0.0.11","continue-on-error":true}
+
+      - name: Run smoke tests
+        run: make smoke-dynamic
+
   smoke-os-override:
     name: OS override smoke test
     needs: build

--- a/Makefile
+++ b/Makefile
@@ -52,7 +52,7 @@ build-all: $(addprefix bin/,$(bins)) bin/checksums.md
 clean:
 	rm -rf bin/ k0sctl
 
-smoketests := smoke-basic smoke-files smoke-upgrade smoke-reset smoke-os-override smoke-init smoke-backup-restore
+smoketests := smoke-basic smoke-files smoke-upgrade smoke-reset smoke-os-override smoke-init smoke-backup-restore smoke-dynamic
 .PHONY: $(smoketests)
 $(smoketests): k0sctl
 	$(MAKE) -C smoke-test $@

--- a/README.md
+++ b/README.md
@@ -441,6 +441,19 @@ This must be set `true` to enable the localhost connection.
 
 The version of k0s to deploy. When left out, k0sctl will default to using the latest released version of k0s or the version already running on the cluster.
 
+##### `spec.k0s.dynamicConfig` &lt;boolean&gt; (optional) (default: false)
+
+Enable k0s dynamic config. The setting will be automatically set to true if:
+
+* Any controller node has `--enable-dynamic-config` in `installFlags`
+* Any existing controller node has `--enable-dynamic-config` in run arguments (`k0s status -o json`)
+
+**Note:**: When running k0s in dynamic config mode, k0sctl will ONLY configure the cluster-wide configuration during the first time initialization, after that the configuration has to be managed via `k0s config edit` or `k0sctl config edit`. The node specific configuration will be updated on each apply.
+
+See also:
+
+* [k0s Dynamic Configuration](https://docs.k0sproject.io/main/dynamic-configuration/)
+
 ##### `spec.k0s.config` &lt;mapping&gt; (optional) (default: auto-generated)
 
 Embedded k0s cluster configuration. See [k0s configuration documentation](https://docs.k0sproject.io/main/configuration/) for details.

--- a/cmd/config_status.go
+++ b/cmd/config_status.go
@@ -2,13 +2,11 @@ package cmd
 
 import (
 	"fmt"
-	"os"
 
 	"github.com/k0sproject/k0sctl/analytics"
 	"github.com/k0sproject/k0sctl/pkg/apis/k0sctl.k0sproject.io/v1beta1"
 	"github.com/k0sproject/rig/exec"
 
-	"github.com/mattn/go-isatty"
 	"github.com/urfave/cli/v2"
 )
 
@@ -31,10 +29,6 @@ var configStatusCommand = &cli.Command{
 	Before: actions(initLogging, startCheckUpgrade, initConfig, initAnalytics),
 	After:  actions(reportCheckUpgrade, closeAnalytics),
 	Action: func(ctx *cli.Context) error {
-		if !isatty.IsTerminal(os.Stdout.Fd()) {
-			return fmt.Errorf("output is not a terminal")
-		}
-
 		if err := analytics.Client.Publish("config-status-start", map[string]interface{}{}); err != nil {
 			return err
 		}

--- a/phase/initialize_k0s.go
+++ b/phase/initialize_k0s.go
@@ -47,6 +47,12 @@ func (p *InitializeK0s) Run() error {
 	h := p.leader
 	h.Metadata.IsK0sLeader = true
 
+	if p.Config.Spec.K0s.DynamicConfig || (h.InstallFlags.Include("--enable-dynamic-config") && h.InstallFlags.GetValue("--enable-dynamic-config") != "false") {
+		p.Config.Spec.K0s.DynamicConfig = true
+		h.InstallFlags.AddOrReplace("--enable-dynamic-config")
+		p.SetProp("dynamic-config", true)
+	}
+
 	log.Infof("%s: installing k0s controller", h)
 	if err := h.Exec(h.K0sInstallCommand()); err != nil {
 		return err

--- a/pkg/apis/k0sctl.k0sproject.io/v1beta1/cluster/flags.go
+++ b/pkg/apis/k0sctl.k0sproject.io/v1beta1/cluster/flags.go
@@ -13,6 +13,11 @@ func (f *Flags) Add(s string) {
 	*f = append(*f, s)
 }
 
+// Add a flag with a value
+func (f *Flags) AddWithValue(key, value string) {
+	*f = append(*f, key+" "+value)
+}
+
 // AddUnlessExist adds a flag unless one with the same prefix exists
 func (f *Flags) AddUnlessExist(s string) {
 	if f.Include(s) {

--- a/smoke-test/Makefile
+++ b/smoke-test/Makefile
@@ -22,6 +22,9 @@ id_rsa_k0s:
 smoke-basic: $(footloose) id_rsa_k0s k0sctl
 	./smoke-basic.sh
 
+smoke-dynamic: $(footloose) id_rsa_k0s k0sctl
+	./smoke-dynamic.sh
+
 smoke-files: $(footloose) id_rsa_k0s k0sctl
 	./smoke-files.sh
 

--- a/smoke-test/k0sctl-dynamic.yaml
+++ b/smoke-test/k0sctl-dynamic.yaml
@@ -1,0 +1,24 @@
+apiVersion: k0sctl.k0sproject.io/v1beta1
+kind: cluster
+spec:
+  hosts:
+    - role: controller
+      uploadBinary: true
+      ssh:
+        address: "127.0.0.1"
+        port: 9022
+        keyPath: ./id_rsa_k0s
+    - role: worker
+      uploadBinary: true
+      os: "$OS_OVERRIDE"
+      ssh:
+        address: "127.0.0.1"
+        port: 9023
+        keyPath: ./id_rsa_k0s
+  k0s:
+    version: "${K0S_VERSION}"
+    dynamicConfig: true
+    config:
+      spec:
+        telemetry:
+          enabled: false

--- a/smoke-test/smoke-dynamic.sh
+++ b/smoke-test/smoke-dynamic.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+
+K0SCTL_CONFIG=${K0SCTL_CONFIG:-"k0sctl-dynamic.yaml"}
+
+set -e
+
+
+. ./smoke.common.sh
+trap cleanup EXIT
+
+deleteCluster
+createCluster
+
+echo "* Starting apply"
+../k0sctl apply --config "${K0SCTL_CONFIG}" --debug
+echo "* Apply OK"
+
+max_retry=5
+counter=0
+echo "* Verifying dynamic config reconciliation was a success"
+until ../k0sctl config status -o json --config "${K0SCTL_CONFIG}" | grep -q "SuccessfulReconcile"
+do
+   [[ counter -eq $max_retry ]] && echo "Failed!" && exit 1
+   echo "* Waiting for a couple of seconds to retry"
+   sleep 5
+   ((counter++))
+done
+
+echo "* OK"
+
+echo "* Dynamic config reconciliation status:"
+../k0sctl config status --config "${K0SCTL_CONFIG}"
+
+echo "* Done"

--- a/smoke-test/smoke.common.sh
+++ b/smoke-test/smoke.common.sh
@@ -3,7 +3,7 @@ FOOTLOOSE_TEMPLATE=${FOOTLOOSE_TEMPLATE:-"footloose.yaml.tpl"}
 export LINUX_IMAGE=${LINUX_IMAGE:-"quay.io/footloose/ubuntu18.04"}
 export PRESERVE_CLUSTER=${PRESERVE_CLUSTER:-""}
 export DISABLE_TELEMETRY=true
-export K0S_VERSION=${K0S_VERSION:-"1.21.1+k0s.0"}
+export K0S_VERSION
 
 function createCluster() {
   envsubst < "${FOOTLOOSE_TEMPLATE}" > footloose.yaml


### PR DESCRIPTION
### Enabling 

Dynamic config will be enabled in one of these ways:

1:

```yaml
spec:
  k0s:
    dynamicConfig: true
```

2:

```yaml
spec:
  hosts:
    - role: controller
      installFlags:
        - --enable-dynamic-config
```

3:  having one of the controllers have `--enable-dynamic-config` in status Args

TODO:

- [ ] It should be possible to alter the run flags if the controller has been installed with no dynamic config - can be done in another pr
- [X] K0sctl could write a stripped down config with node specific options only to non-initial controllers
- [X] ~~Come up with or~~ abandon any hopes of functionality that would allow applying spec.k0s.config to a dynamic config cluster during k0sctl apply



