### PR TITLE
Ignore 64bit ARM when setting ETCD_UNSUPPORTED_ARCH

### DIFF
--- a/phase/arm_prepare.go
+++ b/phase/arm_prepare.go
@@ -27,7 +27,7 @@ func (p *PrepareArm) Prepare(config *v1beta1.Cluster) error {
 
 	p.hosts = p.Config.Spec.Hosts.Filter(func(h *cluster.Host) bool {
 		arch := h.Metadata.Arch
-		return h.Role != "worker" && (strings.HasPrefix(arch, "arm") || strings.HasPrefix(arch, "aarch"))
+		return h.Role != "worker" && (strings.HasPrefix(arch, "arm") || strings.HasPrefix(arch, "aarch")) && !strings.HasSuffix(arch, "64")
 	})
 
 	return nil

--- a/phase/arm_prepare.go
+++ b/phase/arm_prepare.go
@@ -3,6 +3,7 @@ package phase
 import (
 	"strings"
 
+	"github.com/k0sproject/version"
 	log "github.com/sirupsen/logrus"
 
 	"github.com/k0sproject/k0sctl/pkg/apis/k0sctl.k0sproject.io/v1beta1"
@@ -26,8 +27,34 @@ func (p *PrepareArm) Prepare(config *v1beta1.Cluster) error {
 	p.Config = config
 
 	p.hosts = p.Config.Spec.Hosts.Filter(func(h *cluster.Host) bool {
+		if h.Role == "worker" {
+			return false
+		}
+
 		arch := h.Metadata.Arch
-		return h.Role != "worker" && (strings.HasPrefix(arch, "arm") || strings.HasPrefix(arch, "aarch")) && !strings.HasSuffix(arch, "64")
+
+		if !strings.HasPrefix(arch, "arm") && !strings.HasPrefix(arch, "aarch") {
+			return false
+		}
+
+		if strings.HasSuffix(arch, "64") {
+			// 64-bit arm is supported on etcd 3.5.0+ which is included in k0s v1.22.1+k0s.0 and newer
+			minVer, err := version.NewVersion("v1.22.1+k0s.0")
+			if err != nil {
+				log.Warnf("failed to parse constraint k0s version: %v", err)
+				return false
+			}
+			k0sVer, err := version.NewVersion(p.Config.Spec.K0s.Version)
+			if err != nil {
+				log.Warnf("failed to parse target k0s version: %v", err)
+				return false
+			}
+			if k0sVer.GreaterThanOrEqual(minVer) {
+				return false
+			}
+		}
+
+		return true
 	})
 
 	return nil


### PR DESCRIPTION
It's not needed on arm64 anymore.
