### PR TITLE
Use go 1.18 BuildInfo for version when installed using go install

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -41,6 +41,7 @@ require (
 
 require (
 	github.com/alessio/shellescape v1.4.1
+	github.com/carlmjohnson/versioninfo v0.22.4
 	github.com/go-ozzo/ozzo-validation/v4 v4.3.0
 	github.com/go-playground/validator/v10 v10.14.1
 	github.com/k0sproject/version v0.3.0

--- a/go.sum
+++ b/go.sum
@@ -28,6 +28,8 @@ github.com/bmatcuk/doublestar/v4 v4.6.0 h1:HTuxyug8GyFbRkrffIpzNCSK4luc0TY3wzXvz
 github.com/bmatcuk/doublestar/v4 v4.6.0/go.mod h1:xBQ8jztBU6kakFMg+8WGxn0c6z1fTSPVIjEY1Wr7jzc=
 github.com/bmizerany/assert v0.0.0-20160611221934-b7ed37b82869 h1:DDGfHa7BWjL4YnC6+E63dPcxHo2sUxDIu8g3QgEJdRY=
 github.com/bmizerany/assert v0.0.0-20160611221934-b7ed37b82869/go.mod h1:Ekp36dRnpXw/yCqJaO+ZrUyxD+3VXMFFr56k5XYrpB4=
+github.com/carlmjohnson/versioninfo v0.22.4 h1:AucUHDSKmk6j7Yx3dECGUxaowGHOAN0Zx5/EBtsXn4Y=
+github.com/carlmjohnson/versioninfo v0.22.4/go.mod h1:QT9mph3wcVfISUKd0i9sZfVrPviHuSF+cUtLjm2WSf8=
 github.com/cpuguy83/go-md2man/v2 v2.0.2 h1:p1EgwI/C7NhT0JmVkwCD2ZBK8j4aeHQX2pMHHBfMQ6w=
 github.com/cpuguy83/go-md2man/v2 v2.0.2/go.mod h1:tgQtvFlXSQOSOSIRvRPT7W67SCa46tRHOmNcaadrF8o=
 github.com/creack/pty v1.1.17 h1:QeVUsEDNrLBW4tMgZHvxy18sKtr6VI492kBhUfhDJNI=

--- a/version/version.go
+++ b/version/version.go
@@ -1,12 +1,16 @@
 package version
 
-import "strings"
+import (
+	"strings"
+
+	"github.com/carlmjohnson/versioninfo"
+)
 
 var (
 	// Version of the product, is set during the build
-	Version = "0.0.0"
+	Version = versioninfo.Version
 	// GitCommit is set during the build
-	GitCommit = "HEAD"
+	GitCommit = versioninfo.Revision
 	// Environment of the product, is set during the build
 	Environment = "development"
 )


### PR DESCRIPTION
Fixes #479 

Go 1.18 added `debug.ReadBuildInfo()` which can be used to get the version number. This PR uses the wrapper at github.com/carlmjohnson/versioninfo to utilize that information.

This shouldn't have any effect on how the version is set when using make in the release pipeline.
