### PR TITLE
Fix reading host.dataDir from installFlags

### DIFF
--- a/pkg/apis/k0sctl.k0sproject.io/v1beta1/cluster/host.go
+++ b/pkg/apis/k0sctl.k0sproject.io/v1beta1/cluster/host.go
@@ -70,7 +70,7 @@ func (h *Host) SetDefaults() {
 		h.NoTaints = true
 	}
 
-	if dd := h.InstallFlags.Get("--data-dir"); dd != "" {
+	if dd := h.InstallFlags.GetValue("--data-dir"); dd != "" {
 		if h.DataDir != "" {
 			log.Debugf("%s: changed dataDir from '%s' to '%s' because of --data-dir installFlag", h, h.DataDir, dd)
 		}


### PR DESCRIPTION
Fixes #527

The `flags.Get` call would cause `host.DataDir` to become something like `--data-dir="/var/foo"` instead of `/var/foo`.
