### PR TITLE
Support opensuse-microos, use group root instead of adm for bins

### DIFF
--- a/configurer/linux.go
+++ b/configurer/linux.go
@@ -128,7 +128,7 @@ func (l Linux) DownloadK0s(h os.Host, version *version.Version, arch string) err
 		return err
 	}
 
-	return h.Execf(`install -m 0750 -o root -g adm "%s" "%s"`, tmp, l.PathFuncs.K0sBinaryPath(), exec.Sudo(h))
+	return h.Execf(`install -m 0750 -o root -g root "%s" "%s"`, tmp, l.PathFuncs.K0sBinaryPath(), exec.Sudo(h))
 }
 
 // ReplaceK0sTokenPath replaces the config path in the service stub

--- a/configurer/linux/opensuse.go
+++ b/configurer/linux/opensuse.go
@@ -14,7 +14,7 @@ type OpenSUSE struct {
 func init() {
 	registry.RegisterOSModule(
 		func(os rig.OSVersion) bool {
-			return os.ID == "opensuse"
+			return os.ID == "opensuse" || os.ID == "opensuse-microos"
 		},
 		func() interface{} {
 			linuxType := &OpenSUSE{}


### PR DESCRIPTION
Signed-off-by: Kimmo Lehto <klehto@mirantis.com>

Fixes #401 

* Treats MicroOS as OpenSUSE
* Changes the k0s binary group to `root` instead of `adm` which doesn't exist on some systems.
