### PR TITLE
Fix removing backup and tempdir after backup and restore

### DIFF
--- a/configurer/linux.go
+++ b/configurer/linux.go
@@ -242,3 +242,7 @@ func (l Linux) UpsertFile(h os.Host, path, content string) error {
 
 	return nil
 }
+
+func (l Linux) DeleteDir(h os.Host, path string, opts ...exec.Option) error {
+	return h.Exec(fmt.Sprintf(`rmdir %s`, shellescape.Quote(path)), opts...)
+}

--- a/phase/backup.go
+++ b/phase/backup.go
@@ -75,7 +75,7 @@ func (p *Backup) Run() error {
 		if err := h.Configurer.DeleteFile(h, remotePath); err != nil {
 			log.Warnf("%s: failed to clean up backup temp file %s: %s", h, remotePath, err)
 		}
-		if err := h.Configurer.DeleteFile(h, backupDir); err != nil {
+		if err := h.Configurer.DeleteDir(h, backupDir, exec.Sudo(h)); err != nil {
 			log.Warnf("%s: failed to clean up backup temp directory %s: %s", h, backupDir, err)
 		}
 	}()

--- a/phase/backup.go
+++ b/phase/backup.go
@@ -64,7 +64,7 @@ func (p *Backup) Run() error {
 	}
 
 	// get the name of the backup file
-	remoteFile, err := h.ExecOutput(fmt.Sprintf("ls %s", backupDir))
+	remoteFile, err := h.ExecOutputf(`ls "%s"`, backupDir)
 	if err != nil {
 		return err
 	}

--- a/phase/backup.go
+++ b/phase/backup.go
@@ -3,6 +3,7 @@ package phase
 import (
 	"fmt"
 	"os"
+	"path"
 	"path/filepath"
 	"time"
 
@@ -67,11 +68,15 @@ func (p *Backup) Run() error {
 	if err != nil {
 		return err
 	}
+	remotePath := path.Join(backupDir, remoteFile)
 
 	defer func() {
-		log.Debugf("%s: cleaning up %s", h, remoteFile)
-		if err := h.Configurer.DeleteFile(h, remoteFile); err != nil {
-			log.Warnf("%s: failed to clean up backup temp file %s: %s", h, remoteFile, err)
+		log.Debugf("%s: cleaning up %s", h, remotePath)
+		if err := h.Configurer.DeleteFile(h, remotePath); err != nil {
+			log.Warnf("%s: failed to clean up backup temp file %s: %s", h, remotePath, err)
+		}
+		if err := h.Configurer.DeleteFile(h, backupDir); err != nil {
+			log.Warnf("%s: failed to clean up backup temp directory %s: %s", h, backupDir, err)
 		}
 	}()
 
@@ -87,8 +92,7 @@ func (p *Backup) Run() error {
 	}
 	defer f.Close()
 
-	cmd := fmt.Sprintf("cat %s/%s", backupDir, remoteFile)
-	if err := h.Exec(cmd, exec.Writer(f)); err != nil {
+	if err := h.Execf(`cat "%s"`, remotePath, exec.Writer(f)); err != nil {
 		return err
 	}
 

--- a/phase/prepare_hosts.go
+++ b/phase/prepare_hosts.go
@@ -11,7 +11,6 @@ import (
 // PrepareHosts installs required packages and so on on the hosts.
 type PrepareHosts struct {
 	GenericPhase
-	cancel func()
 }
 
 // Title for the phase
@@ -26,10 +25,6 @@ func (p *PrepareHosts) Run() error {
 
 type prepare interface {
 	Prepare(os.Host) error
-}
-
-func (p *PrepareHosts) CleanUp() {
-	p.cancel()
 }
 
 func (p *PrepareHosts) prepareHost(h *cluster.Host) error {

--- a/phase/restore.go
+++ b/phase/restore.go
@@ -60,7 +60,7 @@ func (p *Restore) Run() error {
 			log.Warnf("%s: failed to remove backup file %s: %s", h, dstFile, err)
 		}
 
-		if err := h.Configurer.DeleteFile(h, tmpDir); err != nil {
+		if err := h.Configurer.DeleteDir(h, tmpDir, exec.Sudo(h)); err != nil {
 			log.Warnf("%s: failed to remove backup temp dir %s: %s", h, tmpDir, err)
 		}
 	}()

--- a/phase/restore.go
+++ b/phase/restore.go
@@ -50,7 +50,7 @@ func (p *Restore) Run() error {
 	if err != nil {
 		return err
 	}
-	dstFile := path.Join(tmpDir, "k0s_backup.tar.gz", tmpDir)
+	dstFile := path.Join(tmpDir, "k0s_backup.tar.gz")
 	if err := h.Upload(p.RestoreFrom, dstFile); err != nil {
 		return err
 	}

--- a/phase/restore.go
+++ b/phase/restore.go
@@ -2,6 +2,7 @@ package phase
 
 import (
 	"fmt"
+	"path"
 
 	"github.com/k0sproject/k0sctl/pkg/apis/k0sctl.k0sproject.io/v1beta1"
 	"github.com/k0sproject/k0sctl/pkg/apis/k0sctl.k0sproject.io/v1beta1/cluster"
@@ -49,12 +50,20 @@ func (p *Restore) Run() error {
 	if err != nil {
 		return err
 	}
-	dstFile := fmt.Sprintf("%s/k0s_backup.tar.gz", tmpDir)
+	dstFile := path.Join(tmpDir, "k0s_backup.tar.gz", tmpDir)
 	if err := h.Upload(p.RestoreFrom, dstFile); err != nil {
 		return err
 	}
 
-	defer func() { _ = h.Configurer.DeleteFile(h, dstFile) }()
+	defer func() {
+		if err := h.Configurer.DeleteFile(h, dstFile); err != nil {
+			log.Warnf("%s: failed to remove backup file %s: %s", h, dstFile, err)
+		}
+
+		if err := h.Configurer.DeleteFile(h, tmpDir); err != nil {
+			log.Warnf("%s: failed to remove backup temp dir %s: %s", h, tmpDir, err)
+		}
+	}()
 
 	// Run restore
 	log.Infof("%s: restoring cluster state", h)

--- a/pkg/apis/k0sctl.k0sproject.io/v1beta1/cluster/host.go
+++ b/pkg/apis/k0sctl.k0sproject.io/v1beta1/cluster/host.go
@@ -123,6 +123,7 @@ type configurer interface {
 	CleanupServiceEnvironment(os.Host, string) error
 	Stat(os.Host, string, ...exec.Option) (*os.FileInfo, error)
 	Touch(os.Host, string, time.Time, ...exec.Option) error
+	DeleteDir(os.Host, string, ...exec.Option) error
 	K0sctlLockFilePath(os.Host) string
 	UpsertFile(os.Host, string, string) error
 }


### PR DESCRIPTION
Fixes #393

The removal was attempted from CWD, not the tempdir.

Also, the tempdir was not removed in neither backup or restore.
