### PR TITLE
Automatically switch Kubeconfig if Worker

### DIFF
--- a/configurer/linux.go
+++ b/configurer/linux.go
@@ -18,7 +18,7 @@ type PathFuncs interface {
 	K0sBinaryPath() string
 	K0sConfigPath() string
 	K0sJoinTokenPath() string
-	KubeconfigPath(bool) string
+	KubeconfigPath(h os.Host) string
 }
 
 // Linux is a base module for various linux OS support packages
@@ -147,16 +147,16 @@ func (l Linux) MoveFile(h os.Host, src, dst string) error {
 }
 
 // KubeconfigPath returns the path to a kubeconfig on the host
-func (l Linux) KubeconfigPath(isController bool) string {
-	if !isController {
+func (l Linux) KubeconfigPath(h os.Host) string {
+	if err := h.Exec("stat %s", exec.Sudo(h)); err != nil {
 		return "/var/lib/k0s/kubelet.conf"
 	}
 	return "/var/lib/k0s/pki/admin.conf"
 }
 
 // KubectlCmdf returns a command line in sprintf manner for running kubectl on the host using the kubeconfig from KubeconfigPath
-func (l Linux) KubectlCmdf(isController bool, s string, args ...interface{}) string {
-	return fmt.Sprintf(`env "KUBECONFIG=%s" %s`, l.PathFuncs.KubeconfigPath(isController), l.K0sCmdf(`kubectl %s`, fmt.Sprintf(s, args...)))
+func (l Linux) KubectlCmdf(h os.Host, s string, args ...interface{}) string {
+	return fmt.Sprintf(`env "KUBECONFIG=%s" %s`, l.PathFuncs.KubeconfigPath(h), l.K0sCmdf(`kubectl %s`, fmt.Sprintf(s, args...)))
 }
 
 // HTTPStatus makes a HTTP GET request to the url and returns the status code or an error

--- a/configurer/linux.go
+++ b/configurer/linux.go
@@ -136,12 +136,6 @@ func (l Linux) ReplaceK0sTokenPath(h os.Host, spath string) error {
 	return h.Exec(fmt.Sprintf("sed -i 's^REPLACEME^%s^g' %s", l.PathFuncs.K0sJoinTokenPath(), spath))
 }
 
-// FileExists returns true if a file exiyts
-func (l Linux) FileExists(h os.Host, path string) bool {
-	err := h.Execf(fmt.Sprintf("stat %s", path), exec.Sudo(h))
-	return err == nil
-}
-
 // FileContains returns true if a file contains the substring
 func (l Linux) FileContains(h os.Host, path, s string) bool {
 	return h.Execf(`grep -q "%s" "%s"`, s, path, exec.Sudo(h)) == nil
@@ -154,7 +148,8 @@ func (l Linux) MoveFile(h os.Host, src, dst string) error {
 
 // KubeconfigPath returns the path to a kubeconfig on the host
 func (l Linux) KubeconfigPath(h os.Host) string {
-	if l.FileExists(h, "/var/lib/k0s/pki/admin.conf") {
+	linux := &os.Linux{}
+	if linux.FileExist(h, "/var/lib/k0s/pki/admin.conf") {
 		return "/var/lib/k0s/pki/admin.conf"
 	}
 	return "/var/lib/k0s/kubelet.conf"

--- a/configurer/linux.go
+++ b/configurer/linux.go
@@ -156,7 +156,7 @@ func (l Linux) KubeconfigPath(isController bool) string {
 
 // KubectlCmdf returns a command line in sprintf manner for running kubectl on the host using the kubeconfig from KubeconfigPath
 func (l Linux) KubectlCmdf(isController bool, s string, args ...interface{}) string {
-	return fmt.Sprintf(`env "KUBECONFIG=%s" %s`, l.KubeconfigPath(isController), l.K0sCmdf(`kubectl %s`, fmt.Sprintf(s, args...)))
+	return fmt.Sprintf(`env "KUBECONFIG=%s" %s`, l.PathFuncs.KubeconfigPath(isController), l.K0sCmdf(`kubectl %s`, fmt.Sprintf(s, args...)))
 }
 
 // HTTPStatus makes a HTTP GET request to the url and returns the status code or an error

--- a/configurer/linux.go
+++ b/configurer/linux.go
@@ -136,6 +136,12 @@ func (l Linux) ReplaceK0sTokenPath(h os.Host, spath string) error {
 	return h.Exec(fmt.Sprintf("sed -i 's^REPLACEME^%s^g' %s", l.PathFuncs.K0sJoinTokenPath(), spath))
 }
 
+// FileExists returns true if a file exiyts
+func (l Linux) FileExists(h os.Host, path string) bool {
+	err := h.Execf(fmt.Sprintf("stat %s", path), exec.Sudo(h))
+	return err == nil
+}
+
 // FileContains returns true if a file contains the substring
 func (l Linux) FileContains(h os.Host, path, s string) bool {
 	return h.Execf(`grep -q "%s" "%s"`, s, path, exec.Sudo(h)) == nil
@@ -148,10 +154,10 @@ func (l Linux) MoveFile(h os.Host, src, dst string) error {
 
 // KubeconfigPath returns the path to a kubeconfig on the host
 func (l Linux) KubeconfigPath(h os.Host) string {
-	if err := h.Exec("stat %s", exec.Sudo(h)); err != nil {
-		return "/var/lib/k0s/kubelet.conf"
+	if l.FileExists(h, "/var/lib/k0s/pki/admin.conf") {
+		return "/var/lib/k0s/pki/admin.conf"
 	}
-	return "/var/lib/k0s/pki/admin.conf"
+	return "/var/lib/k0s/kubelet.conf"
 }
 
 // KubectlCmdf returns a command line in sprintf manner for running kubectl on the host using the kubeconfig from KubeconfigPath

--- a/configurer/linux/linux_test.go
+++ b/configurer/linux/linux_test.go
@@ -21,6 +21,9 @@ func TestPaths(t *testing.T) {
 	require.Equal(t, "/opt/bin/k0s --help", fc.K0sCmdf("--help"))
 	require.Equal(t, "/usr/local/bin/k0s --help", ubuntu.K0sCmdf("--help"))
 
-	require.Equal(t, "/var/lib/k0s/pki/admin.conf", fc.KubeconfigPath())
-	require.Equal(t, "/var/lib/k0s/pki/admin.conf", ubuntu.KubeconfigPath())
+	require.Equal(t, "/var/lib/k0s/pki/admin.conf", fc.KubeconfigPath(true))
+	require.Equal(t, "/var/lib/k0s/pki/admin.conf", ubuntu.KubeconfigPath(true))
+
+	require.Equal(t, "/var/lib/k0s/kubelet.conf", fc.KubeconfigPath(false))
+	require.Equal(t, "/var/lib/k0s/kubelet.conf", ubuntu.KubeconfigPath(false))
 }

--- a/configurer/linux/linux_test.go
+++ b/configurer/linux/linux_test.go
@@ -10,7 +10,7 @@ import (
 )
 
 type mockHost struct {
-	ExecError bool
+	ExecFError bool
 }
 
 func (m mockHost) Upload(source, destination string, opts ...exec.Option) error {
@@ -18,9 +18,6 @@ func (m mockHost) Upload(source, destination string, opts ...exec.Option) error 
 }
 
 func (m mockHost) Exec(string, ...exec.Option) error {
-	if m.ExecError {
-		return fmt.Errorf("error")
-	}
 	return nil
 }
 
@@ -29,6 +26,9 @@ func (m mockHost) ExecOutput(string, ...exec.Option) (string, error) {
 }
 
 func (m mockHost) Execf(string, ...interface{}) error {
+	if m.ExecFError {
+		return fmt.Errorf("error")
+	}
 	return nil
 }
 
@@ -53,10 +53,10 @@ func TestPaths(t *testing.T) {
 	ubuntu.PathFuncs = interface{}(ubuntu).(configurer.PathFuncs)
 
 	h1 := &mockHost{
-		ExecError: false,
+		ExecFError: false,
 	}
 	h2 := &mockHost{
-		ExecError: true,
+		ExecFError: true,
 	}
 
 	require.Equal(t, "/opt/bin/k0s", fc.K0sBinaryPath())

--- a/configurer/linux/linux_test.go
+++ b/configurer/linux/linux_test.go
@@ -1,11 +1,48 @@
 package linux
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/k0sproject/k0sctl/configurer"
+	"github.com/k0sproject/rig/exec"
 	"github.com/stretchr/testify/require"
 )
+
+type mockHost struct {
+	ExecError bool
+}
+
+func (m mockHost) Upload(source, destination string, opts ...exec.Option) error {
+	return nil
+}
+
+func (m mockHost) Exec(string, ...exec.Option) error {
+	if m.ExecError {
+		return fmt.Errorf("error")
+	}
+	return nil
+}
+
+func (m mockHost) ExecOutput(string, ...exec.Option) (string, error) {
+	return "", nil
+}
+
+func (m mockHost) Execf(string, ...interface{}) error {
+	return nil
+}
+
+func (m mockHost) ExecOutputf(string, ...interface{}) (string, error) {
+	return "", nil
+}
+
+func (m mockHost) String() string {
+	return ""
+}
+
+func (m mockHost) Sudo(string) (string, error) {
+	return "", nil
+}
 
 // TestPaths tests the slightly weird way to perform function overloading
 func TestPaths(t *testing.T) {
@@ -15,15 +52,22 @@ func TestPaths(t *testing.T) {
 	ubuntu := &Ubuntu{}
 	ubuntu.PathFuncs = interface{}(ubuntu).(configurer.PathFuncs)
 
+	h1 := &mockHost{
+		ExecError: false,
+	}
+	h2 := &mockHost{
+		ExecError: true,
+	}
+
 	require.Equal(t, "/opt/bin/k0s", fc.K0sBinaryPath())
 	require.Equal(t, "/usr/local/bin/k0s", ubuntu.K0sBinaryPath())
 
 	require.Equal(t, "/opt/bin/k0s --help", fc.K0sCmdf("--help"))
 	require.Equal(t, "/usr/local/bin/k0s --help", ubuntu.K0sCmdf("--help"))
 
-	require.Equal(t, "/var/lib/k0s/pki/admin.conf", fc.KubeconfigPath(true))
-	require.Equal(t, "/var/lib/k0s/pki/admin.conf", ubuntu.KubeconfigPath(true))
+	require.Equal(t, "/var/lib/k0s/pki/admin.conf", fc.KubeconfigPath(h1))
+	require.Equal(t, "/var/lib/k0s/pki/admin.conf", ubuntu.KubeconfigPath(h1))
 
-	require.Equal(t, "/var/lib/k0s/kubelet.conf", fc.KubeconfigPath(false))
-	require.Equal(t, "/var/lib/k0s/kubelet.conf", ubuntu.KubeconfigPath(false))
+	require.Equal(t, "/var/lib/k0s/kubelet.conf", fc.KubeconfigPath(h2))
+	require.Equal(t, "/var/lib/k0s/kubelet.conf", ubuntu.KubeconfigPath(h2))
 }

--- a/phase/get_kubeconfig.go
+++ b/phase/get_kubeconfig.go
@@ -20,7 +20,7 @@ func (p *GetKubeconfig) Title() string {
 // Run the phase
 func (p *GetKubeconfig) Run() error {
 	h := p.Config.Spec.Hosts.Controllers()[0]
-	output, err := h.Configurer.ReadFile(h, h.Configurer.KubeconfigPath(h.IsController()))
+	output, err := h.Configurer.ReadFile(h, h.Configurer.KubeconfigPath(h))
 	if err != nil {
 		return err
 	}

--- a/phase/get_kubeconfig.go
+++ b/phase/get_kubeconfig.go
@@ -20,7 +20,7 @@ func (p *GetKubeconfig) Title() string {
 // Run the phase
 func (p *GetKubeconfig) Run() error {
 	h := p.Config.Spec.Hosts.Controllers()[0]
-	output, err := h.Configurer.ReadFile(h, h.Configurer.KubeconfigPath())
+	output, err := h.Configurer.ReadFile(h, h.Configurer.KubeconfigPath(h.IsController()))
 	if err != nil {
 		return err
 	}

--- a/pkg/apis/k0sctl.k0sproject.io/v1beta1/cluster/host.go
+++ b/pkg/apis/k0sctl.k0sproject.io/v1beta1/cluster/host.go
@@ -112,7 +112,7 @@ type configurer interface {
 	CommandExist(os.Host, string) bool
 	Hostname(os.Host) string
 	KubectlCmdf(os.Host, string, ...interface{}) string
-	KubeconfigPath(bool) string
+	KubeconfigPath(os.Host) string
 	IsContainer(os.Host) bool
 	FixContainer(os.Host) error
 	HTTPStatus(os.Host, string) (int, error)

--- a/pkg/apis/k0sctl.k0sproject.io/v1beta1/cluster/host.go
+++ b/pkg/apis/k0sctl.k0sproject.io/v1beta1/cluster/host.go
@@ -111,7 +111,7 @@ type configurer interface {
 	DeleteFile(os.Host, string) error
 	CommandExist(os.Host, string) bool
 	Hostname(os.Host) string
-	KubectlCmdf(bool, string, ...interface{}) string
+	KubectlCmdf(os.Host, string, ...interface{}) string
 	KubeconfigPath(bool) string
 	IsContainer(os.Host) bool
 	FixContainer(os.Host) error
@@ -351,7 +351,7 @@ type kubeNodeStatus struct {
 
 // KubeNodeReady runs kubectl on the host and returns true if the given node is marked as ready
 func (h *Host) KubeNodeReady(node *Host) (bool, error) {
-	output, err := h.ExecOutput(h.Configurer.KubectlCmdf(h.IsController(), "get node -l kubernetes.io/hostname=%s -o json", node.Metadata.Hostname), exec.HideOutput(), exec.Sudo(h))
+	output, err := h.ExecOutput(h.Configurer.KubectlCmdf(h, "get node -l kubernetes.io/hostname=%s -o json", node.Metadata.Hostname), exec.HideOutput(), exec.Sudo(h))
 	if err != nil {
 		return false, err
 	}
@@ -396,17 +396,17 @@ func (h *Host) WaitKubeNodeReady(node *Host) error {
 
 // DrainNode drains the given node
 func (h *Host) DrainNode(node *Host) error {
-	return h.Exec(h.Configurer.KubectlCmdf(h.IsController(), "drain --grace-period=120 --force --timeout=5m --ignore-daemonsets --delete-local-data %s", node.Metadata.Hostname), exec.Sudo(h))
+	return h.Exec(h.Configurer.KubectlCmdf(h, "drain --grace-period=120 --force --timeout=5m --ignore-daemonsets --delete-local-data %s", node.Metadata.Hostname), exec.Sudo(h))
 }
 
 // UncordonNode marks the node schedulable again
 func (h *Host) UncordonNode(node *Host) error {
-	return h.Exec(h.Configurer.KubectlCmdf(h.IsController(), "uncordon %s", node.Metadata.Hostname), exec.Sudo(h))
+	return h.Exec(h.Configurer.KubectlCmdf(h, "uncordon %s", node.Metadata.Hostname), exec.Sudo(h))
 }
 
 // DeleteNode deletes the given node from kubernetes
 func (h *Host) DeleteNode(node *Host) error {
-	return h.Exec(h.Configurer.KubectlCmdf(h.IsController(), "delete node %s", node.Metadata.Hostname), exec.Sudo(h))
+	return h.Exec(h.Configurer.KubectlCmdf(h, "delete node %s", node.Metadata.Hostname), exec.Sudo(h))
 }
 
 func (h *Host) LeaveEtcd(node *Host) error {

--- a/pkg/apis/k0sctl.k0sproject.io/v1beta1/cluster/k0s.go
+++ b/pkg/apis/k0sctl.k0sproject.io/v1beta1/cluster/k0s.go
@@ -164,7 +164,7 @@ func (k K0s) GenerateToken(h *Host, role string, expiry time.Duration) (string, 
 
 // GetClusterID uses kubectl to fetch the kube-system namespace uid
 func (k K0s) GetClusterID(h *Host) (string, error) {
-	return h.ExecOutput(h.Configurer.KubectlCmdf(h.IsController(), "get -n kube-system namespace kube-system -o template={{.metadata.uid}}"), exec.Sudo(h))
+	return h.ExecOutput(h.Configurer.KubectlCmdf(h, "get -n kube-system namespace kube-system -o template={{.metadata.uid}}"), exec.Sudo(h))
 }
 
 // TokenID returns a token id from a token string that can be used to invalidate the token

--- a/pkg/apis/k0sctl.k0sproject.io/v1beta1/cluster/k0s.go
+++ b/pkg/apis/k0sctl.k0sproject.io/v1beta1/cluster/k0s.go
@@ -164,7 +164,7 @@ func (k K0s) GenerateToken(h *Host, role string, expiry time.Duration) (string, 
 
 // GetClusterID uses kubectl to fetch the kube-system namespace uid
 func (k K0s) GetClusterID(h *Host) (string, error) {
-	return h.ExecOutput(h.Configurer.KubectlCmdf("get -n kube-system namespace kube-system -o template={{.metadata.uid}}"), exec.Sudo(h))
+	return h.ExecOutput(h.Configurer.KubectlCmdf(h.IsController(), "get -n kube-system namespace kube-system -o template={{.metadata.uid}}"), exec.Sudo(h))
 }
 
 // TokenID returns a token id from a token string that can be used to invalidate the token


### PR DESCRIPTION
If running `k0s kubectl` commands on a worker automatically switch to the `kubelet.conf` instead of the `admin.conf` file which on workers doesn't exist.

This prepares for #327 