### PR TITLE
Fix c.Spec.K0s nil panics

### DIFF
--- a/cmd/init.go
+++ b/cmd/init.go
@@ -207,7 +207,7 @@ var initCommand = &cli.Command{
 			Metadata:   &v1beta1.ClusterMetadata{Name: ctx.String("cluster-name")},
 			Spec: &cluster.Spec{
 				Hosts: buildHosts(addresses, ctx.Int("controller-count"), ctx.String("user"), ctx.String("key-path")),
-				K0s:   &cluster.K0s{},
+				K0s:   cluster.K0s{},
 			},
 		}
 

--- a/phase/gather_k0s_facts_test.go
+++ b/phase/gather_k0s_facts_test.go
@@ -11,7 +11,7 @@ import (
 func TestNeedsUpgrade(t *testing.T) {
 	cfg := &v1beta1.Cluster{
 		Spec: &cluster.Spec{
-			K0s: &cluster.K0s{
+			K0s: cluster.K0s{
 				Version: "1.23.3+k0s.1",
 			},
 		},

--- a/pkg/apis/k0sctl.k0sproject.io/v1beta1/cluster/spec.go
+++ b/pkg/apis/k0sctl.k0sproject.io/v1beta1/cluster/spec.go
@@ -10,7 +10,7 @@ import (
 // Spec defines cluster config spec section
 type Spec struct {
 	Hosts Hosts `yaml:"hosts"`
-	K0s   *K0s  `yaml:"k0s"`
+	K0s   K0s   `yaml:"k0s"`
 
 	k0sLeader *Host
 }
@@ -19,7 +19,6 @@ type Spec struct {
 func (s *Spec) UnmarshalYAML(unmarshal func(interface{}) error) error {
 	type spec Spec
 	ys := (*spec)(s)
-	ys.K0s = &K0s{}
 
 	if err := unmarshal(ys); err != nil {
 		return err

--- a/pkg/apis/k0sctl.k0sproject.io/v1beta1/cluster_test.go
+++ b/pkg/apis/k0sctl.k0sproject.io/v1beta1/cluster_test.go
@@ -23,7 +23,7 @@ func TestK0sVersionValidation(t *testing.T) {
 		APIVersion: APIVersion,
 		Kind:       "cluster",
 		Spec: &cluster.Spec{
-			K0s: &cluster.K0s{
+			K0s: cluster.K0s{
 				Version: "0.1.0",
 			},
 			Hosts: cluster.Hosts{


### PR DESCRIPTION
Having spec.K0s as a pointer is a great source for nil panics.
