### PR TITLE
Copy networkConfig for every node

### DIFF
--- a/pkg/apis/k0sctl.k0sproject.io/v1beta1/cluster/k0s.go
+++ b/pkg/apis/k0sctl.k0sproject.io/v1beta1/cluster/k0s.go
@@ -127,6 +127,7 @@ func (k *K0s) NodeConfig() dig.Mapping {
 		},
 		"spec": dig.Mapping{
 			"api":     k.Config.DigMapping("spec", "api"),
+			"network": k.Config.DigMapping("spec", "network"),
 			"storage": k.Config.DigMapping("spec", "storage"),
 		},
 	}


### PR DESCRIPTION
Every controller with dynamiConfig needs a properly configured .spec.network, this is required because otherwise the component managers for network components may start synchronizing before getting the configuration dynamically.

Partially fixes https://github.com/k0sproject/k0s/issues/3304

This doesn't impact negatively worker nodes.