### PR TITLE
Store the result of "Get Kubeconfig" phase to cluster config metadata

### DIFF
--- a/cmd/kubeconfig.go
+++ b/cmd/kubeconfig.go
@@ -1,6 +1,8 @@
 package cmd
 
 import (
+	"fmt"
+
 	"github.com/k0sproject/k0sctl/analytics"
 	"github.com/k0sproject/k0sctl/phase"
 	"github.com/k0sproject/k0sctl/pkg/apis/k0sctl.k0sproject.io/v1beta1"
@@ -36,13 +38,21 @@ var kubeconfigCommand = &cli.Command{
 		c.Spec.Hosts = cluster.Hosts{c.Spec.K0sLeader()}
 		manager := phase.Manager{Config: c}
 
+		kubeconfig := &phase.GetKubeconfig{APIAddress: ctx.String("address")}
+
 		manager.AddPhase(
 			&phase.Connect{},
 			&phase.DetectOS{},
-			&phase.GetKubeconfig{APIAddress: ctx.String("address")},
+			kubeconfig,
 			&phase.Disconnect{},
 		)
 
-		return manager.Run()
+		if err := manager.Run(); err != nil {
+			return err
+		}
+
+		fmt.Println(kubeconfig.Kubeconfig())
+
+		return nil
 	},
 }

--- a/cmd/kubeconfig.go
+++ b/cmd/kubeconfig.go
@@ -38,12 +38,10 @@ var kubeconfigCommand = &cli.Command{
 		c.Spec.Hosts = cluster.Hosts{c.Spec.K0sLeader()}
 		manager := phase.Manager{Config: c}
 
-		kubeconfig := &phase.GetKubeconfig{APIAddress: ctx.String("address")}
-
 		manager.AddPhase(
 			&phase.Connect{},
 			&phase.DetectOS{},
-			kubeconfig,
+			&phase.GetKubeconfig{APIAddress: ctx.String("address")},
 			&phase.Disconnect{},
 		)
 
@@ -51,7 +49,7 @@ var kubeconfigCommand = &cli.Command{
 			return err
 		}
 
-		fmt.Println(kubeconfig.Kubeconfig())
+		fmt.Println(c.Metadata.Kubeconfig)
 
 		return nil
 	},

--- a/phase/get_kubeconfig.go
+++ b/phase/get_kubeconfig.go
@@ -10,6 +10,7 @@ import (
 type GetKubeconfig struct {
 	GenericPhase
 	APIAddress string
+	kubeconfig string
 }
 
 // Title for the phase
@@ -45,8 +46,15 @@ func (p *GetKubeconfig) Run() error {
 	if err != nil {
 		return err
 	}
-	fmt.Println(cfgString)
+
+	p.kubeconfig = cfgString
+
 	return nil
+}
+
+// Kubeconfig gets the kubeconfig
+func (p *GetKubeconfig) Kubeconfig() string {
+	return p.kubeconfig
 }
 
 // kubeConfig reads in the raw kubeconfig and changes the given address

--- a/phase/get_kubeconfig.go
+++ b/phase/get_kubeconfig.go
@@ -10,7 +10,6 @@ import (
 type GetKubeconfig struct {
 	GenericPhase
 	APIAddress string
-	kubeconfig string
 }
 
 // Title for the phase
@@ -47,14 +46,9 @@ func (p *GetKubeconfig) Run() error {
 		return err
 	}
 
-	p.kubeconfig = cfgString
+	p.Config.Metadata.Kubeconfig = cfgString
 
 	return nil
-}
-
-// Kubeconfig gets the kubeconfig
-func (p *GetKubeconfig) Kubeconfig() string {
-	return p.kubeconfig
 }
 
 // kubeConfig reads in the raw kubeconfig and changes the given address

--- a/pkg/apis/k0sctl.k0sproject.io/v1beta1/cluster.go
+++ b/pkg/apis/k0sctl.k0sproject.io/v1beta1/cluster.go
@@ -10,7 +10,8 @@ const APIVersion = "k0sctl.k0sproject.io/v1beta1"
 
 // ClusterMetadata defines cluster metadata
 type ClusterMetadata struct {
-	Name string `yaml:"name" validate:"required" default:"k0s-cluster"`
+	Name       string `yaml:"name" validate:"required" default:"k0s-cluster"`
+	Kubeconfig string `yaml:"-"`
 }
 
 // Cluster describes launchpad.yaml configuration


### PR DESCRIPTION
Move the print statement for the kubeconfig from the `GetKubeconfig` phase to the cmd so it is easier to integrate the code into other tools.