### PR TITLE
Fix tee error when uploading k0s binaries

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -18,7 +18,7 @@ require (
 	github.com/gofrs/uuid v4.2.0+incompatible // indirect
 	github.com/hashicorp/go-version v1.4.0 // indirect
 	github.com/k0sproject/dig v0.2.0
-	github.com/k0sproject/rig v0.6.0
+	github.com/k0sproject/rig v0.6.1
 	github.com/logrusorgru/aurora v2.0.3+incompatible
 	github.com/masterzen/simplexml v0.0.0-20190410153822-31eea3082786 // indirect
 	github.com/masterzen/winrm v0.0.0-20211231115050-232efb40349e // indirect

--- a/go.sum
+++ b/go.sum
@@ -228,8 +228,8 @@ github.com/jstemmer/go-junit-report v0.0.0-20190106144839-af01ea7f8024/go.mod h1
 github.com/jstemmer/go-junit-report v0.9.1/go.mod h1:Brl9GWCQeLvo8nXZwPNNblvFj/XSXhF0NWZEnDohbsk=
 github.com/k0sproject/dig v0.2.0 h1:cNxEIl96g9kqSMfPSZLhpnZ0P8bWXKv08nxvsMHop5w=
 github.com/k0sproject/dig v0.2.0/go.mod h1:rBcqaQlJpcKdt2x/OE/lPvhGU50u/e95CSm5g/r4s78=
-github.com/k0sproject/rig v0.6.0 h1:KpnEeFYguLft95pvF+Z6OsfkthAsFK/Hz30eJWx9chs=
-github.com/k0sproject/rig v0.6.0/go.mod h1:myOVP6gFhWATqL2iOuwKL/2hg90ZkyMqqTssx2fjWjM=
+github.com/k0sproject/rig v0.6.1 h1:qPImH2ka4jalu/E0KcIx5SyOH/LBgMAECp4JHSpByWc=
+github.com/k0sproject/rig v0.6.1/go.mod h1:myOVP6gFhWATqL2iOuwKL/2hg90ZkyMqqTssx2fjWjM=
 github.com/k0sproject/version v0.3.0 h1:6HAn8C29+WVksGCzbQvQ9feEJpUZ0iHD8GebIQMiftQ=
 github.com/k0sproject/version v0.3.0/go.mod h1:oEjuz2ItQQtAnGyRgwEV9m5R6/9rjoFC6EiEEzbkFdI=
 github.com/kballard/go-shellquote v0.0.0-20180428030007-95032a82bc51 h1:Z9n2FFNUXsshfwJMBgNA0RU6/i7WVaAegv3PtuIHPMs=

--- a/phase/upload_binaries.go
+++ b/phase/upload_binaries.go
@@ -26,7 +26,22 @@ func (p *UploadBinaries) Title() string {
 func (p *UploadBinaries) Prepare(config *v1beta1.Cluster) error {
 	p.Config = config
 	p.hosts = p.Config.Spec.Hosts.Filter(func(h *cluster.Host) bool {
-		return h.UploadBinaryPath != "" && h.Metadata.K0sBinaryVersion != p.Config.Spec.K0s.Version && !h.Metadata.NeedsUpgrade
+		// Nothing to upload
+		if h.UploadBinaryPath == "" {
+			return false
+		}
+
+		// Upgrade is handled separately (k0s stopped, binary uploaded, k0s restarted)
+		if h.Metadata.NeedsUpgrade {
+			return false
+		}
+
+		// The version is already correct
+		if h.Metadata.K0sBinaryVersion == p.Config.Spec.K0s.Version {
+			return false
+		}
+
+		return true
 	})
 	return nil
 }


### PR DESCRIPTION
Fixes #357 

Expands and reorders the three part host selection filter in `Upload Binaries` phase. This may or may not fix the tee issue.

Also changes the `needsUpgrade` function to return false if the `host.Files` or `host.K0sBinaryPath` have no file changes compared to remote.
