### PR TITLE
Retire upgrade test from k0s v0.11.0

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -183,7 +183,6 @@ jobs:
           #- quay.io/footloose/debian10
           #- quay.io/footloose/fedora29
         k0s_from:
-          - 0.11.0
           - v1.21.6+k0s.0
     name: Upgrade
     needs: build


### PR DESCRIPTION
Signed-off-by: Kimmo Lehto <klehto@mirantis.com>

Dropping the upgrade smoke-test from k0s 0.11.0 to latest (doesn't seem relevant anymore)
