### PR TITLE
Fix always overwriting k0s version with latest version

### DIFF
--- a/phase/download_binaries.go
+++ b/phase/download_binaries.go
@@ -111,7 +111,7 @@ func (b binary) url() string {
 }
 
 func (b binary) downloadTo(path string) error {
-	log.Infof("downloading k0s version %s binary for %s-%s", b.version, b.os, b.arch)
+	log.Infof("downloading k0s version %s binary for %s-%s from %s", b.version, b.os, b.arch, b.url())
 
 	var err error
 

--- a/phase/download_binaries.go
+++ b/phase/download_binaries.go
@@ -5,6 +5,7 @@ import (
 	"io"
 	"net/http"
 	"os"
+	"strings"
 
 	"github.com/k0sproject/k0sctl/cache"
 	"github.com/k0sproject/k0sctl/pkg/apis/k0sctl.k0sproject.io/v1beta1"
@@ -107,7 +108,7 @@ func (b binary) ext() string {
 }
 
 func (b binary) url() string {
-	return fmt.Sprintf("https://github.com/k0sproject/k0s/releases/download/v%s/k0s-v%s-%s%s", b.version, b.version, b.arch, b.ext())
+	return fmt.Sprintf("https://github.com/k0sproject/k0s/releases/download/v%s/k0s-v%s-%s%s", strings.TrimPrefix(b.version, "v"), strings.TrimPrefix(b.version, "v"), b.arch, b.ext())
 }
 
 func (b binary) downloadTo(path string) error {

--- a/pkg/apis/k0sctl.k0sproject.io/v1beta1/cluster/k0s.go
+++ b/pkg/apis/k0sctl.k0sproject.io/v1beta1/cluster/k0s.go
@@ -105,6 +105,10 @@ func (k *K0s) validateMinDynamic() func(interface{}) error {
 
 // SetDefaults (implements defaults Setter interface) defaults the version to latest k0s version
 func (k *K0s) SetDefaults() {
+	if k.Version != "" {
+		return
+	}
+
 	latest, err := version.LatestReleaseByPrerelease(k0sctl.IsPre() || k0sctl.Version == "0.0.0")
 	if err == nil {
 		k.Version = latest.String()


### PR DESCRIPTION
Fix a bug where k0sctl will always overwrite `spec.k0s.version` with the latest version.
