### PR TITLE
Validate host private address uniqueness

### DIFF
--- a/phase/validate_hosts.go
+++ b/phase/validate_hosts.go
@@ -9,8 +9,9 @@ import (
 // ValidateHosts performs remote OS detection
 type ValidateHosts struct {
 	GenericPhase
-	hncount        map[string]int
-	machineidcount map[string]int
+	hncount          map[string]int
+	machineidcount   map[string]int
+	privateaddrcount map[string]int
 }
 
 // Title for the phase
@@ -25,6 +26,7 @@ func (p *ValidateHosts) Run() error {
 	for _, h := range p.Config.Spec.Hosts {
 		p.hncount[h.Metadata.Hostname]++
 		p.machineidcount[h.Metadata.MachineID]++
+		p.privateaddrcount[h.PrivateAddress]++
 	}
 
 	return p.parallelDo(p.Config.Spec.Hosts, p.validateUniqueHostname, p.validateUniqueMachineID, p.validateSudo)
@@ -33,6 +35,14 @@ func (p *ValidateHosts) Run() error {
 func (p *ValidateHosts) validateUniqueHostname(h *cluster.Host) error {
 	if p.hncount[h.Metadata.Hostname] > 1 {
 		return fmt.Errorf("hostname is not unique: %s", h.Metadata.Hostname)
+	}
+
+	return nil
+}
+
+func (p *ValidateHosts) validateUniquePrivateAddress(h *cluster.Host) error {
+	if p.privateaddrcount[h.PrivateAddress] > 1 {
+		return fmt.Errorf("privateAddress %s is not unique: %s", h.PrivateAddress, h.Metadata.Hostname)
 	}
 
 	return nil

--- a/phase/validate_hosts.go
+++ b/phase/validate_hosts.go
@@ -23,6 +23,8 @@ func (p *ValidateHosts) Title() string {
 func (p *ValidateHosts) Run() error {
 	p.hncount = make(map[string]int, len(p.Config.Spec.Hosts))
 	p.machineidcount = make(map[string]int, len(p.Config.Spec.Hosts))
+	p.privateaddrcount = make(map[string]int, len(p.Config.Spec.Hosts))
+
 	for _, h := range p.Config.Spec.Hosts {
 		p.hncount[h.Metadata.Hostname]++
 		p.machineidcount[h.Metadata.MachineID]++

--- a/phase/validate_hosts.go
+++ b/phase/validate_hosts.go
@@ -29,7 +29,13 @@ func (p *ValidateHosts) Run() error {
 		p.privateaddrcount[h.PrivateAddress]++
 	}
 
-	return p.parallelDo(p.Config.Spec.Hosts, p.validateUniqueHostname, p.validateUniqueMachineID, p.validateSudo)
+	return p.parallelDo(
+		p.Config.Spec.Hosts,
+		p.validateUniqueHostname,
+		p.validateUniqueMachineID,
+		p.validateUniquePrivateAddress,
+		p.validateSudo,
+	)
 }
 
 func (p *ValidateHosts) validateUniqueHostname(h *cluster.Host) error {


### PR DESCRIPTION
Signed-off-by: Kimmo Lehto <klehto@mirantis.com>

Fixes #451 

Gives a validation error in `Validate Hosts` phase unless all private addresses are unique.
