### PR TITLE
Avoid retrying connection when it is unlikely that it would succeed

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -5,7 +5,7 @@ on: [ pull_request ]
 jobs:
 
   build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
 
     steps:
     - uses: actions/checkout@v2
@@ -46,7 +46,7 @@ jobs:
         retention-days: 2
 
   build-all:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
 
     steps:
     - uses: actions/checkout@v2
@@ -82,7 +82,7 @@ jobs:
             # - quay.io/footloose/fedora29
     name: Basic 1+1 smoke
     needs: build
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
 
     steps:
       - uses: actions/checkout@v2
@@ -107,7 +107,7 @@ jobs:
   smoke-files:
     name: Basic file upload smoke
     needs: build
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
 
     steps:
       - uses: actions/checkout@v2
@@ -130,7 +130,7 @@ jobs:
   smoke-dynamic:
     name: Basic dynamic config smoke
     needs: build
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
 
     steps:
       - uses: actions/checkout@v2
@@ -153,7 +153,7 @@ jobs:
   smoke-os-override:
     name: OS override smoke test
     needs: build
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
 
     steps:
       - uses: actions/checkout@v2
@@ -187,7 +187,7 @@ jobs:
           - v1.21.6+k0s.0
     name: Upgrade
     needs: build
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
 
     steps:
       - uses: actions/checkout@v2
@@ -219,7 +219,7 @@ jobs:
 
     name: Apply + reset
     needs: build
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
 
     steps:
       - uses: actions/checkout@v2
@@ -250,7 +250,7 @@ jobs:
 
     name: Apply + backup + reset + restore
     needs: build
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
 
     steps:
       - uses: actions/checkout@v2
@@ -275,7 +275,7 @@ jobs:
   smoke-init:
     name: Init sub-command smoke test
     needs: build
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
 
     steps:
       - uses: actions/checkout@v2

--- a/go.mod
+++ b/go.mod
@@ -18,7 +18,7 @@ require (
 	github.com/gofrs/uuid v4.3.1+incompatible // indirect
 	github.com/hashicorp/go-version v1.4.0 // indirect
 	github.com/k0sproject/dig v0.2.0
-	github.com/k0sproject/rig v0.9.2
+	github.com/k0sproject/rig v0.10.0
 	github.com/logrusorgru/aurora v2.0.3+incompatible
 	github.com/masterzen/simplexml v0.0.0-20190410153822-31eea3082786 // indirect
 	github.com/masterzen/winrm v0.0.0-20220917170901-b07f6cb0598d // indirect

--- a/go.sum
+++ b/go.sum
@@ -239,8 +239,8 @@ github.com/jstemmer/go-junit-report v0.0.0-20190106144839-af01ea7f8024/go.mod h1
 github.com/jstemmer/go-junit-report v0.9.1/go.mod h1:Brl9GWCQeLvo8nXZwPNNblvFj/XSXhF0NWZEnDohbsk=
 github.com/k0sproject/dig v0.2.0 h1:cNxEIl96g9kqSMfPSZLhpnZ0P8bWXKv08nxvsMHop5w=
 github.com/k0sproject/dig v0.2.0/go.mod h1:rBcqaQlJpcKdt2x/OE/lPvhGU50u/e95CSm5g/r4s78=
-github.com/k0sproject/rig v0.9.2 h1:qbR/2NUY9saXYtlB/WmaZbc+iLBj9GPhvXaqQcafZVs=
-github.com/k0sproject/rig v0.9.2/go.mod h1:22xaLLKd0UHkFwJbOB1JWMBel6QOAzluxeJXbnxFqmA=
+github.com/k0sproject/rig v0.10.0 h1:uXLA4s19ZxYgq4qcuczjYQIfbjS/zmqBPJXUtmMP+wc=
+github.com/k0sproject/rig v0.10.0/go.mod h1:22xaLLKd0UHkFwJbOB1JWMBel6QOAzluxeJXbnxFqmA=
 github.com/k0sproject/version v0.3.0 h1:6HAn8C29+WVksGCzbQvQ9feEJpUZ0iHD8GebIQMiftQ=
 github.com/k0sproject/version v0.3.0/go.mod h1:oEjuz2ItQQtAnGyRgwEV9m5R6/9rjoFC6EiEEzbkFdI=
 github.com/kballard/go-shellquote v0.0.0-20180428030007-95032a82bc51 h1:Z9n2FFNUXsshfwJMBgNA0RU6/i7WVaAegv3PtuIHPMs=

--- a/phase/connect.go
+++ b/phase/connect.go
@@ -1,11 +1,12 @@
 package phase
 
 import (
-	"strings"
+	"errors"
 	"time"
 
 	retry "github.com/avast/retry-go"
 	"github.com/k0sproject/k0sctl/pkg/apis/k0sctl.k0sproject.io/v1beta1/cluster"
+	"github.com/k0sproject/rig"
 	log "github.com/sirupsen/logrus"
 )
 
@@ -35,7 +36,7 @@ func (p *Connect) Run() error {
 			),
 			retry.RetryIf(
 				func(err error) bool {
-					return !strings.Contains(err.Error(), "no supported methods remain")
+					return !errors.Is(err, rig.ErrCantConnect)
 				},
 			),
 			retry.DelayType(retry.CombineDelay(retry.FixedDelay, retry.RandomDelay)),


### PR DESCRIPTION
Signed-off-by: Kimmo Lehto <klehto@mirantis.com>

Achieved through rig v0.10.0 that now has a specific `ErrCantConnect` error type for those situations.

It's a waste of time to retry the connection 60 times when the error is for example not being able to parse key files or a hostkey mismatch.
