### PR TITLE
alpine: prepare /etc/machine-id

### DIFF
--- a/configurer/linux/alpine.go
+++ b/configurer/linux/alpine.go
@@ -3,6 +3,7 @@ package linux
 import (
 	"strings"
 
+	"github.com/gofrs/uuid"
 	"github.com/k0sproject/k0sctl/configurer"
 	"github.com/k0sproject/rig"
 	"github.com/k0sproject/rig/exec"
@@ -40,5 +41,20 @@ func (l Alpine) InstallPackage(h os.Host, pkg ...string) error {
 }
 
 func (l Alpine) Prepare(h os.Host) error {
+	// alpinelinux by default does not have a machine-id
+	if !l.FileExist(h, "/etc/machine-id") {
+		id, err := uuid.NewV4()
+		if err != nil {
+			return err
+		}
+		if err = l.WriteFile(
+			h,
+			"/etc/machine-id",
+			strings.ReplaceAll(id.String(), "-", "")+"\n",
+			"0444",
+		); err != nil {
+			return err
+		}
+	}
 	return l.InstallPackage(h, "findutils", "coreutils")
 }

--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,7 @@ require (
 	github.com/creasty/defaults v1.5.2
 	github.com/denisbrodbeck/machineid v1.0.1
 	github.com/gammazero/workerpool v1.1.2
-	github.com/gofrs/uuid v4.2.0+incompatible // indirect
+	github.com/gofrs/uuid v4.2.0+incompatible
 	github.com/hashicorp/go-version v1.4.0 // indirect
 	github.com/k0sproject/dig v0.2.0
 	github.com/k0sproject/rig v0.4.8
@@ -42,7 +42,6 @@ require (
 	github.com/alessio/shellescape v1.4.1
 	github.com/go-ozzo/ozzo-validation/v4 v4.3.0
 	github.com/go-playground/validator/v10 v10.9.0
-	github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510
 	github.com/k0sproject/version v0.1.3
 )
 

--- a/go.sum
+++ b/go.sum
@@ -181,8 +181,6 @@ github.com/google/pprof v0.0.0-20200229191704-1ebb73c60ed3/go.mod h1:ZgVRPoUq/hf
 github.com/google/pprof v0.0.0-20200430221834-fc25d7d30c6d/go.mod h1:ZgVRPoUq/hfqzAqh7sHMqb3I9Rq5C59dIz2SbBwJ4eM=
 github.com/google/pprof v0.0.0-20200708004538-1a94d8640e99/go.mod h1:ZgVRPoUq/hfqzAqh7sHMqb3I9Rq5C59dIz2SbBwJ4eM=
 github.com/google/renameio v0.1.0/go.mod h1:KWCgfxg9yswjAJkECMjeO8J8rahYeXnNhOm40UhjYkI=
-github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510 h1:El6M4kTTCOh6aBiKaUGG7oYTSPP8MxqL4YI3kZKwcP4=
-github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510/go.mod h1:pupxD2MaaD3pAXIBCelhxNneeOaAeabZDe5s4K6zSpQ=
 github.com/google/uuid v1.1.1/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/google/uuid v1.1.2/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/googleapis/gax-go/v2 v2.0.4/go.mod h1:0Wqv26UfaUD9n4G6kQubkQ+KchISgw+vpHVxEJEs9eg=


### PR DESCRIPTION
alpinelinux by default does not have a machine-id, k0s require /etc/machine-id

https://github.com/k0sproject/k0s/issues/1546#issuecomment-1046877719