### PR TITLE
Add spec.hosts.noTaints to disable default controller+worker taints

### DIFF
--- a/README.md
+++ b/README.md
@@ -291,6 +291,10 @@ One of:
 - `single` - a [single-node cluster](https://docs.k0sproject.io/main/k0s-single-node/) host, the configuration can only contain one host
 - `worker` - a worker host
 
+###### `spec.hosts[*].noTaints` &lt;boolean&gt; (optional) (default: `false`)
+
+When `true` and used in conjuction with the `controller+worker` role, the default taints are disabled making regular workloads schedulable on the node. By default, k0s sets a node-role.kubernetes.io/master:NoSchedule taint on controller+worker nodes and only workloads with toleration for it will be scheduled.
+
 ###### `spec.hosts[*].uploadBinary` &lt;boolean&gt; (optional) (default: `false`)
 
 When `true`, the k0s binaries for target host will be downloaded and cached on the local host and uploaded to the target.

--- a/phase/gather_k0s_facts.go
+++ b/phase/gather_k0s_facts.go
@@ -150,6 +150,10 @@ func (p *GatherK0sFacts) investigateK0s(h *cluster.Host) error {
 		}
 	}
 
+	if h.Role == "controller+worker" && !h.NoTaints {
+		log.Warnf("%s: the controller+worker node will not schedule regular workloads without toleration for node-role.kubernetes.io/master:NoSchedule unless 'noTaints: true' is set", h)
+	}
+
 	if h.Metadata.NeedsUpgrade {
 		log.Warnf("%s: k0s will be upgraded", h)
 	}


### PR DESCRIPTION
Fixes #376

Adds a setting for disabling the default controller+worker taints, making it possible to run regular workloads on controller+worker nodes.

```yaml
spec:
  hosts:
    - role: controller+worker
      noTaints: true
```

When false (default), k0s will set taints on controller nodes, making kube only schedule workloads with specific tolerations on them.

The setting can only be used with the `controller+worker` role.
