### PR TITLE
Unify the way k0s binary is installed after upload or download

### DIFF
--- a/cmd/apply.go
+++ b/cmd/apply.go
@@ -75,6 +75,7 @@ var applyCommand = &cli.Command{
 			&phase.ValidateFacts{SkipDowngradeCheck: ctx.Bool("disable-downgrade-check")},
 			&phase.UploadBinaries{},
 			&phase.DownloadK0s{},
+			&phase.InstallBinaries{},
 			&phase.RunHooks{Stage: "before", Action: "apply"},
 			&phase.PrepareArm{},
 			&phase.ConfigureK0s{},

--- a/configurer/linux.go
+++ b/configurer/linux.go
@@ -2,7 +2,6 @@ package configurer
 
 import (
 	"fmt"
-	"path"
 	"regexp"
 	"strconv"
 	"strings"
@@ -112,23 +111,13 @@ func (l Linux) DownloadURL(h os.Host, url, destination string, opts ...exec.Opti
 }
 
 // DownloadK0s performs k0s binary download from github on the host
-func (l Linux) DownloadK0s(h os.Host, version *version.Version, arch string) error {
-	tmp, err := l.TempFile(h)
-	if err != nil {
-		return err
-	}
-	defer func() { _ = h.Execf(`rm -f "%s"`, tmp) }()
-
+func (l Linux) DownloadK0s(h os.Host, path string, version *version.Version, arch string) error {
 	url := fmt.Sprintf("https://github.com/k0sproject/k0s/releases/download/%s/k0s-%s-%s", version, version, arch)
-	if err := l.DownloadURL(h, url, tmp); err != nil {
-		return err
+	if err := l.DownloadURL(h, url, path); err != nil {
+		return fmt.Errorf("download k0s: %w", err)
 	}
 
-	if err := h.Execf(`install -m 0755 -o root -g root -d "%s"`, path.Dir(l.PathFuncs.K0sBinaryPath()), exec.Sudo(h)); err != nil {
-		return err
-	}
-
-	return h.Execf(`install -m 0750 -o root -g root "%s" "%s"`, tmp, l.PathFuncs.K0sBinaryPath(), exec.Sudo(h))
+	return nil
 }
 
 // ReplaceK0sTokenPath replaces the config path in the service stub

--- a/go.sum
+++ b/go.sum
@@ -79,7 +79,6 @@ github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e/go.mod h1:nSuG5e5P
 github.com/chzyer/test v0.0.0-20180213035817-a1ea475d72b1/go.mod h1:Q3SI9o4m/ZMnBNeIyt5eFwwo7qiLfzFZmjNmxjkiQlU=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
 github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
-github.com/cpuguy83/go-md2man/v2 v2.0.0-20190314233015-f79a8a8ca69d/go.mod h1:maD7wRr/U5Z6m/iR4s+kqSMx2CaBsrgA7czyZG/E6dU=
 github.com/cpuguy83/go-md2man/v2 v2.0.2 h1:p1EgwI/C7NhT0JmVkwCD2ZBK8j4aeHQX2pMHHBfMQ6w=
 github.com/cpuguy83/go-md2man/v2 v2.0.2/go.mod h1:tgQtvFlXSQOSOSIRvRPT7W67SCa46tRHOmNcaadrF8o=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
@@ -312,7 +311,6 @@ github.com/rogpeppe/go-internal v1.3.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFR
 github.com/rogpeppe/go-internal v1.6.1/go.mod h1:xXDCJY+GAPziupqXw64V24skbSoqbTEfhy4qGm1nDQc=
 github.com/rogpeppe/go-internal v1.8.0 h1:FCbCCtXNOY3UtUuHUYaghJg4y7Fd14rXifAYUAtL9R8=
 github.com/rogpeppe/go-internal v1.8.0/go.mod h1:WmiCO8CzOY8rg0OYDC4/i/2WRWAB6poM+XZ2dLUbcbE=
-github.com/russross/blackfriday/v2 v2.0.1/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/russross/blackfriday/v2 v2.1.0 h1:JIOH55/0cWyOuilr9/qlrm0BSXldqnqwMsf35Ld67mk=
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/segmentio/analytics-go v3.1.0+incompatible h1:IyiOfUgQFVHvsykKKbdI7ZsH374uv3/DfZUo9+G0Z80=
@@ -321,7 +319,6 @@ github.com/segmentio/backo-go v0.0.0-20200129164019-23eae7c10bd3 h1:ZuhckGJ10ula
 github.com/segmentio/backo-go v0.0.0-20200129164019-23eae7c10bd3/go.mod h1:9/Rh6yILuLysoQnZ2oNooD2g7aBnvM7r/fNVxRNWfBc=
 github.com/shiena/ansicolor v0.0.0-20200904210342-c7312218db18 h1:DAYUYH5869yV94zvCES9F51oYtN5oGlwjxJJz7ZCnik=
 github.com/shiena/ansicolor v0.0.0-20200904210342-c7312218db18/go.mod h1:nkxAfR/5quYxwPZhyDxgasBMnRtBZd0FCEpawpjMUFg=
-github.com/shurcooL/sanitized_anchor_name v1.0.0/go.mod h1:1NzhyTcUVG4SuEtjjoZeVRXNmyL/1OwPU0+IJeTBvfc=
 github.com/sirupsen/logrus v1.8.1 h1:dJKuHgqk1NNQlqoA6BTlM1Wf9DOH3NBjQyu0h9+AZZE=
 github.com/sirupsen/logrus v1.8.1/go.mod h1:yWOB1SBYBC5VeMP7gHvWumXLIWorT60ONWic61uBYv0=
 github.com/spf13/afero v1.2.2/go.mod h1:9ZxEEn6pIJ8Rxe320qSDBk6AsU0r9pR7Q4OcevTdifk=
@@ -341,8 +338,6 @@ github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/
 github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.8.0 h1:pSgiaMZlXftHpm5L7V1+rVB+AZJydKsMxsQBIJw4PKk=
 github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
-github.com/urfave/cli/v2 v2.3.0 h1:qph92Y649prgesehzOrQjdWyxFOp/QVM+6imKHad91M=
-github.com/urfave/cli/v2 v2.3.0/go.mod h1:LJmUH05zAU44vOAcrfzZQKsZbVcdbOG8rtL3/XcUArI=
 github.com/urfave/cli/v2 v2.23.6 h1:iWmtKD+prGo1nKUtLO0Wg4z9esfBM4rAV4QRLQiEmJ4=
 github.com/urfave/cli/v2 v2.23.6/go.mod h1:GHupkWPMM0M/sj1a2b4wUrWBPzazNrIjouW6fmdJLxc=
 github.com/xrash/smetrics v0.0.0-20201216005158-039620a65673 h1:bAn7/zixMGCfxrRTfdpNzjtPYqr8smhKouy9mxVdGPU=
@@ -666,7 +661,6 @@ gopkg.in/inf.v0 v0.9.1/go.mod h1:cWUDdTG/fYaXco+Dcufb5Vnc6Gp2YChqWtbxRZE0mXw=
 gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7/go.mod h1:dt/ZhP58zS4L8KSrWDmTeBkI65Dw0HsyUHuEVlX15mw=
 gopkg.in/yaml.v2 v2.2.1/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
-gopkg.in/yaml.v2 v2.2.3/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.2.4/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.2.8/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.3.0/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=

--- a/phase/install_binaries.go
+++ b/phase/install_binaries.go
@@ -1,0 +1,76 @@
+package phase
+
+import (
+	"fmt"
+
+	"github.com/k0sproject/k0sctl/pkg/apis/k0sctl.k0sproject.io/v1beta1"
+	"github.com/k0sproject/k0sctl/pkg/apis/k0sctl.k0sproject.io/v1beta1/cluster"
+	"github.com/k0sproject/version"
+	"github.com/sirupsen/logrus"
+)
+
+// InstallBinaries installs the k0s binaries from the temp location of UploadBinaries or InstallBinaries
+type InstallBinaries struct {
+	GenericPhase
+	hosts cluster.Hosts
+}
+
+// Title for the phase
+func (p *InstallBinaries) Title() string {
+	return "Install k0s binaries on hosts"
+}
+
+// Prepare the phase
+func (p *InstallBinaries) Prepare(config *v1beta1.Cluster) error {
+	p.Config = config
+	p.hosts = p.Config.Spec.Hosts.Filter(func(h *cluster.Host) bool {
+
+		// Upgrade is handled in UpgradeControllers/UpgradeWorkers phases
+		if h.Metadata.NeedsUpgrade {
+			return false
+		}
+
+		return h.Metadata.K0sBinaryTempFile != ""
+	})
+	return nil
+}
+
+// ShouldRun is true when the phase should be run
+func (p *InstallBinaries) ShouldRun() bool {
+	return len(p.hosts) > 0
+}
+
+// Run the phase
+func (p *InstallBinaries) Run() error {
+	return p.parallelDo(p.hosts, p.installBinary)
+}
+
+func (p *InstallBinaries) installBinary(h *cluster.Host) error {
+	targetVersion, err := version.NewVersion(p.Config.Spec.K0s.Version)
+	if err != nil {
+		return fmt.Errorf("parse k0s version: %w", err)
+	}
+
+	if err := h.UpdateK0sBinary(h.Metadata.K0sBinaryTempFile, targetVersion); err != nil {
+		return fmt.Errorf("failed to install k0s binary: %w", err)
+	}
+
+	return nil
+}
+
+func (p *InstallBinaries) CleanUp() {
+	err := p.parallelDo(p.hosts, func(h *cluster.Host) error {
+		if h.Metadata.K0sBinaryTempFile == "" {
+			return nil
+		}
+		logrus.Infof("%s: cleaning up k0s binary tempfile", h)
+		if err := h.Configurer.DeleteFile(h, h.Metadata.K0sBinaryTempFile); err != nil {
+			return fmt.Errorf("clean up tempfile: %w", err)
+		}
+		return nil
+	})
+
+	if err != nil {
+		logrus.Debugf("failed to clean up tempfiles: %v", err)
+	}
+}

--- a/phase/upload_binaries.go
+++ b/phase/upload_binaries.go
@@ -3,12 +3,9 @@ package phase
 import (
 	"fmt"
 	"os"
-	"path/filepath"
 
 	"github.com/k0sproject/k0sctl/pkg/apis/k0sctl.k0sproject.io/v1beta1"
 	"github.com/k0sproject/k0sctl/pkg/apis/k0sctl.k0sproject.io/v1beta1/cluster"
-	"github.com/k0sproject/rig/exec"
-	"github.com/k0sproject/version"
 	log "github.com/sirupsen/logrus"
 )
 
@@ -37,13 +34,12 @@ func (p *UploadBinaries) Prepare(config *v1beta1.Cluster) error {
 			return false
 		}
 
-		// Upgrade is handled separately (k0s stopped, binary uploaded, k0s restarted)
-		if h.Metadata.NeedsUpgrade {
+		// The version is already correct
+		if h.Metadata.K0sBinaryVersion == p.Config.Spec.K0s.Version {
 			return false
 		}
 
-		// The version is already correct
-		if h.Metadata.K0sBinaryVersion == p.Config.Spec.K0s.Version {
+		if !h.FileChanged(h.UploadBinaryPath, h.Configurer.K0sBinaryPath()) {
 			return false
 		}
 
@@ -62,58 +58,27 @@ func (p *UploadBinaries) Run() error {
 	return p.parallelDoUpload(p.hosts, p.uploadBinary)
 }
 
-func (p *UploadBinaries) ensureBinPath(h *cluster.Host) error {
-	dir := filepath.Dir(h.Configurer.K0sBinaryPath())
-	// FileExist uses "-e" which also works for dirs
-	if h.Configurer.FileExist(h, dir) {
-		return nil
-	}
-	if err := h.Configurer.MkDir(h, dir, exec.Sudo(h)); err != nil {
-		return fmt.Errorf("failed to create %s: %w", dir, err)
-	}
-	if err := h.Configurer.Chmod(h, dir, "0755", exec.Sudo(h)); err != nil {
-		return fmt.Errorf("failed to chmod %s: %w", dir, err)
-	}
-	return nil
-}
-
 func (p *UploadBinaries) uploadBinary(h *cluster.Host) error {
+	tmp, err := h.Configurer.TempFile(h)
+	if err != nil {
+		return fmt.Errorf("failed to create tempfile %w", err)
+	}
+
 	stat, err := os.Stat(h.UploadBinaryPath)
 	if err != nil {
-		return fmt.Errorf("failed to stat %s: %w", h.UploadBinaryPath, err)
-	}
-	if h.FileChanged(h.UploadBinaryPath, h.Configurer.K0sBinaryPath()) {
-		if err := p.ensureBinPath(h); err != nil {
-			return err
-		}
-		log.Infof("%s: uploading k0s binary from %s", h, h.UploadBinaryPath)
-		if err := h.Upload(h.UploadBinaryPath, h.Configurer.K0sBinaryPath(), exec.Sudo(h)); err != nil {
-			return err
-		}
-	} else {
-		log.Infof("%s: k0s binary %s already exists on the target and hasn't been changed, skipping upload", h, h.UploadBinaryPath)
+		return fmt.Errorf("stat %s: %w", h.UploadBinaryPath, err)
 	}
 
-	if err := h.Configurer.Chmod(h, h.Configurer.K0sBinaryPath(), "0700", exec.Sudo(h)); err != nil {
-		return err
+	log.Infof("%s: uploading k0s binary from %s", h, h.UploadBinaryPath)
+	if err := h.Upload(h.UploadBinaryPath, tmp); err != nil {
+		return fmt.Errorf("upload k0s binary: %w", err)
 	}
 
-	log.Debugf("%s: touching %s", h, h.Configurer.K0sBinaryPath())
-	if err := h.Configurer.Touch(h, h.Configurer.K0sBinaryPath(), stat.ModTime(), exec.Sudo(h)); err != nil {
-		return fmt.Errorf("failed to touch %s: %w", h.Configurer.K0sBinaryPath(), err)
+	if err := h.Configurer.Touch(h, tmp, stat.ModTime()); err != nil {
+		return fmt.Errorf("failed to touch %s: %w", tmp, err)
 	}
 
-	uploadedVersion, err := h.Configurer.K0sBinaryVersion(h)
-	if err != nil {
-		return fmt.Errorf("failed to get uploaded k0s binary version: %w", err)
-	}
-
-	h.Metadata.K0sBinaryVersion = uploadedVersion.String()
-	log.Debugf("%s: has k0s binary version %s", h, h.Metadata.K0sBinaryVersion)
-
-	if version, err := version.NewVersion(p.Config.Spec.K0s.Version); err == nil && !version.Equal(uploadedVersion) {
-		return fmt.Errorf("uploaded k0s binary version is %s not %s", uploadedVersion, version)
-	}
+	h.Metadata.K0sBinaryTempFile = tmp
 
 	return nil
 }

--- a/pkg/apis/k0sctl.k0sproject.io/v1beta1/cluster/host.go
+++ b/pkg/apis/k0sctl.k0sproject.io/v1beta1/cluster/host.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	gos "os"
+	"path/filepath"
 	"regexp"
 	"strconv"
 	"strings"
@@ -102,7 +103,7 @@ type configurer interface {
 	ReadFile(os.Host, string) (string, error)
 	FileExist(os.Host, string) bool
 	Chmod(os.Host, string, string, ...exec.Option) error
-	DownloadK0s(os.Host, *version.Version, string) error
+	DownloadK0s(os.Host, string, *version.Version, string) error
 	DownloadURL(os.Host, string, string, ...exec.Option) error
 	InstallPackage(os.Host, ...string) error
 	FileContains(os.Host, string, string) bool
@@ -133,6 +134,7 @@ type configurer interface {
 // HostMetadata resolved metadata for host
 type HostMetadata struct {
 	K0sBinaryVersion  string
+	K0sBinaryTempFile string
 	K0sRunningVersion string
 	Arch              string
 	IsK0sLeader       bool
@@ -321,19 +323,28 @@ func (h *Host) K0sServiceName() string {
 	}
 }
 
+// InstallK0sBinary installs the k0s binary from the provided file path to K0sBinaryPath
+func (h *Host) InstallK0sBinary(path string) error {
+	if !h.Configurer.FileExist(h, path) {
+		return fmt.Errorf("k0s binary tempfile not found")
+	}
+
+	dir := filepath.Dir(h.Configurer.K0sBinaryPath())
+	if err := h.Execf(`install -m 0755 -o root -g root -d "%s"`, dir, exec.Sudo(h)); err != nil {
+		return fmt.Errorf("create k0s binary dir: %w", err)
+	}
+
+	if err := h.Execf(`install -m 0750 -o root -g root "%s" "%s"`, path, h.Configurer.K0sBinaryPath(), exec.Sudo(h)); err != nil {
+		return fmt.Errorf("install k0s binary: %w", err)
+	}
+
+	return nil
+}
+
 // UpdateK0sBinary updates the binary on the host either by downloading or uploading, based on the config
-func (h *Host) UpdateK0sBinary(version *version.Version) error {
-	if h.UploadBinaryPath != "" {
-		if err := h.Upload(h.UploadBinaryPath, h.Configurer.K0sBinaryPath(), exec.Sudo(h)); err != nil {
-			return err
-		}
-		if err := h.Configurer.Chmod(h, h.Configurer.K0sBinaryPath(), "0700", exec.Sudo(h)); err != nil {
-			return err
-		}
-	} else {
-		if err := h.Configurer.DownloadK0s(h, version, h.Metadata.Arch); err != nil {
-			return err
-		}
+func (h *Host) UpdateK0sBinary(path string, version *version.Version) error {
+	if err := h.InstallK0sBinary(path); err != nil {
+		return fmt.Errorf("update k0s binary: %w", err)
 	}
 
 	updatedVersion, err := h.Configurer.K0sBinaryVersion(h)

--- a/pkg/apis/k0sctl.k0sproject.io/v1beta1/cluster/host.go
+++ b/pkg/apis/k0sctl.k0sproject.io/v1beta1/cluster/host.go
@@ -341,7 +341,7 @@ func (h *Host) InstallK0sBinary(path string) error {
 	return nil
 }
 
-// UpdateK0sBinary updates the binary on the host either by downloading or uploading, based on the config
+// UpdateK0sBinary updates the binary on the host from the provided file path
 func (h *Host) UpdateK0sBinary(path string, version *version.Version) error {
 	if err := h.InstallK0sBinary(path); err != nil {
 		return fmt.Errorf("update k0s binary: %w", err)


### PR DESCRIPTION
Signed-off-by: Kimmo Lehto <klehto@mirantis.com>

Before this PR the k0s binary was installed to the `K0sBinaryPath` in three different ways depending on:

* If the file was uploaded from local k0s binary cache to the host
* If the file was downloaded directly to the host from the k0s repository
* If performing an upgrade to a running k0s instance (and also this would branch depending on the two ways to get the binary to the host above)

With this PR, the final binary installation is done using the same function.

This may help with the selinux issue in #440 or at least provides a single place where the selinux permission granting can be done.
