### PR TITLE
Fix dual stack installation with cloud provider

### DIFF
--- a/phase/initialize_k0s.go
+++ b/phase/initialize_k0s.go
@@ -54,7 +54,11 @@ func (p *InitializeK0s) Run() error {
 	}
 
 	log.Infof("%s: installing k0s controller", h)
-	if err := h.Exec(h.K0sInstallCommand()); err != nil {
+	cmd, err := h.K0sInstallCommand()
+	if err != nil {
+		return err
+	}
+	if err = h.Exec(cmd); err != nil {
 		return err
 	}
 

--- a/phase/install_controllers.go
+++ b/phase/install_controllers.go
@@ -84,7 +84,11 @@ func (p *InstallControllers) Run() error {
 		}()
 
 		log.Infof("%s: installing k0s controller", h)
-		if err := h.Exec(h.K0sInstallCommand()); err != nil {
+		cmd, err := h.K0sInstallCommand()
+		if err != nil {
+			return err
+		}
+		if err = h.Exec(cmd); err != nil {
 			return err
 		}
 

--- a/phase/install_workers.go
+++ b/phase/install_workers.go
@@ -121,7 +121,11 @@ func (p *InstallWorkers) Run() error {
 		}
 
 		log.Infof("%s: installing k0s worker", h)
-		if err := h.Exec(h.K0sInstallCommand()); err != nil {
+		cmd, err := h.K0sInstallCommand()
+		if err != nil {
+			return err
+		}
+		if err = h.Exec(cmd); err != nil {
 			return err
 		}
 

--- a/pkg/apis/k0sctl.k0sproject.io/v1beta1/cluster/flags.go
+++ b/pkg/apis/k0sctl.k0sproject.io/v1beta1/cluster/flags.go
@@ -88,6 +88,23 @@ func (f Flags) GetValue(s string) string {
 	return val
 }
 
+// GetValue returns the boolean value part of a flag such as true for a flag like "--san"
+// If the flag is not defined returns false. If the flag is defined without a value, returns true
+// If no value is set, returns true
+func (f Flags) GetBoolean(s string) (bool, error) {
+	idx := f.Index(s)
+	if idx < 0 {
+		return false, nil
+	}
+
+	fl := f.GetValue(s)
+	if fl == "" {
+		return true, nil
+	}
+
+	return strconv.ParseBool(fl)
+}
+
 // Delete removes a matching flag from the list
 func (f *Flags) Delete(s string) {
 	idx := f.Index(s)

--- a/pkg/apis/k0sctl.k0sproject.io/v1beta1/cluster/host_test.go
+++ b/pkg/apis/k0sctl.k0sproject.io/v1beta1/cluster/host_test.go
@@ -78,23 +78,44 @@ func TestK0sInstallCommand(t *testing.T) {
 	h := Host{Role: "worker"}
 	h.Configurer = &mockconfigurer{}
 
-	require.Equal(t, `k0s install worker --token-file "from-configurer"`, h.K0sInstallCommand())
+	cmd, err := h.K0sInstallCommand()
+	require.NoError(t, err)
+	require.Equal(t, `k0s install worker --token-file "from-configurer"`, cmd)
 
 	h.Role = "controller"
 	h.Metadata.IsK0sLeader = true
-	require.Equal(t, `k0s install controller --config "from-configurer"`, h.K0sInstallCommand())
+	cmd, err = h.K0sInstallCommand()
+	require.NoError(t, err)
+	require.Equal(t, `k0s install controller --config "from-configurer"`, cmd)
+
 	h.Metadata.IsK0sLeader = false
-	require.Equal(t, `k0s install controller --token-file "from-configurer" --config "from-configurer"`, h.K0sInstallCommand())
+	cmd, err = h.K0sInstallCommand()
+	require.NoError(t, err)
+	require.Equal(t, `k0s install controller --token-file "from-configurer" --config "from-configurer"`, cmd)
 
 	h.Role = "controller+worker"
 	h.Metadata.IsK0sLeader = true
-	require.Equal(t, `k0s install controller --enable-worker --config "from-configurer"`, h.K0sInstallCommand())
+	cmd, err = h.K0sInstallCommand()
+	require.NoError(t, err)
+	require.Equal(t, `k0s install controller --enable-worker --config "from-configurer"`, cmd)
 	h.Metadata.IsK0sLeader = false
-	require.Equal(t, `k0s install controller --enable-worker --token-file "from-configurer" --config "from-configurer"`, h.K0sInstallCommand())
+	cmd, err = h.K0sInstallCommand()
+	require.NoError(t, err)
+	require.Equal(t, `k0s install controller --enable-worker --token-file "from-configurer" --config "from-configurer"`, cmd)
 
 	h.Role = "worker"
 	h.PrivateAddress = "10.0.0.9"
-	require.Equal(t, `k0s install worker --token-file "from-configurer" --kubelet-extra-args="--node-ip=10.0.0.9"`, h.K0sInstallCommand())
+	cmd, err = h.K0sInstallCommand()
+	require.NoError(t, err)
+	require.Equal(t, `k0s install worker --token-file "from-configurer" --kubelet-extra-args="--node-ip=10.0.0.9"`, cmd)
+
 	h.InstallFlags = []string{`--kubelet-extra-args="--foo bar"`}
-	require.Equal(t, `k0s install worker --kubelet-extra-args="--foo bar --node-ip=10.0.0.9" --token-file "from-configurer"`, h.K0sInstallCommand())
+	cmd, err = h.K0sInstallCommand()
+	require.NoError(t, err)
+	require.Equal(t, `k0s install worker --kubelet-extra-args="--foo bar --node-ip=10.0.0.9" --token-file "from-configurer"`, cmd)
+
+	h.InstallFlags = []string{`--enable-cloud-provider`}
+	cmd, err = h.K0sInstallCommand()
+	require.NoError(t, err)
+	require.Equal(t, `k0s install worker --enable-cloud-provider --token-file "from-configurer"`, cmd)
 }


### PR DESCRIPTION
Fixes https://github.com/k0sproject/k0s/issues/2464

`--node-ip` is incompatible with cloud providers because: https://github.com/kubernetes/kubernetes/pull/95239

Not defining the flag `--node-ip` if `--enable-cloud-provider` is defined fixes the issue. In the long term we need to handle the configuration using a `KubeletConfiguration` file instead of flags. But for now this fixes the issue.

Signed-off-by: Juan Luis de Sousa-Valadas Castaño <jvaladas@mirantis.com>