### PR TITLE
fix: localhost panic nil pointer dereference

### DIFF
--- a/pkg/apis/k0sctl.k0sproject.io/v1beta1/cluster/host.go
+++ b/pkg/apis/k0sctl.k0sproject.io/v1beta1/cluster/host.go
@@ -166,7 +166,7 @@ func (h *Host) UnmarshalYAML(unmarshal func(interface{}) error) error {
 		return err
 	}
 
-	if h.SSH.HostKey != "" {
+	if h.SSH != nil && h.SSH.HostKey != "" {
 		log.Warnf("%s: host.ssh.hostKey is deprecated, use a ssh known hosts file instead", h)
 	}
 


### PR DESCRIPTION
Using localhost connection options I get the following runtime error: invalid memory address or nil pointer dereference

```
$ k0sctl apply --debug -c k0s-cluster.yaml
DEBU[0000] Loaded configuration:
apiVersion: k0sctl.k0sproject.io/v1beta1
kind: Cluster
metadata:
  name: k0s
spec:
  hosts:
  - localhost:
      enabled: true
    role: controller
DEBU[0000] upgrade check failed: failed to get the latest version information
FATA[0000] PANIC: runtime error: invalid memory address or nil pointer dereference
```