### PR TITLE
Only report the self upgrade check result in after-action

### DIFF
--- a/cmd/backup.go
+++ b/cmd/backup.go
@@ -22,7 +22,7 @@ var backupCommand = &cli.Command{
 		analyticsFlag,
 		upgradeCheckFlag,
 	},
-	Before: actions(initLogging, startCheckUpgrade, initConfig, displayLogo, initAnalytics, displayCopyright, reportCheckUpgrade),
+	Before: actions(initLogging, startCheckUpgrade, initConfig, displayLogo, initAnalytics, displayCopyright),
 	After:  actions(reportCheckUpgrade, closeAnalytics),
 	Action: func(ctx *cli.Context) error {
 		start := time.Now()

--- a/cmd/reset.go
+++ b/cmd/reset.go
@@ -31,7 +31,7 @@ var resetCommand = &cli.Command{
 			Aliases: []string{"f"},
 		},
 	},
-	Before: actions(initLogging, startCheckUpgrade, initConfig, initAnalytics, displayCopyright, reportCheckUpgrade),
+	Before: actions(initLogging, startCheckUpgrade, initConfig, initAnalytics, displayCopyright),
 	After:  actions(reportCheckUpgrade, closeAnalytics),
 	Action: func(ctx *cli.Context) error {
 		if !ctx.Bool("force") {


### PR DESCRIPTION
Looks like the `reportCheckUpgrade` was in both `Before` and `After` of some sub-commands. It's only supposed to be in the after.
