### PR TITLE
Wait for dynamic config reconciliation after leader init

### DIFF
--- a/phase/initialize_k0s.go
+++ b/phase/initialize_k0s.go
@@ -1,6 +1,8 @@
 package phase
 
 import (
+	"fmt"
+
 	"github.com/k0sproject/k0sctl/pkg/apis/k0sctl.k0sproject.io/v1beta1"
 	"github.com/k0sproject/k0sctl/pkg/apis/k0sctl.k0sproject.io/v1beta1/cluster"
 	log "github.com/sirupsen/logrus"
@@ -90,6 +92,12 @@ func (p *InitializeK0s) Run() error {
 	log.Infof("%s: waiting for kubernetes api to respond", h)
 	if err := h.WaitKubeAPIReady(port); err != nil {
 		return err
+	}
+
+	if p.Config.Spec.K0s.DynamicConfig {
+		if err := h.WaitK0sDynamicConfigReady(); err != nil {
+			return fmt.Errorf("dynamic config reconciliation failed: %w", err)
+		}
 	}
 
 	h.Metadata.K0sRunningVersion = p.Config.Spec.K0s.Version

--- a/pkg/apis/k0sctl.k0sproject.io/v1beta1/cluster/host.go
+++ b/pkg/apis/k0sctl.k0sproject.io/v1beta1/cluster/host.go
@@ -469,7 +469,7 @@ func (h *Host) WaitK0sDynamicConfigReady() error {
 					return nil
 				}
 			}
-			return fmt.Errorf("failed to find ReconcileSuccess event in kubectl output")
+			return fmt.Errorf("failed to find SuccessfulReconcile event in kubectl output")
 		},
 		retry.DelayType(retry.CombineDelay(retry.FixedDelay, retry.RandomDelay)),
 		retry.MaxJitter(time.Second*2),

--- a/pkg/apis/k0sctl.k0sproject.io/v1beta1/cluster/host.go
+++ b/pkg/apis/k0sctl.k0sproject.io/v1beta1/cluster/host.go
@@ -446,6 +446,39 @@ func (h *Host) WaitKubeNodeReady() error {
 	)
 }
 
+type statusEvents struct {
+	Items []struct {
+		Reason string `json:"reason"`
+	} `json:"items"`
+}
+
+// WaitK0sDynamicConfigReady blocks until dynamic config reconciliation has been performed
+func (h *Host) WaitK0sDynamicConfigReady() error {
+	return retry.Do(
+		func() error {
+			output, err := h.ExecOutput(h.Configurer.K0sCmdf("kubectl --data-dir=%s -n kube-system get event --field-selector involvedObject.name=k0s -o json", h.DataDir), exec.Sudo(h))
+			if err != nil {
+				return fmt.Errorf("failed to get k0s config status events: %w", err)
+			}
+			events := &statusEvents{}
+			if err := json.Unmarshal([]byte(output), &events); err != nil {
+				return fmt.Errorf("failed to decode kubectl output: %w", err)
+			}
+			for _, e := range events.Items {
+				if e.Reason == "ReconcileSuccess" {
+					return nil
+				}
+			}
+			return fmt.Errorf("failed to find ReconcileSuccess event in kubectl output")
+		},
+		retry.DelayType(retry.CombineDelay(retry.FixedDelay, retry.RandomDelay)),
+		retry.MaxJitter(time.Second*2),
+		retry.Delay(time.Second*3),
+		retry.Attempts(120),
+		retry.LastErrorOnly(true),
+	)
+}
+
 // DrainNode drains the given node
 func (h *Host) DrainNode(node *Host) error {
 	return h.Exec(h.Configurer.KubectlCmdf(h, "drain --data-dir=%s --grace-period=120 --force --timeout=5m --ignore-daemonsets --delete-emptydir-data %s", h.DataDir, node.Metadata.Hostname), exec.Sudo(h))

--- a/pkg/apis/k0sctl.k0sproject.io/v1beta1/cluster/host.go
+++ b/pkg/apis/k0sctl.k0sproject.io/v1beta1/cluster/host.go
@@ -465,7 +465,7 @@ func (h *Host) WaitK0sDynamicConfigReady() error {
 				return fmt.Errorf("failed to decode kubectl output: %w", err)
 			}
 			for _, e := range events.Items {
-				if e.Reason == "ReconcileSuccess" {
+				if e.Reason == "SuccessfulReconcile" {
 					return nil
 				}
 			}


### PR DESCRIPTION
Fixes #529 

Waits for dynamic config to be reconciled before proceeding to install the rest of the controllers.
