### PR TITLE
Ignore missing k0s binary on reset and avoid panic

### DIFF
--- a/phase/reset_controllers.go
+++ b/phase/reset_controllers.go
@@ -1,9 +1,6 @@
 package phase
 
 import (
-	"strings"
-
-	"github.com/Masterminds/semver"
 	"github.com/k0sproject/k0sctl/pkg/apis/k0sctl.k0sproject.io/v1beta1"
 	"github.com/k0sproject/k0sctl/pkg/apis/k0sctl.k0sproject.io/v1beta1/cluster"
 	"github.com/k0sproject/rig/exec"
@@ -107,13 +104,9 @@ func (p *ResetControllers) Run() error {
 
 		log.Debugf("%s: resetting k0s...", h)
 		out, err := h.ExecOutput(h.Configurer.K0sCmdf("reset --data-dir=%s", h.DataDir), exec.Sudo(h))
-		c, _ := semver.NewConstraint("<= 1.22.3+k0s.0")
-		running, _ := semver.NewVersion(h.Metadata.K0sBinaryVersion)
 		if err != nil {
+			log.Debugf("%s: k0s reset failed: %s", h, out)
 			log.Warnf("%s: k0s reported failure: %v", h, err)
-			if c.Check(running) && !strings.Contains(out, "k0s cleanup operations done") {
-				log.Warnf("%s: k0s reset failed, trying k0s cleanup", h)
-			}
 		}
 		log.Debugf("%s: resetting k0s completed", h)
 

--- a/phase/reset_leader.go
+++ b/phase/reset_leader.go
@@ -1,9 +1,6 @@
 package phase
 
 import (
-	"strings"
-
-	"github.com/Masterminds/semver"
 	"github.com/k0sproject/k0sctl/pkg/apis/k0sctl.k0sproject.io/v1beta1"
 	"github.com/k0sproject/k0sctl/pkg/apis/k0sctl.k0sproject.io/v1beta1/cluster"
 	"github.com/k0sproject/rig/exec"
@@ -53,13 +50,9 @@ func (p *ResetLeader) Run() error {
 
 	log.Debugf("%s: resetting k0s...", p.leader)
 	out, err := p.leader.ExecOutput(p.leader.Configurer.K0sCmdf("reset --data-dir=%s", p.leader.DataDir), exec.Sudo(p.leader))
-	c, _ := semver.NewConstraint("<= 1.22.3+k0s.0")
-	running, _ := semver.NewVersion(p.leader.Metadata.K0sBinaryVersion)
 	if err != nil {
+		log.Debugf("%s: k0s reset failed: %s", p.leader, out)
 		log.Warnf("%s: k0s reported failure: %v", p.leader, err)
-		if c.Check(running) && !strings.Contains(out, "k0s cleanup operations done") {
-			log.Warnf("%s: k0s reset failed, trying k0s cleanup", p.leader)
-		}
 	}
 	log.Debugf("%s: resetting k0s completed", p.leader)
 

--- a/phase/reset_workers.go
+++ b/phase/reset_workers.go
@@ -1,9 +1,6 @@
 package phase
 
 import (
-	"strings"
-
-	"github.com/Masterminds/semver"
 	"github.com/k0sproject/k0sctl/pkg/apis/k0sctl.k0sproject.io/v1beta1"
 	"github.com/k0sproject/k0sctl/pkg/apis/k0sctl.k0sproject.io/v1beta1/cluster"
 	"github.com/k0sproject/rig/exec"
@@ -98,13 +95,9 @@ func (p *ResetWorkers) Run() error {
 
 		log.Debugf("%s: resetting k0s...", h)
 		out, err := h.ExecOutput(h.Configurer.K0sCmdf("reset --data-dir=%s", h.DataDir), exec.Sudo(h))
-		c, _ := semver.NewConstraint("<= 1.22.3+k0s.0")
-		running, _ := semver.NewVersion(h.Metadata.K0sBinaryVersion)
 		if err != nil {
+			log.Debugf("%s: k0s reset failed: %s", h, out)
 			log.Warnf("%s: k0s reported failure: %v", h, err)
-			if c.Check(running) && !strings.Contains(out, "k0s cleanup operations done") {
-				log.Warnf("%s: k0s reset failed, trying k0s cleanup", h)
-			}
 		}
 		log.Debugf("%s: resetting k0s completed", h)
 


### PR DESCRIPTION
Fixes #464 

The version constraint was some remnant from an earlier version when it was necessary to ignore a non-zero exit code on certain versions of k0s. It has been ignoring the error for a while anyway and just continued onwards.

Here the problem was that the semver returned nil (error was not checked), which made the condition after it panic.
