### PR TITLE
Monitor Ready status from node

### DIFF
--- a/phase/gather_k0s_facts.go
+++ b/phase/gather_k0s_facts.go
@@ -160,7 +160,7 @@ func (p *GatherK0sFacts) investigateK0s(h *cluster.Host) error {
 
 	if !h.IsController() {
 		log.Infof("%s: checking if worker %s has joined", p.leader, h.Metadata.Hostname)
-		ready, err := p.leader.KubeNodeReady(h)
+		ready, err := h.KubeNodeReady()
 		if err != nil {
 			log.Debugf("%s: failed to get ready status: %s", h, err.Error())
 		}

--- a/phase/install_workers.go
+++ b/phase/install_workers.go
@@ -141,7 +141,7 @@ func (p *InstallWorkers) Run() error {
 			log.Debugf("%s: not waiting because --no-wait given", h)
 		} else {
 			log.Infof("%s: waiting for node to become ready", h)
-			if err := p.Config.Spec.K0sLeader().WaitKubeNodeReady(h); err != nil {
+			if err := h.WaitKubeNodeReady(); err != nil {
 				return err
 			}
 			h.Metadata.Ready = true

--- a/phase/upgrade_workers.go
+++ b/phase/upgrade_workers.go
@@ -130,7 +130,7 @@ func (p *UpgradeWorkers) upgradeWorker(h *cluster.Host) error {
 		log.Debugf("%s: not waiting because --no-wait given", h)
 	} else {
 		log.Infof("%s: waiting for node to become ready again", h)
-		if err := p.Config.Spec.K0sLeader().WaitKubeNodeReady(h); err != nil {
+		if err := h.WaitKubeNodeReady(); err != nil {
 			return err
 		}
 		h.Metadata.Ready = true


### PR DESCRIPTION
Monitor the ready status from the node itself instead of using the leader controller.
This prepares for worker-only installs where there is no controller in the k0sctl config file, but instead only a join token is used.

Fixes #327 