### PR TITLE
Only allow one k0sctl to run simultaneously per host

### DIFF
--- a/cmd/apply.go
+++ b/cmd/apply.go
@@ -48,10 +48,12 @@ var applyCommand = &cli.Command{
 		phase.NoWait = ctx.Bool("no-wait")
 
 		manager := phase.Manager{Config: ctx.Context.Value(ctxConfigKey{}).(*v1beta1.Cluster)}
+		lockPhase := &phase.Lock{}
 
 		manager.AddPhase(
 			&phase.Connect{},
 			&phase.DetectOS{},
+			lockPhase,
 			&phase.PrepareHosts{},
 			&phase.GatherFacts{},
 			&phase.DownloadBinaries{},
@@ -75,6 +77,7 @@ var applyCommand = &cli.Command{
 				NoDrain: ctx.Bool("no-drain"),
 			},
 			&phase.RunHooks{Stage: "after", Action: "apply"},
+			&phase.Unlock{Cancel: lockPhase.Cancel},
 			&phase.Disconnect{},
 		)
 

--- a/cmd/apply.go
+++ b/cmd/apply.go
@@ -85,18 +85,6 @@ var applyCommand = &cli.Command{
 
 		var result error
 
-		defer func() {
-			// Handle panics and failed applies by running the disconnect phase
-			if err := recover(); err != nil || result != nil {
-				p := &phase.Disconnect{}
-				_ = p.Prepare(manager.Config)
-				_ = p.Run()
-				if err != nil {
-					panic(err)
-				}
-			}
-		}()
-
 		if result = manager.Run(); result != nil {
 			analytics.Client.Publish("apply-failure", map[string]interface{}{"clusterID": manager.Config.Spec.K0s.Metadata.ClusterID})
 			if lf, err := LogFile(); err == nil {

--- a/cmd/backup.go
+++ b/cmd/backup.go
@@ -28,14 +28,18 @@ var backupCommand = &cli.Command{
 		start := time.Now()
 
 		manager := phase.Manager{Config: ctx.Context.Value(ctxConfigKey{}).(*v1beta1.Cluster)}
+		lockPhase := &phase.Lock{}
+
 		manager.AddPhase(
 			&phase.Connect{},
 			&phase.DetectOS{},
+			lockPhase,
 			&phase.GatherFacts{},
 			&phase.GatherK0sFacts{},
 			&phase.RunHooks{Stage: "before", Action: "backup"},
 			&phase.Backup{},
 			&phase.RunHooks{Stage: "after", Action: "backup"},
+			&phase.Unlock{Cancel: lockPhase.Cancel},
 			&phase.Disconnect{},
 		)
 

--- a/cmd/reset.go
+++ b/cmd/reset.go
@@ -52,14 +52,17 @@ var resetCommand = &cli.Command{
 
 		manager := phase.Manager{Config: ctx.Context.Value(ctxConfigKey{}).(*v1beta1.Cluster)}
 
+		lockPhase := &phase.Lock{}
 		manager.AddPhase(
 			&phase.Connect{},
 			&phase.DetectOS{},
+			lockPhase,
 			&phase.PrepareHosts{},
 			&phase.GatherK0sFacts{},
 			&phase.RunHooks{Stage: "before", Action: "reset"},
 			&phase.Reset{},
 			&phase.RunHooks{Stage: "after", Action: "reset"},
+			&phase.Unlock{Cancel: lockPhase.Cancel},
 			&phase.Disconnect{},
 		)
 

--- a/configurer/linux.go
+++ b/configurer/linux.go
@@ -19,7 +19,6 @@ type PathFuncs interface {
 	K0sConfigPath() string
 	K0sJoinTokenPath() string
 	KubeconfigPath() string
-	K0sctlLockFilePath() string
 }
 
 // Linux is a base module for various linux OS support packages
@@ -89,8 +88,12 @@ func (l Linux) K0sJoinTokenPath() string {
 }
 
 // K0sctlLockFilePath returns a path to a lock file
-func (l Linux) K0sctlLockFilePath() string {
-	return "/run/lock/k0sctl"
+func (l Linux) K0sctlLockFilePath(h os.Host) string {
+	if h.Exec("test -d /run/lock", exec.Sudo(h)) == nil {
+		return "/run/lock/k0sctl"
+	}
+
+	return "/tmp/k0sctl.lock"
 }
 
 // TempFile returns a temp file path

--- a/phase/lock.go
+++ b/phase/lock.go
@@ -72,9 +72,9 @@ func (p *Lock) startTicker(h *cluster.Host) error {
 					log.Warnf("%s: failed to touch lock file: %s", h, err)
 				}
 			case <-ctx.Done():
-				log.Debugf("%s: stopped lock cycle, removing file")
+				log.Debugf("%s: stopped lock cycle, removing file", h)
 				if err := h.Configurer.DeleteFile(h, lfp); err != nil {
-					log.Warnf("%s: failed to remove host lock file: %s", err)
+					log.Warnf("%s: failed to remove host lock file: %s", h, err)
 				}
 				p.wg.Done()
 				return

--- a/phase/lock.go
+++ b/phase/lock.go
@@ -56,7 +56,7 @@ func (p *Lock) Run() error {
 
 func (p *Lock) startTicker(h *cluster.Host) error {
 	p.wg.Add(1)
-	lfp := h.Configurer.K0sctlLockFilePath()
+	lfp := h.Configurer.K0sctlLockFilePath(h)
 	ticker := time.NewTicker(10 * time.Second)
 	ctx, cancel := context.WithCancel(context.Background())
 	p.m.Lock()
@@ -68,7 +68,7 @@ func (p *Lock) startTicker(h *cluster.Host) error {
 		for {
 			select {
 			case <-ticker.C:
-				if err := h.Configurer.Touch(h, h.Configurer.K0sctlLockFilePath(), time.Now(), exec.Sudo(h)); err != nil {
+				if err := h.Configurer.Touch(h, lfp, time.Now(), exec.Sudo(h)); err != nil {
 					log.Warnf("%s: failed to touch lock file: %s", h, err)
 				}
 			case <-ctx.Done():
@@ -104,7 +104,7 @@ func (p *Lock) startLock(h *cluster.Host) error {
 }
 
 func (p *Lock) tryLock(h *cluster.Host) error {
-	lfp := h.Configurer.K0sctlLockFilePath()
+	lfp := h.Configurer.K0sctlLockFilePath(h)
 
 	if err := h.Configurer.UpsertFile(h, lfp, p.instanceID); err != nil {
 		stat, err := h.Configurer.Stat(h, lfp, exec.Sudo(h))

--- a/phase/lock.go
+++ b/phase/lock.go
@@ -1,0 +1,121 @@
+package phase
+
+import (
+	"context"
+	"fmt"
+	gos "os"
+	"sync"
+	"time"
+
+	retry "github.com/avast/retry-go"
+	"github.com/k0sproject/k0sctl/analytics"
+	"github.com/k0sproject/k0sctl/pkg/apis/k0sctl.k0sproject.io/v1beta1"
+	"github.com/k0sproject/k0sctl/pkg/apis/k0sctl.k0sproject.io/v1beta1/cluster"
+	"github.com/k0sproject/rig/exec"
+	log "github.com/sirupsen/logrus"
+)
+
+// Lock acquires an exclusive k0sctl lock on hosts
+type Lock struct {
+	GenericPhase
+	cfs        []func()
+	instanceID string
+	m          sync.Mutex
+}
+
+// Prepare the phase
+func (p *Lock) Prepare(c *v1beta1.Cluster) error {
+	p.Config = c
+	mid, _ := analytics.MachineID()
+	p.instanceID = fmt.Sprintf("%s-%d", mid, gos.Getpid())
+	return nil
+}
+
+// Title for the phase
+func (p *Lock) Title() string {
+	return "Acquire exclusive host lock"
+}
+
+func (p *Lock) Cancel() {
+	p.m.Lock()
+	defer p.m.Unlock()
+	for _, f := range p.cfs {
+		f()
+	}
+}
+
+// Run the phase
+func (p *Lock) Run() error {
+	if err := p.Config.Spec.Hosts.ParallelEach(p.startLock); err != nil {
+		return err
+	}
+	return p.Config.Spec.Hosts.ParallelEach(p.startTicker)
+}
+
+func (p *Lock) startTicker(h *cluster.Host) error {
+	lfp := h.Configurer.K0sctlLockFilePath()
+	ticker := time.NewTicker(10 * time.Second)
+	ctx, cancel := context.WithCancel(context.Background())
+	p.m.Lock()
+	p.cfs = append(p.cfs, cancel)
+	p.m.Unlock()
+
+	go func() {
+		log.Debugf("%s: started periodic update of lock file %s timestamp", h, lfp)
+		for {
+			select {
+			case <-ticker.C:
+				if err := h.Configurer.Touch(h, h.Configurer.K0sctlLockFilePath(), time.Now(), exec.Sudo(h)); err != nil {
+					log.Debugf("%s: failed to touch lock file: %s", h, err)
+				}
+			case <-ctx.Done():
+				_ = h.Configurer.DeleteFile(h, lfp)
+				return
+			}
+		}
+	}()
+
+	return nil
+}
+
+func (p *Lock) startLock(h *cluster.Host) error {
+	return retry.Do(
+		func() error {
+			return p.tryLock(h)
+		},
+		retry.OnRetry(
+			func(n uint, err error) {
+				log.Errorf("%s: attempt %d of %d.. trying to obtain a lock on host: %s", h, n+1, retries, err.Error())
+			},
+		),
+		retry.DelayType(retry.CombineDelay(retry.FixedDelay, retry.RandomDelay)),
+		retry.MaxJitter(time.Second*2),
+		retry.Delay(time.Second*3),
+		retry.Attempts(5),
+		retry.LastErrorOnly(true),
+	)
+}
+
+func (p *Lock) tryLock(h *cluster.Host) error {
+	lfp := h.Configurer.K0sctlLockFilePath()
+
+	if err := h.Configurer.UpsertFile(h, lfp, p.instanceID); err != nil {
+		stat, err := h.Configurer.Stat(h, lfp, exec.Sudo(h))
+		if err != nil {
+			return fmt.Errorf("lock file disappeared: %w", err)
+		}
+		content, err := h.Configurer.ReadFile(h, lfp)
+		if err != nil {
+			return fmt.Errorf("failed to read lock file:  %w", err)
+		}
+		if content != p.instanceID {
+			if time.Since(stat.ModTime()) < 20*time.Second {
+				return fmt.Errorf("another instance of k0sctl is currently operating on the host")
+			}
+			_ = h.Configurer.DeleteFile(h, lfp)
+			return fmt.Errorf("removed existing expired lock file")
+		}
+	}
+
+	return nil
+}

--- a/phase/prepare_hosts.go
+++ b/phase/prepare_hosts.go
@@ -1,11 +1,8 @@
 package phase
 
 import (
-	"errors"
 	"strings"
-	"time"
 
-	retry "github.com/avast/retry-go"
 	"github.com/k0sproject/k0sctl/pkg/apis/k0sctl.k0sproject.io/v1beta1/cluster"
 	"github.com/k0sproject/rig/os"
 	log "github.com/sirupsen/logrus"
@@ -14,6 +11,7 @@ import (
 // PrepareHosts installs required packages and so on on the hosts.
 type PrepareHosts struct {
 	GenericPhase
+	cancel func()
 }
 
 // Title for the phase
@@ -30,36 +28,15 @@ type prepare interface {
 	Prepare(os.Host) error
 }
 
+func (p *PrepareHosts) CleanUp() {
+	p.cancel()
+}
+
 func (p *PrepareHosts) prepareHost(h *cluster.Host) error {
 	if c, ok := h.Configurer.(prepare); ok {
 		if err := c.Prepare(h); err != nil {
 			return err
 		}
-	}
-
-	err := retry.Do(
-		func() error {
-			return h.Configurer.TryLock(h)
-		},
-		retry.OnRetry(
-			func(n uint, err error) {
-				log.Errorf("%s: attempt %d of %d.. trying to obtain a lock on host: %s", h, n+1, retries, err.Error())
-			},
-		),
-		retry.RetryIf(
-			func(err error) bool {
-				return !strings.Contains(err.Error(), "host does not have")
-			},
-		),
-		retry.DelayType(retry.CombineDelay(retry.FixedDelay, retry.RandomDelay)),
-		retry.MaxJitter(time.Second*2),
-		retry.Delay(time.Second*3),
-		retry.Attempts(5),
-		retry.LastErrorOnly(true),
-	)
-
-	if err != nil && !strings.Contains(err.Error(), "host does not have") {
-		return errors.New("another k0sctl instance is currently operating on the node")
 	}
 
 	if len(h.Environment) > 0 {

--- a/phase/unlock.go
+++ b/phase/unlock.go
@@ -1,0 +1,34 @@
+package phase
+
+import (
+	"github.com/k0sproject/k0sctl/pkg/apis/k0sctl.k0sproject.io/v1beta1"
+	log "github.com/sirupsen/logrus"
+)
+
+// Unlock acquires an exclusive k0sctl lock on hosts
+type Unlock struct {
+	GenericPhase
+	Cancel func()
+}
+
+// Prepare the phase
+func (p *Unlock) Prepare(c *v1beta1.Cluster) error {
+	p.Config = c
+	if p.Cancel == nil {
+		p.Cancel = func() {
+			log.Fatalf("cancel function not defined")
+		}
+	}
+	return nil
+}
+
+// Title for the phase
+func (p *Unlock) Title() string {
+	return "Release exclusive host lock"
+}
+
+// Run the phase
+func (p *Unlock) Run() error {
+	p.Cancel()
+	return nil
+}

--- a/pkg/apis/k0sctl.k0sproject.io/v1beta1/cluster/host.go
+++ b/pkg/apis/k0sctl.k0sproject.io/v1beta1/cluster/host.go
@@ -117,7 +117,8 @@ type configurer interface {
 	CleanupServiceEnvironment(os.Host, string) error
 	Stat(os.Host, string, ...exec.Option) (*os.FileInfo, error)
 	Touch(os.Host, string, time.Time, ...exec.Option) error
-	TryLock(os.Host) error
+	K0sctlLockFilePath() string
+	UpsertFile(os.Host, string, string) error
 }
 
 // HostMetadata resolved metadata for host

--- a/pkg/apis/k0sctl.k0sproject.io/v1beta1/cluster/host.go
+++ b/pkg/apis/k0sctl.k0sproject.io/v1beta1/cluster/host.go
@@ -117,6 +117,7 @@ type configurer interface {
 	CleanupServiceEnvironment(os.Host, string) error
 	Stat(os.Host, string, ...exec.Option) (*os.FileInfo, error)
 	Touch(os.Host, string, time.Time, ...exec.Option) error
+	TryLock(os.Host) error
 }
 
 // HostMetadata resolved metadata for host

--- a/pkg/apis/k0sctl.k0sproject.io/v1beta1/cluster/host.go
+++ b/pkg/apis/k0sctl.k0sproject.io/v1beta1/cluster/host.go
@@ -117,7 +117,7 @@ type configurer interface {
 	CleanupServiceEnvironment(os.Host, string) error
 	Stat(os.Host, string, ...exec.Option) (*os.FileInfo, error)
 	Touch(os.Host, string, time.Time, ...exec.Option) error
-	K0sctlLockFilePath() string
+	K0sctlLockFilePath(os.Host) string
 	UpsertFile(os.Host, string, string) error
 }
 


### PR DESCRIPTION
Fixes #381 

Uses a lock file (`/run/lock/k0sctl`) to stop multiple instances of k0sctl from operating on the same target host simultaneously. A background loop touches the modtime of the lock file every 10 seconds while k0sctl is running.

If a lock file is found, it is discarded if it is over 30 seconds old.
