### PR TITLE
Validate MachineID existence & uniqueness

### DIFF
--- a/configurer/linux.go
+++ b/configurer/linux.go
@@ -250,3 +250,7 @@ func (l Linux) UpsertFile(h os.Host, path, content string) error {
 func (l Linux) DeleteDir(h os.Host, path string, opts ...exec.Option) error {
 	return h.Exec(fmt.Sprintf(`rmdir %s`, shellescape.Quote(path)), opts...)
 }
+
+func (l Linux) MachineID(h os.Host) (string, error) {
+	return h.ExecOutput(`cat /etc/machine-id || cat /var/lib/dbus/machine-id`)
+}

--- a/phase/gather_facts.go
+++ b/phase/gather_facts.go
@@ -32,6 +32,13 @@ func (p *GatherFacts) investigateHost(h *cluster.Host) error {
 		return err
 	}
 	h.Metadata.Arch = output
+
+	id, err := h.Configurer.MachineID(h)
+	if err != nil {
+		return err
+	}
+	h.Metadata.MachineID = id
+
 	p.IncProp(h.Metadata.Arch)
 
 	if extra := h.InstallFlags.GetValue("--kubelet-extra-args"); extra != "" {

--- a/phase/validate_hosts.go
+++ b/phase/validate_hosts.go
@@ -9,7 +9,8 @@ import (
 // ValidateHosts performs remote OS detection
 type ValidateHosts struct {
 	GenericPhase
-	hncount map[string]int
+	hncount        map[string]int
+	machineidcount map[string]int
 }
 
 // Title for the phase
@@ -20,16 +21,26 @@ func (p *ValidateHosts) Title() string {
 // Run the phase
 func (p *ValidateHosts) Run() error {
 	p.hncount = make(map[string]int, len(p.Config.Spec.Hosts))
+	p.machineidcount = make(map[string]int, len(p.Config.Spec.Hosts))
 	for _, h := range p.Config.Spec.Hosts {
 		p.hncount[h.Metadata.Hostname]++
+		p.machineidcount[h.Metadata.MachineID]++
 	}
 
-	return p.parallelDo(p.Config.Spec.Hosts, p.validateUniqueHostname, p.validateSudo)
+	return p.parallelDo(p.Config.Spec.Hosts, p.validateUniqueHostname, p.validateUniqueMachineID, p.validateSudo)
 }
 
 func (p *ValidateHosts) validateUniqueHostname(h *cluster.Host) error {
 	if p.hncount[h.Metadata.Hostname] > 1 {
 		return fmt.Errorf("hostname is not unique: %s", h.Metadata.Hostname)
+	}
+
+	return nil
+}
+
+func (p *ValidateHosts) validateUniqueMachineID(h *cluster.Host) error {
+	if p.machineidcount[h.Metadata.MachineID] > 1 {
+		return fmt.Errorf("machine id %s is not unique: %s", h.Metadata.MachineID, h.Metadata.Hostname)
 	}
 
 	return nil

--- a/pkg/apis/k0sctl.k0sproject.io/v1beta1/cluster/host.go
+++ b/pkg/apis/k0sctl.k0sproject.io/v1beta1/cluster/host.go
@@ -127,6 +127,7 @@ type configurer interface {
 	DeleteDir(os.Host, string, ...exec.Option) error
 	K0sctlLockFilePath(os.Host) string
 	UpsertFile(os.Host, string, string) error
+	MachineID(os.Host) (string, error)
 }
 
 // HostMetadata resolved metadata for host
@@ -138,6 +139,7 @@ type HostMetadata struct {
 	Hostname          string
 	Ready             bool
 	NeedsUpgrade      bool
+	MachineID         string
 }
 
 // UnmarshalYAML sets in some sane defaults when unmarshaling the data from yaml

--- a/smoke-test/smoke.common.sh
+++ b/smoke-test/smoke.common.sh
@@ -10,7 +10,7 @@ function createCluster() {
   footloose create
   if [ "${LINUX_IMAGE}" = "quay.io/footloose/debian10" ]; then
     for host in $(footloose status -o json|grep hostname|cut -d"\"" -f4); do
-      footloose ssh root@${host} -- rm /etc/machine-id
+      footloose ssh root@${host} -- rm -f /etc/machine-id /var/lib/dbus/machine-id
       footloose ssh root@${host} -- systemd-machine-id-setup
     done
   fi

--- a/smoke-test/smoke.common.sh
+++ b/smoke-test/smoke.common.sh
@@ -8,6 +8,12 @@ export K0S_VERSION
 function createCluster() {
   envsubst < "${FOOTLOOSE_TEMPLATE}" > footloose.yaml
   footloose create
+  if [ "${LINUX_IMAGE}" = "quay.io/footloose/debian10" ]; then
+    for host in $(footloose status -o json|grep hostname|cut -d"\"" -f4); do
+      footloose ssh root@${host} -- rm /etc/machine-id
+      footloose ssh root@${host} -- systemd-machine-id-setup
+    done
+  fi
 }
 
 function deleteCluster() {


### PR DESCRIPTION
Signed-off-by: Kimmo Lehto <klehto@mirantis.com>

Fixes #434 

Checks on each host that /etc/machine-id or /var/lib/dbus/machine-id exists and that it is unique.

