### PR TITLE
Use --data-dir from installFlags for token creation

### DIFF
--- a/pkg/apis/k0sctl.k0sproject.io/v1beta1/cluster/k0s.go
+++ b/pkg/apis/k0sctl.k0sproject.io/v1beta1/cluster/k0s.go
@@ -143,6 +143,10 @@ func (k K0s) GenerateToken(h *Host, role string, expiry time.Duration) (string, 
 		k0sFlags.Add(fmt.Sprintf("--config %s", shellescape.Quote(h.K0sConfigPath())))
 	}
 
+	if datadir := h.InstallFlags.GetValue("data-dir"); datadir != "" {
+		k0sFlags.Add(fmt.Sprintf("--data-dir %s", shellescape.Quote(datadir)))
+	}
+
 	var token string
 	err = retry.Do(
 		func() error {


### PR DESCRIPTION
Signed-off-by: Kimmo Lehto <klehto@mirantis.com>

Fixes #436

Looks into host's `installFlags` and copies the `--data-dir` flag into `k0s token create` flags if it is set.
