### PR TITLE
Ignore v-prefix when comparing k0s versions

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -32,7 +32,7 @@ jobs:
       uses: golangci/golangci-lint-action@v3.6.0
       with:
         version: latest
-        timeout: 10m
+        args: --timeout=30m
 
     - name: Build
       run: make k0sctl

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -32,6 +32,7 @@ jobs:
       uses: golangci/golangci-lint-action@v3.6.0
       with:
         version: latest
+        timeout: 10m
 
     - name: Build
       run: make k0sctl

--- a/phase/download_k0s.go
+++ b/phase/download_k0s.go
@@ -35,7 +35,7 @@ func (p *DownloadK0s) Prepare(config *v1beta1.Cluster) error {
 		}
 
 		// The version is already correct
-		if h.Metadata.K0sBinaryVersion == p.Config.Spec.K0s.Version {
+		if p.Config.Spec.K0s.VersionEquals(h.Metadata.K0sBinaryVersion) {
 			return false
 		}
 

--- a/phase/download_k0s.go
+++ b/phase/download_k0s.go
@@ -23,24 +23,30 @@ func (p *DownloadK0s) Title() string {
 // Prepare the phase
 func (p *DownloadK0s) Prepare(config *v1beta1.Cluster) error {
 	p.Config = config
+
 	p.hosts = p.Config.Spec.Hosts.Filter(func(h *cluster.Host) bool {
-		// Nothing to upload
+		// Nothing to download
 		if h.UploadBinary {
 			return false
 		}
 
-		// Nothing to upload
+		// No need to download, host is going to be reset
 		if h.Reset {
 			return false
 		}
 
 		// The version is already correct
-		if p.Config.Spec.K0s.VersionEquals(h.Metadata.K0sBinaryVersion) {
+		err := p.Config.Spec.K0s.VersionMustEqual(h.Metadata.K0sBinaryVersion)
+		if err == nil {
+			log.Debugf("%s: k0s version on target host is already %s", h, h.Metadata.K0sBinaryVersion)
 			return false
 		}
 
+		log.Debugf("%s: %v", h, err)
+
 		return true
 	})
+
 	return nil
 }
 

--- a/phase/upload_binaries.go
+++ b/phase/upload_binaries.go
@@ -35,7 +35,7 @@ func (p *UploadBinaries) Prepare(config *v1beta1.Cluster) error {
 		}
 
 		// The version is already correct
-		if h.Metadata.K0sBinaryVersion == p.Config.Spec.K0s.Version {
+		if p.Config.Spec.K0s.VersionEquals(h.Metadata.K0sBinaryVersion) {
 			return false
 		}
 

--- a/phase/upload_binaries.go
+++ b/phase/upload_binaries.go
@@ -29,21 +29,19 @@ func (p *UploadBinaries) Prepare(config *v1beta1.Cluster) error {
 			return false
 		}
 
-		// Nothing to upload
+		// No need to upload, host is going to be reset
 		if h.Reset {
 			return false
 		}
 
-		// The version is already correct
-		if p.Config.Spec.K0s.VersionEquals(h.Metadata.K0sBinaryVersion) {
-			return false
+		// The version on target is incorrect
+		if err := p.Config.Spec.K0s.VersionMustEqual(h.Metadata.K0sBinaryVersion); err != nil {
+			log.Debugf("%s: %v", h, err)
+			return true
 		}
 
-		if !h.FileChanged(h.UploadBinaryPath, h.Configurer.K0sBinaryPath()) {
-			return false
-		}
-
-		return true
+		// If the file has been changed compared to local, re-upload and replace
+		return h.FileChanged(h.UploadBinaryPath, h.Configurer.K0sBinaryPath())
 	})
 	return nil
 }

--- a/pkg/apis/k0sctl.k0sproject.io/v1beta1/cluster/k0s.go
+++ b/pkg/apis/k0sctl.k0sproject.io/v1beta1/cluster/k0s.go
@@ -169,9 +169,32 @@ func (k K0s) GetClusterID(h *Host) (string, error) {
 	return h.ExecOutput(h.Configurer.KubectlCmdf(h, "get --data-dir=%s -n kube-system namespace kube-system -o template={{.metadata.uid}}", h.DataDir), exec.Sudo(h))
 }
 
-// VersionEquals returns true when the k0s version is equal to a given version
-func (k K0s) VersionEquals(b string) bool {
-	return strings.TrimPrefix(k.Version, "v") == strings.TrimPrefix(b, "v")
+// VersionMustEqual returns an error if the k0s version in the struct does not match the given version or
+// if either of the version strings can't be parsed
+func (k K0s) VersionMustEqual(b string) error {
+	if k.Version == "" {
+		return fmt.Errorf("k0s version not set")
+	}
+
+	if b == "" {
+		return fmt.Errorf("empty k0s version given")
+	}
+
+	aVer, err := version.NewVersion(k.Version)
+	if err != nil {
+		return fmt.Errorf("failed to parse k0s version: %w", err)
+	}
+
+	bVer, err := version.NewVersion(b)
+	if err != nil {
+		return fmt.Errorf("failed to parse given k0s version: %w", err)
+	}
+
+	if aVer.String() != bVer.String() {
+		return fmt.Errorf("k0s version mismatch: expected %s, got %s", bVer, aVer)
+	}
+
+	return nil
 }
 
 // TokenID returns a token id from a token string that can be used to invalidate the token

--- a/pkg/apis/k0sctl.k0sproject.io/v1beta1/cluster/k0s.go
+++ b/pkg/apis/k0sctl.k0sproject.io/v1beta1/cluster/k0s.go
@@ -169,6 +169,11 @@ func (k K0s) GetClusterID(h *Host) (string, error) {
 	return h.ExecOutput(h.Configurer.KubectlCmdf(h, "get --data-dir=%s -n kube-system namespace kube-system -o template={{.metadata.uid}}", h.DataDir), exec.Sudo(h))
 }
 
+// VersionEquals returns true when the k0s version is equal to a given version
+func (k K0s) VersionEquals(b string) bool {
+	return strings.TrimPrefix(k.Version, "v") == strings.TrimPrefix(b, "v")
+}
+
 // TokenID returns a token id from a token string that can be used to invalidate the token
 func TokenID(s string) (string, error) {
 	b64 := make([]byte, base64.StdEncoding.DecodedLen(len(s)))


### PR DESCRIPTION
Fixes #513 

Makes k0sctl ignore the v prefix when comparing k0s versions.
