### PR TITLE
Add host.DataDir

### DIFF
--- a/README.md
+++ b/README.md
@@ -308,6 +308,10 @@ A path to a file on the local host that contains a k0s binary to be uploaded to 
 
 Override host's hostname. When not set, the hostname reported by the operating system is used.
 
+###### `spec.hosts[*].dataDir` &lt;string&gt; (optional) (default: `/var/lib/k0s`)
+
+Set host's k0s data-dir.
+
 ###### `spec.hosts[*].installFlags` &lt;sequence&gt; (optional)
 
 Extra flags passed to the `k0s install` command on the target host. See `k0s install --help` for a list of options.

--- a/cmd/backup.go
+++ b/cmd/backup.go
@@ -35,6 +35,7 @@ var backupCommand = &cli.Command{
 			&phase.Connect{},
 			&phase.DetectOS{},
 			lockPhase,
+			&phase.PrepareHosts{},
 			&phase.GatherFacts{},
 			&phase.GatherK0sFacts{},
 			&phase.RunHooks{Stage: "before", Action: "backup"},

--- a/cmd/config_edit.go
+++ b/cmd/config_edit.go
@@ -65,7 +65,7 @@ var configEditCommand = &cli.Command{
 			return err
 		}
 
-		oldCfg, err := h.ExecOutput(h.Configurer.K0sCmdf("kubectl -n kube-system get clusterconfig k0s -o yaml"), exec.Sudo(h))
+		oldCfg, err := h.ExecOutput(h.Configurer.K0sCmdf("kubectl --data-dir=%s -n kube-system get clusterconfig k0s -o yaml", h.DataDir), exec.Sudo(h))
 		if err != nil {
 			return fmt.Errorf("%s: %w", h, err)
 		}
@@ -102,7 +102,7 @@ var configEditCommand = &cli.Command{
 			return fmt.Errorf("configuration was not changed, aborting")
 		}
 
-		if err := h.Exec(h.Configurer.K0sCmdf("kubectl apply -n kube-system -f -"), exec.Stdin(newCfg), exec.Sudo(h)); err != nil {
+		if err := h.Exec(h.Configurer.K0sCmdf("kubectl apply --data-dir=%s -n kube-system -f -", h.DataDir), exec.Stdin(newCfg), exec.Sudo(h)); err != nil {
 			return err
 		}
 

--- a/cmd/config_status.go
+++ b/cmd/config_status.go
@@ -47,7 +47,7 @@ var configStatusCommand = &cli.Command{
 			format = "-o " + format
 		}
 
-		output, err := h.ExecOutput(h.Configurer.K0sCmdf("kubectl -n kube-system get event --field-selector involvedObject.name=k0s %s", format), exec.Sudo(h))
+		output, err := h.ExecOutput(h.Configurer.K0sCmdf("kubectl --data-dir=%s -n kube-system get event --field-selector involvedObject.name=k0s %s", h.DataDir, format), exec.Sudo(h))
 		if err != nil {
 			return fmt.Errorf("%s: %w", h, err)
 		}

--- a/configurer/linux.go
+++ b/configurer/linux.go
@@ -18,6 +18,7 @@ type PathFuncs interface {
 	K0sConfigPath() string
 	K0sJoinTokenPath() string
 	KubeconfigPath(h os.Host) string
+	DataDirDefaultPath() string
 }
 
 // Linux is a base module for various linux OS support packages
@@ -142,6 +143,11 @@ func (l Linux) KubeconfigPath(h os.Host) string {
 		return "/var/lib/k0s/pki/admin.conf"
 	}
 	return "/var/lib/k0s/kubelet.conf"
+}
+
+// DataDirPath returns the location of k0s data dir
+func (l Linux) DataDirDefaultPath() string {
+	return "/var/lib/k0s"
 }
 
 // KubectlCmdf returns a command line in sprintf manner for running kubectl on the host using the kubeconfig from KubeconfigPath

--- a/phase/configure_k0s.go
+++ b/phase/configure_k0s.go
@@ -41,7 +41,7 @@ func (p *ConfigureK0s) Run() error {
 
 		var cmd string
 		if p.leader.Exec(p.leader.Configurer.K0sCmdf("config create --help"), exec.Sudo(p.leader)) == nil {
-			cmd = p.leader.Configurer.K0sCmdf("config create")
+			cmd = p.leader.Configurer.K0sCmdf("config create --data-dir=%s", p.leader.DataDir)
 		} else {
 			cmd = p.leader.Configurer.K0sCmdf("default-config")
 		}

--- a/phase/gather_facts.go
+++ b/phase/gather_facts.go
@@ -3,7 +3,6 @@ package phase
 import (
 	"fmt"
 
-	"github.com/alessio/shellescape"
 	"github.com/k0sproject/k0sctl/pkg/apis/k0sctl.k0sproject.io/v1beta1/cluster"
 	log "github.com/sirupsen/logrus"
 )
@@ -78,11 +77,6 @@ func (p *GatherFacts) investigateHost(h *cluster.Host) error {
 				log.Infof("%s: discovered %s as private address", h, addr)
 			}
 		}
-
-		if datadir := h.InstallFlags.GetValue("data-dir"); datadir != "" {
-			k0sFlags.Add(fmt.Sprintf("--data-dir %s", shellescape.Quote(datadir)))
-		}
-
 	}
 
 	return nil

--- a/phase/gather_facts.go
+++ b/phase/gather_facts.go
@@ -3,6 +3,7 @@ package phase
 import (
 	"fmt"
 
+	"github.com/alessio/shellescape"
 	"github.com/k0sproject/k0sctl/pkg/apis/k0sctl.k0sproject.io/v1beta1/cluster"
 	log "github.com/sirupsen/logrus"
 )
@@ -77,6 +78,11 @@ func (p *GatherFacts) investigateHost(h *cluster.Host) error {
 				log.Infof("%s: discovered %s as private address", h, addr)
 			}
 		}
+
+		if datadir := h.InstallFlags.GetValue("data-dir"); datadir != "" {
+			k0sFlags.Add(fmt.Sprintf("--data-dir %s", shellescape.Quote(datadir)))
+		}
+
 	}
 
 	return nil

--- a/phase/install_controllers.go
+++ b/phase/install_controllers.go
@@ -67,7 +67,7 @@ func (p *InstallControllers) Run() error {
 		}
 		log.Debugf("%s: join token ID: %s", p.leader, tokenID)
 		defer func() {
-			if err := p.leader.Exec(p.leader.Configurer.K0sCmdf("token invalidate %s", tokenID), exec.Sudo(p.leader), exec.RedactString(token)); err != nil {
+			if err := p.leader.Exec(p.leader.Configurer.K0sCmdf("token invalidate --data-dir=%s %s", h.DataDir, tokenID), exec.Sudo(p.leader), exec.RedactString(token)); err != nil {
 				log.Warnf("%s: failed to invalidate the controller join token", p.leader)
 			}
 		}()

--- a/phase/install_workers.go
+++ b/phase/install_workers.go
@@ -85,7 +85,7 @@ func (p *InstallWorkers) Run() error {
 
 	if !NoWait {
 		defer func() {
-			if err := p.leader.Exec(p.leader.Configurer.K0sCmdf("token invalidate %s", tokenID), exec.Sudo(p.leader), exec.RedactString(token)); err != nil {
+			if err := p.leader.Exec(p.leader.Configurer.K0sCmdf("token invalidate --data-dir=%s %s", p.leader.DataDir, tokenID), exec.Sudo(p.leader), exec.RedactString(token)); err != nil {
 				log.Warnf("%s: failed to invalidate the worker join token", p.leader)
 			}
 		}()

--- a/phase/prepare_hosts.go
+++ b/phase/prepare_hosts.go
@@ -3,6 +3,7 @@ package phase
 import (
 	"strings"
 
+	"github.com/alessio/shellescape"
 	"github.com/k0sproject/k0sctl/pkg/apis/k0sctl.k0sproject.io/v1beta1/cluster"
 	"github.com/k0sproject/rig/os"
 	log "github.com/sirupsen/logrus"
@@ -68,6 +69,12 @@ func (p *PrepareHosts) prepareHost(h *cluster.Host) error {
 			return err
 		}
 	}
+
+	if h.DataDir == "" {
+		log.Debugf("%s: data-dir is not set, using default", h)
+		h.DataDir = h.Configurer.DataDirDefaultPath()
+	}
+	h.DataDir = shellescape.Quote(h.DataDir)
 
 	return nil
 }

--- a/phase/reset_controllers.go
+++ b/phase/reset_controllers.go
@@ -106,7 +106,7 @@ func (p *ResetControllers) Run() error {
 		log.Debugf("%s: leaving etcd completed", h)
 
 		log.Debugf("%s: resetting k0s...", h)
-		out, err := h.ExecOutput(h.Configurer.K0sCmdf("reset"), exec.Sudo(h))
+		out, err := h.ExecOutput(h.Configurer.K0sCmdf("reset --data-dir=%s", h.DataDir), exec.Sudo(h))
 		c, _ := semver.NewConstraint("<= 1.22.3+k0s.0")
 		running, _ := semver.NewVersion(h.Metadata.K0sBinaryVersion)
 		if err != nil {

--- a/phase/reset_leader.go
+++ b/phase/reset_leader.go
@@ -52,7 +52,7 @@ func (p *ResetLeader) Run() error {
 	}
 
 	log.Debugf("%s: resetting k0s...", p.leader)
-	out, err := p.leader.ExecOutput(p.leader.Configurer.K0sCmdf("reset"), exec.Sudo(p.leader))
+	out, err := p.leader.ExecOutput(p.leader.Configurer.K0sCmdf("reset --data-dir=%s", p.leader.DataDir), exec.Sudo(p.leader))
 	c, _ := semver.NewConstraint("<= 1.22.3+k0s.0")
 	running, _ := semver.NewVersion(p.leader.Metadata.K0sBinaryVersion)
 	if err != nil {

--- a/phase/reset_workers.go
+++ b/phase/reset_workers.go
@@ -97,7 +97,7 @@ func (p *ResetWorkers) Run() error {
 		}
 
 		log.Debugf("%s: resetting k0s...", h)
-		out, err := h.ExecOutput(h.Configurer.K0sCmdf("reset"), exec.Sudo(h))
+		out, err := h.ExecOutput(h.Configurer.K0sCmdf("reset --data-dir=%s", h.DataDir), exec.Sudo(h))
 		c, _ := semver.NewConstraint("<= 1.22.3+k0s.0")
 		running, _ := semver.NewVersion(h.Metadata.K0sBinaryVersion)
 		if err != nil {

--- a/pkg/apis/k0sctl.k0sproject.io/v1beta1/cluster/host.go
+++ b/pkg/apis/k0sctl.k0sproject.io/v1beta1/cluster/host.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/alessio/shellescape"
 	"github.com/avast/retry-go"
 	"github.com/creasty/defaults"
 	validation "github.com/go-ozzo/ozzo-validation/v4"
@@ -31,6 +32,7 @@ type Host struct {
 	Reset            bool              `yaml:"reset,omitempty"`
 	PrivateInterface string            `yaml:"privateInterface,omitempty"`
 	PrivateAddress   string            `yaml:"privateAddress,omitempty"`
+	DataDir          string            `yaml:"dataDir,omitempty"`
 	Environment      map[string]string `yaml:"environment,flow,omitempty"`
 	UploadBinary     bool              `yaml:"uploadBinary,omitempty"`
 	K0sBinaryPath    string            `yaml:"k0sBinaryPath,omitempty"`
@@ -65,6 +67,17 @@ func (h *Host) SetDefaults() {
 	if h.InstallFlags.Get("--no-taints") != "" && h.InstallFlags.GetValue("--no-taints") != "false" {
 		h.NoTaints = true
 	}
+
+	if dd := h.InstallFlags.Get("--data-dir"); dd != "" {
+		if h.DataDir != "" {
+			log.Debugf("%s: changed dataDir from '%s' to '%s' because of --data-dir installFlag", h, h.DataDir, dd)
+		}
+		h.InstallFlags.Delete("--data-dir")
+		h.DataDir = dd
+	} else if h.DataDir == "" {
+		h.DataDir = h.Configurer.DataDirDefaultPath()
+	}
+	h.DataDir = shellescape.Quote(h.DataDir)
 }
 
 func (h *Host) Validate() error {
@@ -94,6 +107,7 @@ type configurer interface {
 	K0sBinaryPath() string
 	K0sBinaryVersion(os.Host) (*version.Version, error)
 	K0sConfigPath() string
+	DataDirDefaultPath() string
 	K0sJoinTokenPath() string
 	WriteFile(os.Host, string, string, string) error
 	UpdateEnvironment(os.Host, map[string]string) error
@@ -247,6 +261,8 @@ func (h *Host) K0sInstallCommand() (string, error) {
 	role := h.Role
 	flags := h.InstallFlags
 
+	flags.AddOrReplace(fmt.Sprintf("--data-dir=%s", h.DataDir))
+
 	switch role {
 	case "controller+worker":
 		role = "controller"
@@ -300,12 +316,12 @@ func (h *Host) K0sInstallCommand() (string, error) {
 
 // K0sBackupCommand returns a full command to be used as run k0s backup
 func (h *Host) K0sBackupCommand(targetDir string) string {
-	return h.Configurer.K0sCmdf("backup --save-path %s", targetDir)
+	return h.Configurer.K0sCmdf("backup --save-path %s --data-dir %s", shellescape.Quote(targetDir), h.DataDir)
 }
 
 // K0sRestoreCommand returns a full command to restore cluster state from a backup
 func (h *Host) K0sRestoreCommand(backupfile string) string {
-	return h.Configurer.K0sCmdf("restore %s", backupfile)
+	return h.Configurer.K0sCmdf("restore --data-dir=%s %s", h.DataDir, shellescape.Quote(backupfile))
 }
 
 // IsController returns true for controller and controller+worker roles
@@ -373,7 +389,7 @@ type kubeNodeStatus struct {
 
 // KubeNodeReady runs kubectl on the host and returns true if the given node is marked as ready
 func (h *Host) KubeNodeReady() (bool, error) {
-	output, err := h.ExecOutput(h.Configurer.KubectlCmdf(h, "get node -l kubernetes.io/hostname=%s -o json", h.Metadata.Hostname), exec.HideOutput(), exec.Sudo(h))
+	output, err := h.ExecOutput(h.Configurer.KubectlCmdf(h, "get node --data-dir=%s -l kubernetes.io/hostname=%s -o json", h.DataDir, h.Metadata.Hostname), exec.HideOutput(), exec.Sudo(h))
 	if err != nil {
 		return false, err
 	}
@@ -418,17 +434,17 @@ func (h *Host) WaitKubeNodeReady() error {
 
 // DrainNode drains the given node
 func (h *Host) DrainNode(node *Host) error {
-	return h.Exec(h.Configurer.KubectlCmdf(h, "drain --grace-period=120 --force --timeout=5m --ignore-daemonsets --delete-local-data %s", node.Metadata.Hostname), exec.Sudo(h))
+	return h.Exec(h.Configurer.KubectlCmdf(h, "drain --data-dir=%s --grace-period=120 --force --timeout=5m --ignore-daemonsets --delete-local-data %s", h.DataDir, node.Metadata.Hostname), exec.Sudo(h))
 }
 
 // UncordonNode marks the node schedulable again
 func (h *Host) UncordonNode(node *Host) error {
-	return h.Exec(h.Configurer.KubectlCmdf(h, "uncordon %s", node.Metadata.Hostname), exec.Sudo(h))
+	return h.Exec(h.Configurer.KubectlCmdf(h, "uncordon --data-dir=%s %s", h.DataDir, node.Metadata.Hostname), exec.Sudo(h))
 }
 
 // DeleteNode deletes the given node from kubernetes
 func (h *Host) DeleteNode(node *Host) error {
-	return h.Exec(h.Configurer.KubectlCmdf(h, "delete node %s", node.Metadata.Hostname), exec.Sudo(h))
+	return h.Exec(h.Configurer.KubectlCmdf(h, "delete node --data-dir=%s %s", h.DataDir, node.Metadata.Hostname), exec.Sudo(h))
 }
 
 func (h *Host) LeaveEtcd(node *Host) error {
@@ -436,7 +452,7 @@ func (h *Host) LeaveEtcd(node *Host) error {
 	if node.PrivateAddress != "" {
 		etcdAddress = node.PrivateAddress
 	}
-	return h.Exec(h.Configurer.K0sCmdf("etcd leave --peer-address %s", etcdAddress), exec.Sudo(h))
+	return h.Exec(h.Configurer.K0sCmdf("etcd leave --peer-address %s --datadir %s", etcdAddress, h.DataDir), exec.Sudo(h))
 }
 
 // CheckHTTPStatus will perform a web request to the url and return an error if the http status is not the expected

--- a/pkg/apis/k0sctl.k0sproject.io/v1beta1/cluster/host.go
+++ b/pkg/apis/k0sctl.k0sproject.io/v1beta1/cluster/host.go
@@ -74,10 +74,7 @@ func (h *Host) SetDefaults() {
 		}
 		h.InstallFlags.Delete("--data-dir")
 		h.DataDir = dd
-	} else if h.DataDir == "" {
-		h.DataDir = h.Configurer.DataDirDefaultPath()
 	}
-	h.DataDir = shellescape.Quote(h.DataDir)
 }
 
 func (h *Host) Validate() error {

--- a/pkg/apis/k0sctl.k0sproject.io/v1beta1/cluster/host_test.go
+++ b/pkg/apis/k0sctl.k0sproject.io/v1beta1/cluster/host_test.go
@@ -75,47 +75,47 @@ func TestUnQE(t *testing.T) {
 }
 
 func TestK0sInstallCommand(t *testing.T) {
-	h := Host{Role: "worker"}
+	h := Host{Role: "worker", DataDir: "/tmp/k0s"}
 	h.Configurer = &mockconfigurer{}
 
 	cmd, err := h.K0sInstallCommand()
 	require.NoError(t, err)
-	require.Equal(t, `k0s install worker --token-file "from-configurer"`, cmd)
+	require.Equal(t, `k0s install worker --data-dir=/tmp/k0s --token-file "from-configurer"`, cmd)
 
 	h.Role = "controller"
 	h.Metadata.IsK0sLeader = true
 	cmd, err = h.K0sInstallCommand()
 	require.NoError(t, err)
-	require.Equal(t, `k0s install controller --config "from-configurer"`, cmd)
+	require.Equal(t, `k0s install controller --data-dir=/tmp/k0s --config "from-configurer"`, cmd)
 
 	h.Metadata.IsK0sLeader = false
 	cmd, err = h.K0sInstallCommand()
 	require.NoError(t, err)
-	require.Equal(t, `k0s install controller --token-file "from-configurer" --config "from-configurer"`, cmd)
+	require.Equal(t, `k0s install controller --data-dir=/tmp/k0s --token-file "from-configurer" --config "from-configurer"`, cmd)
 
 	h.Role = "controller+worker"
 	h.Metadata.IsK0sLeader = true
 	cmd, err = h.K0sInstallCommand()
 	require.NoError(t, err)
-	require.Equal(t, `k0s install controller --enable-worker --config "from-configurer"`, cmd)
+	require.Equal(t, `k0s install controller --data-dir=/tmp/k0s --enable-worker --config "from-configurer"`, cmd)
 	h.Metadata.IsK0sLeader = false
 	cmd, err = h.K0sInstallCommand()
 	require.NoError(t, err)
-	require.Equal(t, `k0s install controller --enable-worker --token-file "from-configurer" --config "from-configurer"`, cmd)
+	require.Equal(t, `k0s install controller --data-dir=/tmp/k0s --enable-worker --token-file "from-configurer" --config "from-configurer"`, cmd)
 
 	h.Role = "worker"
 	h.PrivateAddress = "10.0.0.9"
 	cmd, err = h.K0sInstallCommand()
 	require.NoError(t, err)
-	require.Equal(t, `k0s install worker --token-file "from-configurer" --kubelet-extra-args="--node-ip=10.0.0.9"`, cmd)
+	require.Equal(t, `k0s install worker --data-dir=/tmp/k0s --token-file "from-configurer" --kubelet-extra-args="--node-ip=10.0.0.9"`, cmd)
 
 	h.InstallFlags = []string{`--kubelet-extra-args="--foo bar"`}
 	cmd, err = h.K0sInstallCommand()
 	require.NoError(t, err)
-	require.Equal(t, `k0s install worker --kubelet-extra-args="--foo bar --node-ip=10.0.0.9" --token-file "from-configurer"`, cmd)
+	require.Equal(t, `k0s install worker --kubelet-extra-args="--foo bar --node-ip=10.0.0.9" --data-dir=/tmp/k0s --token-file "from-configurer"`, cmd)
 
 	h.InstallFlags = []string{`--enable-cloud-provider`}
 	cmd, err = h.K0sInstallCommand()
 	require.NoError(t, err)
-	require.Equal(t, `k0s install worker --enable-cloud-provider --token-file "from-configurer"`, cmd)
+	require.Equal(t, `k0s install worker --enable-cloud-provider --data-dir=/tmp/k0s --token-file "from-configurer"`, cmd)
 }

--- a/pkg/apis/k0sctl.k0sproject.io/v1beta1/cluster/k0s.go
+++ b/pkg/apis/k0sctl.k0sproject.io/v1beta1/cluster/k0s.go
@@ -143,9 +143,7 @@ func (k K0s) GenerateToken(h *Host, role string, expiry time.Duration) (string, 
 		k0sFlags.Add(fmt.Sprintf("--config %s", shellescape.Quote(h.K0sConfigPath())))
 	}
 
-	if datadir := h.InstallFlags.GetValue("data-dir"); datadir != "" {
-		k0sFlags.Add(fmt.Sprintf("--data-dir %s", shellescape.Quote(datadir)))
-	}
+	k0sFlags.AddOrReplace(fmt.Sprintf("--data-dir=%s", h.DataDir))
 
 	var token string
 	err = retry.Do(
@@ -168,7 +166,7 @@ func (k K0s) GenerateToken(h *Host, role string, expiry time.Duration) (string, 
 
 // GetClusterID uses kubectl to fetch the kube-system namespace uid
 func (k K0s) GetClusterID(h *Host) (string, error) {
-	return h.ExecOutput(h.Configurer.KubectlCmdf(h, "get -n kube-system namespace kube-system -o template={{.metadata.uid}}"), exec.Sudo(h))
+	return h.ExecOutput(h.Configurer.KubectlCmdf(h, "get --data-dir=%s -n kube-system namespace kube-system -o template={{.metadata.uid}}", h.DataDir), exec.Sudo(h))
 }
 
 // TokenID returns a token id from a token string that can be used to invalidate the token


### PR DESCRIPTION
Signed-off-by: Kimmo Lehto <klehto@mirantis.com>

Adds `spec.hosts[*].dataDir` which defaults to `h.Configurer.DataDirDefaultPath()` (`/var/lib/k0s` for now).

It is used in all k0s commands that support it.
