### PR TITLE
Add K0sBinaryVersion(...) as a Configurer method

### DIFF
--- a/phase/upgrade_controllers.go
+++ b/phase/upgrade_controllers.go
@@ -7,6 +7,7 @@ import (
 	"github.com/Masterminds/semver"
 	"github.com/k0sproject/k0sctl/pkg/apis/k0sctl.k0sproject.io/v1beta1"
 	"github.com/k0sproject/k0sctl/pkg/apis/k0sctl.k0sproject.io/v1beta1/cluster"
+	"github.com/k0sproject/version"
 	log "github.com/sirupsen/logrus"
 )
 
@@ -67,7 +68,11 @@ func (p *UpgradeControllers) Run() error {
 		if err := h.WaitK0sServiceStopped(); err != nil {
 			return err
 		}
-		if err := h.UpdateK0sBinary(p.Config.Spec.K0s.Version); err != nil {
+		version, err := version.NewVersion(p.Config.Spec.K0s.Version)
+		if err != nil {
+			return err
+		}
+		if err := h.UpdateK0sBinary(version); err != nil {
 			return err
 		}
 

--- a/phase/upgrade_workers.go
+++ b/phase/upgrade_workers.go
@@ -7,6 +7,7 @@ import (
 	"github.com/gammazero/workerpool"
 	"github.com/k0sproject/k0sctl/pkg/apis/k0sctl.k0sproject.io/v1beta1"
 	"github.com/k0sproject/k0sctl/pkg/apis/k0sctl.k0sproject.io/v1beta1/cluster"
+	"github.com/k0sproject/version"
 	log "github.com/sirupsen/logrus"
 )
 
@@ -101,7 +102,11 @@ func (p *UpgradeWorkers) upgradeWorker(h *cluster.Host) error {
 	if err := h.WaitK0sServiceStopped(); err != nil {
 		return err
 	}
-	if err := h.UpdateK0sBinary(p.Config.Spec.K0s.Version); err != nil {
+	version, err := version.NewVersion(p.Config.Spec.K0s.Version)
+	if err != nil {
+		return err
+	}
+	if err := h.UpdateK0sBinary(version); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
Introduce K0sBinaryVersion and use it in places where the k0s version was retrieved manually. Also switch from string to *version.Version for versions, so that we cannot forget to add or strip the "v" prefix when processing version numbers.