### PR TITLE
Use /usr/local/bin on CoreOS

### DIFF
--- a/configurer/linux/coreos.go
+++ b/configurer/linux/coreos.go
@@ -2,11 +2,12 @@ package linux
 
 import (
 	"errors"
+	"strings"
+
 	"github.com/k0sproject/k0sctl/configurer"
 	"github.com/k0sproject/rig"
 	"github.com/k0sproject/rig/os"
 	"github.com/k0sproject/rig/os/registry"
-	"strings"
 )
 
 // CoreOS provides OS support for ostree based Fedora & RHEL systems
@@ -18,7 +19,7 @@ type CoreOS struct {
 func init() {
 	registry.RegisterOSModule(
 		func(os rig.OSVersion) bool {
-			return os.ID == "fedora" && strings.Contains(os.Name, "CoreOS") || os.ID == "rhel" && strings.Contains(os.Name, "CoreOS")
+			return strings.Contains(os.Name, "CoreOS") && (os.ID == "fedora" || os.ID == "rhel")
 		},
 		func() interface{} {
 			linuxType := &CoreOS{}
@@ -30,8 +31,4 @@ func init() {
 
 func (l CoreOS) InstallPackage(h os.Host, pkg ...string) error {
 	return errors.New("CoreOS does not support installing packages manually")
-}
-
-func (l CoreOS) K0sBinaryPath() string {
-	return "/opt/bin/k0s"
 }


### PR DESCRIPTION
Signed-off-by: Kimmo Lehto <klehto@mirantis.com>

Use `/usr/local/bin/k0s` instead of `/opt/bin/k0s` on CoreOS to solve some of the SELinux issues #440. A subset of #448.
