### PR TITLE
Revert "Use /usr/local/bin on Flatcar (#460)"

### DIFF
--- a/configurer/linux/flatcar.go
+++ b/configurer/linux/flatcar.go
@@ -30,3 +30,7 @@ func init() {
 func (l Flatcar) InstallPackage(h os.Host, pkg ...string) error {
 	return errors.New("FlatcarContainerLinux does not support installing packages manually")
 }
+
+func (l Flatcar) K0sBinaryPath() string {
+	return "/opt/bin/k0s"
+}

--- a/configurer/linux/linux_test.go
+++ b/configurer/linux/linux_test.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/k0sproject/k0sctl/configurer"
 	"github.com/k0sproject/rig/exec"
-	"github.com/k0sproject/rig/os"
 	"github.com/stretchr/testify/require"
 )
 
@@ -45,19 +44,9 @@ func (m mockHost) Sudo(string) (string, error) {
 	return "", nil
 }
 
-type custompaths struct {
-	BaseLinux
-}
-
-func (l custompaths) InstallPackage(_ os.Host, pkg ...string) error {
-	return nil
-}
-func (l custompaths) K0sBinaryPath() string {
-	return "/opt/bin/k0s"
-}
-
+// TestPaths tests the slightly weird way to perform function overloading
 func TestPaths(t *testing.T) {
-	fc := &custompaths{}
+	fc := &Flatcar{}
 	fc.PathFuncs = interface{}(fc).(configurer.PathFuncs)
 
 	ubuntu := &Ubuntu{}


### PR DESCRIPTION
This reverts commit 7801b9aab7c6e81157d1a047a973dd50f392eff4.

Fixes #495 