### PR TITLE
Check for existing k0s service init script when k0s isn't running

### DIFF
--- a/cmd/apply.go
+++ b/cmd/apply.go
@@ -47,6 +47,10 @@ var applyCommand = &cli.Command{
 			Usage:  "Skip downgrade check",
 			Hidden: true,
 		},
+		&cli.BoolFlag{
+			Name:  "force",
+			Usage: "Attempt a forced installation in case of certain failures",
+		},
 		debugFlag,
 		traceFlag,
 		redactFlag,
@@ -58,6 +62,7 @@ var applyCommand = &cli.Command{
 	Action: func(ctx *cli.Context) error {
 		start := time.Now()
 		phase.NoWait = ctx.Bool("no-wait")
+		phase.Force = ctx.Bool("force")
 
 		manager := phase.Manager{Config: ctx.Context.Value(ctxConfigKey{}).(*v1beta1.Cluster), Concurrency: ctx.Int("concurrency"), ConcurrentUploads: ctx.Int("concurrent-uploads")}
 		lockPhase := &phase.Lock{}

--- a/phase/download_k0s.go
+++ b/phase/download_k0s.go
@@ -35,14 +35,11 @@ func (p *DownloadK0s) Prepare(config *v1beta1.Cluster) error {
 			return false
 		}
 
-		// The version is already correct
-		err := p.Config.Spec.K0s.VersionMustEqual(h.Metadata.K0sBinaryVersion)
-		if err == nil {
+		// The version on host is already same as the target version
+		if p.Config.Spec.K0s.VersionEqual(h.Metadata.K0sBinaryVersion) {
 			log.Debugf("%s: k0s version on target host is already %s", h, h.Metadata.K0sBinaryVersion)
 			return false
 		}
-
-		log.Debugf("%s: %v", h, err)
 
 		return true
 	})

--- a/phase/initialize_k0s.go
+++ b/phase/initialize_k0s.go
@@ -53,6 +53,11 @@ func (p *InitializeK0s) Run() error {
 		p.SetProp("dynamic-config", true)
 	}
 
+	if Force {
+		log.Warnf("%s: --force given, using k0s install with --force", h)
+		h.InstallFlags.AddOrReplace("--force=true")
+	}
+
 	log.Infof("%s: installing k0s controller", h)
 	cmd, err := h.K0sInstallCommand()
 	if err != nil {

--- a/phase/lock.go
+++ b/phase/lock.go
@@ -37,6 +37,7 @@ func (p *Lock) Title() string {
 	return "Acquire exclusive host lock"
 }
 
+// Cancel releases the lock
 func (p *Lock) Cancel() {
 	p.m.Lock()
 	defer p.m.Unlock()
@@ -44,6 +45,11 @@ func (p *Lock) Cancel() {
 		f()
 	}
 	p.wg.Wait()
+}
+
+// CleanUp calls Cancel to release the lock
+func (p *Lock) CleanUp() {
+	p.Cancel()
 }
 
 // Run the phase

--- a/phase/manager.go
+++ b/phase/manager.go
@@ -9,6 +9,11 @@ import (
 
 // NoWait is used by various phases to decide if node ready state should be waited for or not
 var NoWait bool
+
+// Force is used by various phases to attempt a forced installation
+var Force bool
+
+// Colorize is an instance of "aurora", used to colorize the output
 var Colorize = aurora.NewAurora(false)
 
 type phase interface {

--- a/phase/upload_binaries.go
+++ b/phase/upload_binaries.go
@@ -34,9 +34,8 @@ func (p *UploadBinaries) Prepare(config *v1beta1.Cluster) error {
 			return false
 		}
 
-		// The version on target is incorrect
-		if err := p.Config.Spec.K0s.VersionMustEqual(h.Metadata.K0sBinaryVersion); err != nil {
-			log.Debugf("%s: %v", h, err)
+		if !p.Config.Spec.K0s.VersionEqual(h.Metadata.K0sBinaryVersion) {
+			log.Debugf("%s: k0s version on host is '%s'", h, h.Metadata.K0sBinaryVersion)
 			return true
 		}
 

--- a/pkg/apis/k0sctl.k0sproject.io/v1beta1/cluster/k0s.go
+++ b/pkg/apis/k0sctl.k0sproject.io/v1beta1/cluster/k0s.go
@@ -169,32 +169,27 @@ func (k K0s) GetClusterID(h *Host) (string, error) {
 	return h.ExecOutput(h.Configurer.KubectlCmdf(h, "get --data-dir=%s -n kube-system namespace kube-system -o template={{.metadata.uid}}", h.DataDir), exec.Sudo(h))
 }
 
-// VersionMustEqual returns an error if the k0s version in the struct does not match the given version or
-// if either of the version strings can't be parsed
-func (k K0s) VersionMustEqual(b string) error {
+// VersionEqual returns true if the configured k0s version is equal to the given version string
+func (k K0s) VersionEqual(b string) bool {
 	if k.Version == "" {
-		return fmt.Errorf("k0s version not set")
+		return false
 	}
 
 	if b == "" {
-		return fmt.Errorf("empty k0s version given")
+		return false
 	}
 
 	aVer, err := version.NewVersion(k.Version)
 	if err != nil {
-		return fmt.Errorf("failed to parse k0s version: %w", err)
+		return false
 	}
 
 	bVer, err := version.NewVersion(b)
 	if err != nil {
-		return fmt.Errorf("failed to parse given k0s version: %w", err)
+		return false
 	}
 
-	if aVer.String() != bVer.String() {
-		return fmt.Errorf("k0s version mismatch: expected %s, got %s", bVer, aVer)
-	}
-
-	return nil
+	return aVer.Equal(bVer)
 }
 
 // TokenID returns a token id from a token string that can be used to invalidate the token

--- a/smoke-test/smoke-upgrade.sh
+++ b/smoke-test/smoke-upgrade.sh
@@ -16,8 +16,14 @@ K0S_VERSION="${K0S_FROM}"
 echo "Installing ${K0S_VERSION}"
 ../k0sctl apply --config "${K0SCTL_CONFIG}" --debug
 
+echo "Stopping k0s to verify the 'installed but not running' detection"
+footloose ssh root@manager0 -- k0s stop
+
 # Create config with blank version (to use latest) and apply as upgrade
 K0S_VERSION="$(curl https://api.github.com/repos/k0sproject/k0s/releases | grep tag_name | cut -d"\"" -f4 | grep "+k0s" | sed -r 's/^(v[0-9]+\.[0-9]+\.[0-9]+)\+/\19999+/g' | sort -r -t "." -k1,5n | head -1 | sed 's/9999//')"
 
-echo "Upgrading to ${K0S_VERSION}"
-../k0sctl apply --config "${K0SCTL_CONFIG}" --debug
+echo "Upgrading to ${K0S_VERSION} (should fail)"
+! ../k0sctl apply --config "${K0SCTL_CONFIG}" --debug 
+
+echo "Upgrading to ${K0S_VERSION} using --force"
+../k0sctl apply --config "${K0SCTL_CONFIG}" --debug --force


### PR DESCRIPTION
Fixes #520 (or addresses it)

- If k0s is already running but no service exists -- error out with a proper message 
- If k0s is not running but a service exists -- error out with a proper message
- Add a `k0sctl apply --force` flag that can be used to ignore either of the above errors and also make `k0s install` use the `--force` flag when it is run.

