### PR TITLE
Fix dependabot auto-approve workflow

### DIFF
--- a/.github/workflows/dependabot-auto-approve.yml
+++ b/.github/workflows/dependabot-auto-approve.yml
@@ -1,4 +1,4 @@
-name: Dependabot auto-approve and merge
+name: Dependabot auto-approve
 on: pull_request
 
 permissions:
@@ -15,14 +15,8 @@ jobs:
         with:
           github-token: "${{ secrets.GITHUB_TOKEN }}"
 
-      - name: Approve a PR
+      - name: Approve PR
         run: gh pr review --approve "$PR_URL"
-        env:
-          PR_URL: ${{github.event.pull_request.html_url}}
-          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
-            
-      - name: Enable auto-merge for Dependabot PRs
-        run: gh pr merge --auto --merge "$PR_URL"
         env:
           PR_URL: ${{github.event.pull_request.html_url}}
           GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}


### PR DESCRIPTION
Removes the failing auto-merge. Keeping the auto-approve for passing bump PRs.