### PR TITLE
Update the role in smoke-test k0sctl-single.yaml

### DIFF
--- a/smoke-test/k0sctl-single.yaml
+++ b/smoke-test/k0sctl-single.yaml
@@ -2,7 +2,7 @@ apiVersion: k0sctl.k0sproject.io/v1beta1
 kind: cluster
 spec:
   hosts:
-    - role: controller
+    - role: single
       uploadBinary: true
       os: "$OS_OVERRIDE"
       ssh:


### PR DESCRIPTION
The config for single node tests had role 'controller' instead of 'single'.
