### PR TITLE
Enable analytics only when started from cmd/

### DIFF
--- a/analytics/analytics.go
+++ b/analytics/analytics.go
@@ -1,9 +1,5 @@
 package analytics
 
-import (
-	log "github.com/sirupsen/logrus"
-)
-
 type publisher interface {
 	Publish(string, map[string]interface{})
 	Close()
@@ -21,9 +17,7 @@ func (c *NullClient) Initialize() error {
 }
 
 // Publish would send a tracking event
-func (c *NullClient) Publish(event string, props map[string]interface{}) {
-	log.Tracef("analytics event %s - properties: %+v", event, props)
-}
+func (c *NullClient) Publish(_ string, _ map[string]interface{}) {}
 
 // Close the analytics connection
 func (c *NullClient) Close() {}

--- a/cmd/flags.go
+++ b/cmd/flags.go
@@ -169,18 +169,15 @@ func warnOldCache(_ *cli.Context) error {
 	return nil
 }
 
+const segmentWriteKey string = "oU2iC4shRUBfEboaO0FDuDIUk49Ime92"
+
 func initAnalytics(ctx *cli.Context) error {
 	if ctx.Bool("disable-telemetry") {
 		log.Tracef("disabling telemetry")
 		return nil
 	}
 
-	if segment.WriteKey == "" {
-		log.Tracef("segment write key not set, analytics disabled")
-		return nil
-	}
-
-	client, err := segment.NewClient()
+	client, err := segment.NewClient(segmentWriteKey)
 	if err != nil {
 		return err
 	}

--- a/integration/segment/segment.go
+++ b/integration/segment/segment.go
@@ -9,9 +9,6 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
-// WriteKey for analytics
-const WriteKey string = "oU2iC4shRUBfEboaO0FDuDIUk49Ime92"
-
 // Verbose controls the verbosity of segment analytics client
 var Verbose bool
 
@@ -35,8 +32,8 @@ type Client struct {
 }
 
 // NewClient returns a new segment analytics client
-func NewClient() (*Client, error) {
-	client, err := segment.NewWithConfig(WriteKey, segment.Config{Verbose: Verbose})
+func NewClient(writeKey string) (*Client, error) {
+	client, err := segment.NewWithConfig(writeKey, segment.Config{Verbose: Verbose})
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Fixes #505 

Moves the hardcoded segment write key for analytics to cli initAnalytics function. This way the analytics will only be enabled when the actions are triggered from the CLI commands, not when reused as a library.
