### PR TITLE
Drop images from k0s init --k0s config template

### DIFF
--- a/cmd/init.go
+++ b/cmd/init.go
@@ -50,37 +50,6 @@ spec:
       konnectivityUser: konnectivity-server
       kubeAPIserverUser: kube-apiserver
       kubeSchedulerUser: kube-scheduler
-  images:
-    konnectivity:
-      image: us.gcr.io/k8s-artifacts-prod/kas-network-proxy/proxy-agent
-      version: v0.0.24
-    metricsserver:
-      image: gcr.io/k8s-staging-metrics-server/metrics-server
-      version: v0.5.0
-    kubeproxy:
-      image: k8s.gcr.io/kube-proxy
-      version: v1.22.1
-    coredns:
-      image: docker.io/coredns/coredns
-      version: 1.7.0
-    calico:
-      cni:
-        image: docker.io/calico/cni
-        version: v3.18.1
-      node:
-        image: docker.io/calico/node
-        version: v3.18.1
-      kubecontrollers:
-        image: docker.io/calico/kube-controllers
-        version: v3.18.1
-    kuberouter:
-      cni:
-        image: docker.io/cloudnativelabs/kube-router
-        version: v1.2.1
-      cniInstaller:
-        image: quay.io/k0sproject/cni-node
-        version: 0.1.0
-    default_pull_policy: IfNotPresent
   konnectivity:
     agentPort: 8132
     adminPort: 8133


### PR DESCRIPTION
Fixes #322 

Drops the images section from the template used in `k0sctl init --k0s`. Having the images and versions there will mostly just cause problems.
