### PR TITLE
Use the correct `io.Writer` for `k0sctl kubeconfig` output

### DIFF
--- a/cmd/kubeconfig.go
+++ b/cmd/kubeconfig.go
@@ -49,7 +49,7 @@ var kubeconfigCommand = &cli.Command{
 			return err
 		}
 
-		fmt.Println(c.Metadata.Kubeconfig)
+		fmt.Fprintf(ctx.App.Writer, "%s\n", c.Metadata.Kubeconfig)
 
 		return nil
 	},


### PR DESCRIPTION
Redirect the output of `k0sctl kubeconfig` to the `io.Writer` being used in `cli.App` instead of `fmt.Println()`. This fixes the usage of `k0sctl` as a module when configured with an `cli.App.Writer` other than `os.Stdout`

Signed-off-by: Shane Jarych <sjarych@mirantis.com>