### PR TITLE
Update README.md (typo, examples)

### DIFF
--- a/README.md
+++ b/README.md
@@ -262,7 +262,7 @@ See [host object documentation](#host-fields) below.
 
 Settings related to the k0s cluster.
 
-See [k0s object documentation](#spec-fields) below.
+See [k0s object documentation](#k0s-fields) below.
 
 ### Host Fields
 
@@ -312,7 +312,7 @@ Example:
 - name: image-bundle
   src: airgap-images.tgz
   dstDir: /var/lib/k0s/images/
-  perm: 0700
+  perm: 0600
 ```
 
 * `name`: name of the file "bundle", used only for logging purposes (optional)
@@ -334,9 +334,9 @@ Example:
 hooks:
   apply:
     before:
-      - date > k0sctl-apply.log
+      - date >> k0sctl-apply.log
     after:
-      - echo "apply success" > k0sctl-apply.log
+      - echo "apply success" >> k0sctl-apply.log
 ```
 
 The currently available "hook points" are:


### PR DESCRIPTION
Fix minor typo in README.md

1. FIx incorrect bookmark target (`#spec-fields` -> `#k0s-fields`)
2. 'tgz' file permission in example shouldn't set for executable (`0700` -> `0600`)
3. output redirection in example will `k0sctl-apply.log` file. I think this isn't an intended behavior (`>` -> `>>`)