### PR TITLE
Move K0sCmdf and KubectlCmdf from configurer to host

### DIFF
--- a/cmd/config_edit.go
+++ b/cmd/config_edit.go
@@ -65,7 +65,7 @@ var configEditCommand = &cli.Command{
 			return err
 		}
 
-		oldCfg, err := h.ExecOutput(h.Configurer.K0sCmdf("kubectl --data-dir=%s -n kube-system get clusterconfig k0s -o yaml", h.K0sDataDir()), exec.Sudo(h))
+		oldCfg, err := h.ExecOutput(h.KubectlCmdf("-n kube-system get clusterconfig k0s -o yaml"), exec.Sudo(h))
 		if err != nil {
 			return fmt.Errorf("%s: %w", h, err)
 		}
@@ -102,7 +102,7 @@ var configEditCommand = &cli.Command{
 			return fmt.Errorf("configuration was not changed, aborting")
 		}
 
-		if err := h.Exec(h.Configurer.K0sCmdf("kubectl apply --data-dir=%s -n kube-system -f -", h.K0sDataDir()), exec.Stdin(newCfg), exec.Sudo(h)); err != nil {
+		if err := h.Exec(h.KubectlCmdf("apply -n kube-system -f -"), exec.Stdin(newCfg), exec.Sudo(h)); err != nil {
 			return err
 		}
 

--- a/cmd/config_status.go
+++ b/cmd/config_status.go
@@ -47,7 +47,7 @@ var configStatusCommand = &cli.Command{
 			format = "-o " + format
 		}
 
-		output, err := h.ExecOutput(h.Configurer.K0sCmdf("kubectl --data-dir=%s -n kube-system get event --field-selector involvedObject.name=k0s %s", h.K0sDataDir(), format), exec.Sudo(h))
+		output, err := h.ExecOutput(h.KubectlCmdf("-n kube-system get event --field-selector involvedObject.name=k0s %s", format), exec.Sudo(h))
 		if err != nil {
 			return fmt.Errorf("%s: %w", h, err)
 		}

--- a/configurer/linux/linux_test.go
+++ b/configurer/linux/linux_test.go
@@ -1,48 +1,11 @@
 package linux
 
 import (
-	"fmt"
 	"testing"
 
 	"github.com/k0sproject/k0sctl/configurer"
-	"github.com/k0sproject/rig/exec"
 	"github.com/stretchr/testify/require"
 )
-
-type mockHost struct {
-	ExecFError bool
-}
-
-func (m mockHost) Upload(source, destination string, opts ...exec.Option) error {
-	return nil
-}
-
-func (m mockHost) Exec(string, ...exec.Option) error {
-	return nil
-}
-
-func (m mockHost) ExecOutput(string, ...exec.Option) (string, error) {
-	return "", nil
-}
-
-func (m mockHost) Execf(string, ...interface{}) error {
-	if m.ExecFError {
-		return fmt.Errorf("error")
-	}
-	return nil
-}
-
-func (m mockHost) ExecOutputf(string, ...interface{}) (string, error) {
-	return "", nil
-}
-
-func (m mockHost) String() string {
-	return ""
-}
-
-func (m mockHost) Sudo(string) (string, error) {
-	return "", nil
-}
 
 // TestPaths tests the slightly weird way to perform function overloading
 func TestPaths(t *testing.T) {
@@ -52,22 +15,6 @@ func TestPaths(t *testing.T) {
 	ubuntu := &Ubuntu{}
 	ubuntu.PathFuncs = interface{}(ubuntu).(configurer.PathFuncs)
 
-	h1 := &mockHost{
-		ExecFError: false,
-	}
-	h2 := &mockHost{
-		ExecFError: true,
-	}
-
 	require.Equal(t, "/opt/bin/k0s", fc.K0sBinaryPath())
 	require.Equal(t, "/usr/local/bin/k0s", ubuntu.K0sBinaryPath())
-
-	require.Equal(t, "/opt/bin/k0s --help", fc.K0sCmdf("--help"))
-	require.Equal(t, "/usr/local/bin/k0s --help", ubuntu.K0sCmdf("--help"))
-
-	require.Equal(t, "/var/lib/k0s/pki/admin.conf", fc.KubeconfigPath(h1, fc.DataDirDefaultPath()))
-	require.Equal(t, "/var/lib/k0s/pki/admin.conf", ubuntu.KubeconfigPath(h1, ubuntu.DataDirDefaultPath()))
-
-	require.Equal(t, "/var/lib/k0s/kubelet.conf", fc.KubeconfigPath(h2, fc.DataDirDefaultPath()))
-	require.Equal(t, "/var/lib/k0s/kubelet.conf", ubuntu.KubeconfigPath(h2, ubuntu.DataDirDefaultPath()))
 }

--- a/phase/backup.go
+++ b/phase/backup.go
@@ -35,7 +35,7 @@ func (p *Backup) Prepare(config *v1beta1.Cluster) error {
 		return fmt.Errorf("failed to find a running controller")
 	}
 
-	if leader.Exec(leader.Configurer.K0sCmdf("backup --help"), exec.Sudo(leader)) != nil {
+	if leader.Exec(leader.K0sCmdf("backup --help"), exec.Sudo(leader)) != nil {
 		return fmt.Errorf("the version of k0s on the host does not support taking backups")
 	}
 

--- a/phase/configure_k0s.go
+++ b/phase/configure_k0s.go
@@ -40,10 +40,10 @@ func (p *ConfigureK0s) Run() error {
 		log.Warnf("%s: generating default configuration", p.leader)
 
 		var cmd string
-		if p.leader.Exec(p.leader.Configurer.K0sCmdf("config create --help"), exec.Sudo(p.leader)) == nil {
-			cmd = p.leader.Configurer.K0sCmdf("config create --data-dir=%s", p.leader.K0sDataDir())
+		if p.leader.Exec(p.leader.K0sCmdf("config create --help"), exec.Sudo(p.leader)) == nil {
+			cmd = p.leader.K0sCmdf("config create")
 		} else {
-			cmd = p.leader.Configurer.K0sCmdf("default-config")
+			cmd = p.leader.K0sCmdf("default-config")
 		}
 
 		cfg, err := p.leader.ExecOutput(cmd, exec.Sudo(p.leader))
@@ -65,10 +65,10 @@ func (p *ConfigureK0s) Run() error {
 func (p *ConfigureK0s) validateConfig(h *cluster.Host) error {
 	log.Infof("%s: validating configuration", h)
 	var cmd string
-	if h.Exec(h.Configurer.K0sCmdf("config validate --help"), exec.Sudo(h)) == nil {
-		cmd = h.Configurer.K0sCmdf(`config validate --config "%s"`, h.K0sConfigPath())
+	if h.Exec(h.K0sCmdf("config validate --help"), exec.Sudo(h)) == nil {
+		cmd = h.K0sCmdf(`config validate --config "%s"`, h.K0sConfigPath())
 	} else {
-		cmd = h.Configurer.K0sCmdf(`validate config --config "%s"`, h.K0sConfigPath())
+		cmd = h.K0sCmdf(`validate config --config "%s"`, h.K0sConfigPath())
 	}
 
 	output, err := h.ExecOutput(cmd, exec.Sudo(h))

--- a/phase/gather_k0s_facts.go
+++ b/phase/gather_k0s_facts.go
@@ -69,7 +69,7 @@ func (p *GatherK0sFacts) Run() error {
 }
 
 func (p *GatherK0sFacts) investigateK0s(h *cluster.Host) error {
-	output, err := h.ExecOutput(h.Configurer.K0sCmdf("version"), exec.Sudo(h))
+	output, err := h.ExecOutput(h.K0sCmdf("version"), exec.Sudo(h))
 	if err != nil {
 		log.Debugf("%s: no 'k0s' binary in PATH", h)
 		return nil
@@ -98,7 +98,7 @@ func (p *GatherK0sFacts) investigateK0s(h *cluster.Host) error {
 		}
 	}
 
-	output, err = h.ExecOutput(h.Configurer.K0sCmdf("status -o json"), exec.Sudo(h))
+	output, err = h.ExecOutput(h.K0sCmdf("status -o json"), exec.Sudo(h))
 	if err != nil {
 		if existingServiceScript == "" {
 			log.Debugf("%s: an existing k0s instance is not running and does not seem to have been installed as a service", h)

--- a/phase/get_kubeconfig.go
+++ b/phase/get_kubeconfig.go
@@ -20,7 +20,7 @@ func (p *GetKubeconfig) Title() string {
 }
 
 var readKubeconfig = func(h *cluster.Host) (string, error) {
-	return h.Configurer.ReadFile(h, h.Configurer.KubeconfigPath(h, h.K0sDataDir()))
+	return h.Configurer.ReadFile(h, h.KubeconfigPath())
 }
 
 // Run the phase

--- a/phase/install_controllers.go
+++ b/phase/install_controllers.go
@@ -67,7 +67,7 @@ func (p *InstallControllers) Run() error {
 		}
 		log.Debugf("%s: join token ID: %s", p.leader, tokenID)
 		defer func() {
-			if err := p.leader.Exec(p.leader.Configurer.K0sCmdf("token invalidate --data-dir=%s %s", h.K0sDataDir(), tokenID), exec.Sudo(p.leader), exec.RedactString(token)); err != nil {
+			if err := p.leader.Exec(p.leader.K0sCmdf("token invalidate %s", tokenID), exec.Sudo(p.leader), exec.RedactString(token)); err != nil {
 				log.Warnf("%s: failed to invalidate the controller join token", p.leader)
 			}
 		}()

--- a/phase/install_controllers.go
+++ b/phase/install_controllers.go
@@ -67,7 +67,7 @@ func (p *InstallControllers) Run() error {
 		}
 		log.Debugf("%s: join token ID: %s", p.leader, tokenID)
 		defer func() {
-			if err := p.leader.Exec(p.leader.K0sCmdf("token invalidate %s", tokenID), exec.Sudo(p.leader), exec.RedactString(token)); err != nil {
+			if err := p.leader.Exec(p.leader.K0sCmdf("token invalidate %s", tokenID), exec.Sudo(p.leader), exec.RedactString(token, tokenID)); err != nil {
 				log.Warnf("%s: failed to invalidate the controller join token", p.leader)
 			}
 		}()

--- a/phase/install_workers.go
+++ b/phase/install_workers.go
@@ -85,7 +85,7 @@ func (p *InstallWorkers) Run() error {
 
 	if !NoWait {
 		defer func() {
-			if err := p.leader.Exec(p.leader.Configurer.K0sCmdf("token invalidate --data-dir=%s %s", p.leader.K0sDataDir(), tokenID), exec.Sudo(p.leader), exec.RedactString(token)); err != nil {
+			if err := p.leader.Exec(p.leader.K0sCmdf("token invalidate %s", tokenID), exec.Sudo(p.leader), exec.RedactString(token)); err != nil {
 				log.Warnf("%s: failed to invalidate the worker join token", p.leader)
 			}
 		}()

--- a/phase/install_workers.go
+++ b/phase/install_workers.go
@@ -85,7 +85,7 @@ func (p *InstallWorkers) Run() error {
 
 	if !NoWait {
 		defer func() {
-			if err := p.leader.Exec(p.leader.K0sCmdf("token invalidate %s", tokenID), exec.Sudo(p.leader), exec.RedactString(token)); err != nil {
+			if err := p.leader.Exec(p.leader.K0sCmdf("token invalidate %s", tokenID), exec.Sudo(p.leader), exec.RedactString(token, tokenID)); err != nil {
 				log.Warnf("%s: failed to invalidate the worker join token", p.leader)
 			}
 		}()

--- a/phase/reset_controllers.go
+++ b/phase/reset_controllers.go
@@ -103,7 +103,7 @@ func (p *ResetControllers) Run() error {
 		log.Debugf("%s: leaving etcd completed", h)
 
 		log.Debugf("%s: resetting k0s...", h)
-		out, err := h.ExecOutput(h.Configurer.K0sCmdf("reset --data-dir=%s", h.K0sDataDir()), exec.Sudo(h))
+		out, err := h.ExecOutput(h.K0sCmdf("reset"), exec.Sudo(h))
 		if err != nil {
 			log.Debugf("%s: k0s reset failed: %s", h, out)
 			log.Warnf("%s: k0s reported failure: %v", h, err)

--- a/phase/reset_leader.go
+++ b/phase/reset_leader.go
@@ -49,7 +49,7 @@ func (p *ResetLeader) Run() error {
 	}
 
 	log.Debugf("%s: resetting k0s...", p.leader)
-	out, err := p.leader.ExecOutput(p.leader.Configurer.K0sCmdf("reset --data-dir=%s", p.leader.K0sDataDir()), exec.Sudo(p.leader))
+	out, err := p.leader.ExecOutput(p.leader.K0sCmdf("reset"), exec.Sudo(p.leader))
 	if err != nil {
 		log.Debugf("%s: k0s reset failed: %s", p.leader, out)
 		log.Warnf("%s: k0s reported failure: %v", p.leader, err)

--- a/phase/reset_workers.go
+++ b/phase/reset_workers.go
@@ -94,7 +94,7 @@ func (p *ResetWorkers) Run() error {
 		}
 
 		log.Debugf("%s: resetting k0s...", h)
-		out, err := h.ExecOutput(h.Configurer.K0sCmdf("reset --data-dir=%s", h.K0sDataDir()), exec.Sudo(h))
+		out, err := h.ExecOutput(h.K0sCmdf("reset"), exec.Sudo(h))
 		if err != nil {
 			log.Debugf("%s: k0s reset failed: %s", h, out)
 			log.Warnf("%s: k0s reported failure: %v", h, err)

--- a/phase/restore.go
+++ b/phase/restore.go
@@ -33,7 +33,7 @@ func (p *Restore) Prepare(config *v1beta1.Cluster) error {
 	p.Config = config
 	p.leader = p.Config.Spec.K0sLeader()
 
-	if p.RestoreFrom != "" && p.leader.Exec(p.leader.Configurer.K0sCmdf("restore --help"), exec.Sudo(p.leader)) != nil {
+	if p.RestoreFrom != "" && p.leader.Exec(p.leader.K0sCmdf("restore --help"), exec.Sudo(p.leader)) != nil {
 		return fmt.Errorf("the version of k0s on the host does not support restoring backups")
 	}
 

--- a/pkg/apis/k0sctl.k0sproject.io/v1beta1/cluster/host.go
+++ b/pkg/apis/k0sctl.k0sproject.io/v1beta1/cluster/host.go
@@ -237,7 +237,7 @@ func (h *Host) K0sCmdf(template string, args ...any) string {
 
 // KubectlCmdf returns a command line in sprintf manner for running kubectl on the host using the kubeconfig from KubeconfigPath
 func (h *Host) KubectlCmdf(s string, args ...any) string {
-	return h.K0sCmdf(`kubectl --kubeconfig=%s %s`, h.KubeconfigPath(), fmt.Sprintf(s, args...))
+	return fmt.Sprintf("env KUBECONFIG=%s %s", h.KubeconfigPath(), h.K0sCmdf(`kubectl %s`, fmt.Sprintf(s, args...)))
 }
 
 // K0sConfigPath returns the config file path from install flags or configurer
@@ -436,8 +436,7 @@ type kubeNodeStatus struct {
 
 // KubeNodeReady runs kubectl on the host and returns true if the given node is marked as ready
 func (h *Host) KubeNodeReady() (bool, error) {
-	//output, err := h.ExecOutput(h.KubectlCmdf("get node -l kubernetes.io/hostname=%s -o json", h.Metadata.Hostname), exec.HideOutput(), exec.Sudo(h))
-	output, err := h.ExecOutput(h.KubectlCmdf("get node -l kubernetes.io/hostname=%s -o json", h.Metadata.Hostname), exec.Sudo(h))
+	output, err := h.ExecOutput(h.KubectlCmdf("get node -l kubernetes.io/hostname=%s -o json", h.Metadata.Hostname), exec.HideOutput(), exec.Sudo(h))
 	if err != nil {
 		return false, err
 	}

--- a/pkg/apis/k0sctl.k0sproject.io/v1beta1/cluster/host.go
+++ b/pkg/apis/k0sctl.k0sproject.io/v1beta1/cluster/host.go
@@ -439,6 +439,7 @@ func (h *Host) KubeNodeReady() (bool, error) {
 	output, err := h.ExecOutput(h.KubectlCmdf("get node -l kubernetes.io/hostname=%s -o json", h.Metadata.Hostname), exec.HideOutput(), exec.Sudo(h))
 	if err != nil {
 		log.Debugf("%s: failed to get node status: %s", h, err.Error())
+		log.Debugf("%s: kubectl output:\n%s", h, output)
 		return false, err
 	}
 	log.Tracef("node status output:\n%s\n", output)

--- a/pkg/apis/k0sctl.k0sproject.io/v1beta1/cluster/host.go
+++ b/pkg/apis/k0sctl.k0sproject.io/v1beta1/cluster/host.go
@@ -436,7 +436,8 @@ type kubeNodeStatus struct {
 
 // KubeNodeReady runs kubectl on the host and returns true if the given node is marked as ready
 func (h *Host) KubeNodeReady() (bool, error) {
-	output, err := h.ExecOutput(h.KubectlCmdf("get node -l kubernetes.io/hostname=%s -o json", h.Metadata.Hostname), exec.HideOutput(), exec.Sudo(h))
+	//output, err := h.ExecOutput(h.KubectlCmdf("get node -l kubernetes.io/hostname=%s -o json", h.Metadata.Hostname), exec.HideOutput(), exec.Sudo(h))
+	output, err := h.ExecOutput(h.KubectlCmdf("get node -l kubernetes.io/hostname=%s -o json", h.Metadata.Hostname), exec.Sudo(h))
 	if err != nil {
 		return false, err
 	}

--- a/pkg/apis/k0sctl.k0sproject.io/v1beta1/cluster/host.go
+++ b/pkg/apis/k0sctl.k0sproject.io/v1beta1/cluster/host.go
@@ -229,7 +229,7 @@ func (h *Host) K0sJoinTokenPath() string {
 
 // K0sCmdf can be used to construct k0s commands in sprintf style.
 func (h *Host) K0sCmdf(template string, args ...any) string {
-	if template == "version" || strings.Contains(template, "--help") {
+	if template == "version" || strings.HasPrefix(template, "status") || strings.Contains(template, "--help") {
 		return fmt.Sprintf("%s %s", h.Configurer.K0sBinaryPath(), fmt.Sprintf(template, args...))
 	}
 	return fmt.Sprintf("%s --data-dir=%s %s", h.Configurer.K0sBinaryPath(), h.K0sDataDir(), fmt.Sprintf(template, args...))

--- a/pkg/apis/k0sctl.k0sproject.io/v1beta1/cluster/host.go
+++ b/pkg/apis/k0sctl.k0sproject.io/v1beta1/cluster/host.go
@@ -417,7 +417,7 @@ func (h *Host) K0sDataDir() string {
 // KubeconfigPath returns the path to a kubeconfig on the host
 func (h *Host) KubeconfigPath() string {
 	if h.Metadata.KubeconfigPath != "" {
-		eturn h.Metadata.KubeconfigPath
+		return h.Metadata.KubeconfigPath
 	}
 
 	// if admin.conf exists, use that

--- a/pkg/apis/k0sctl.k0sproject.io/v1beta1/cluster/host.go
+++ b/pkg/apis/k0sctl.k0sproject.io/v1beta1/cluster/host.go
@@ -417,7 +417,7 @@ func (h *Host) K0sDataDir() string {
 // KubeconfigPath returns the path to a kubeconfig on the host
 func (h *Host) KubeconfigPath() string {
 	if h.Role == "worker" {
-		return path.Join(h.K0sDataDir(), "pki/kubelet.conf")
+		return path.Join(h.K0sDataDir(), "kubelet.conf")
 	}
 
 	return path.Join(h.K0sDataDir(), "pki/admin.conf")
@@ -438,9 +438,7 @@ type kubeNodeStatus struct {
 func (h *Host) KubeNodeReady() (bool, error) {
 	output, err := h.ExecOutput(h.KubectlCmdf("get node -l kubernetes.io/hostname=%s -o json", h.Metadata.Hostname), exec.HideOutput(), exec.Sudo(h))
 	if err != nil {
-		log.Debugf("%s: failed to get node status: %s", h, err.Error())
-		log.Debugf("%s: kubectl output:\n%s", h, output)
-		return false, err
+		return false, fmt.Errorf("failed to get kube node status: %w", err)
 	}
 	log.Tracef("node status output:\n%s\n", output)
 	status := kubeNodeStatus{}

--- a/pkg/apis/k0sctl.k0sproject.io/v1beta1/cluster/host.go
+++ b/pkg/apis/k0sctl.k0sproject.io/v1beta1/cluster/host.go
@@ -229,6 +229,9 @@ func (h *Host) K0sJoinTokenPath() string {
 
 // K0sCmdf can be used to construct k0s commands in sprintf style.
 func (h *Host) K0sCmdf(template string, args ...any) string {
+	if template == "version" || strings.Contains(template, "--help") {
+		return fmt.Sprintf("%s %s", h.Configurer.K0sBinaryPath(), fmt.Sprintf(template, args...))
+	}
 	return fmt.Sprintf("%s --data-dir=%s %s", h.Configurer.K0sBinaryPath(), h.K0sDataDir(), fmt.Sprintf(template, args...))
 }
 

--- a/pkg/apis/k0sctl.k0sproject.io/v1beta1/cluster/host.go
+++ b/pkg/apis/k0sctl.k0sproject.io/v1beta1/cluster/host.go
@@ -146,6 +146,7 @@ type HostMetadata struct {
 	K0sBinaryVersion  string
 	K0sBinaryTempFile string
 	K0sRunningVersion string
+	KubeconfigPath    string
 	Arch              string
 	IsK0sLeader       bool
 	Hostname          string
@@ -415,12 +416,21 @@ func (h *Host) K0sDataDir() string {
 
 // KubeconfigPath returns the path to a kubeconfig on the host
 func (h *Host) KubeconfigPath() string {
-	// if admin.conf exists, use that
-	adminConfPath := path.Join(h.K0sDataDir(), "pki/admin.conf")
-	if h.Configurer.FileExist(h, adminConfPath) {
-		return adminConfPath
+	if h.Metadata.KubeconfigPath != "" {
+		eturn h.Metadata.KubeconfigPath
 	}
-	return path.Join(h.K0sDataDir(), "kubelet.conf")
+
+	// if admin.conf exists, use that
+	adminConfigPath := path.Join(h.K0sDataDir(), "pki/admin.conf")
+	if h.Configurer.FileExist(h, adminConfigPath) {
+		h.Metadata.KubeconfigPath = adminConfigPath
+		return adminConfigPath
+	}
+	workerConfigPath := path.Join(h.K0sDataDir(), "pki/kubelet.conf")
+	if h.Configurer.FileExist(h, workerConfigPath) {
+		h.Metadata.KubeconfigPath = workerConfigPath
+	}
+	return workerConfigPath
 }
 
 type kubeNodeStatus struct {

--- a/pkg/apis/k0sctl.k0sproject.io/v1beta1/cluster/host_test.go
+++ b/pkg/apis/k0sctl.k0sproject.io/v1beta1/cluster/host_test.go
@@ -25,6 +25,10 @@ type mockconfigurer struct {
 	linux.Ubuntu
 }
 
+func (c mockconfigurer) Arch(_ os.Host) (string, error) {
+	return "mockarch", nil
+}
+
 func (c mockconfigurer) Chmod(_ os.Host, _, _ string, _ ...exec.Option) error {
 	return nil
 }
@@ -80,42 +84,42 @@ func TestK0sInstallCommand(t *testing.T) {
 
 	cmd, err := h.K0sInstallCommand()
 	require.NoError(t, err)
-	require.Equal(t, `k0s install worker --data-dir=/tmp/k0s --token-file "from-configurer"`, cmd)
+	require.Equal(t, `/usr/local/bin/k0s --data-dir=/tmp/k0s install worker --token-file "from-configurer"`, cmd)
 
 	h.Role = "controller"
 	h.Metadata.IsK0sLeader = true
 	cmd, err = h.K0sInstallCommand()
 	require.NoError(t, err)
-	require.Equal(t, `k0s install controller --data-dir=/tmp/k0s --config "from-configurer"`, cmd)
+	require.Equal(t, `/usr/local/bin/k0s --data-dir=/tmp/k0s install controller --config "from-configurer"`, cmd)
 
 	h.Metadata.IsK0sLeader = false
 	cmd, err = h.K0sInstallCommand()
 	require.NoError(t, err)
-	require.Equal(t, `k0s install controller --data-dir=/tmp/k0s --token-file "from-configurer" --config "from-configurer"`, cmd)
+	require.Equal(t, `/usr/local/bin/k0s --data-dir=/tmp/k0s install controller --token-file "from-configurer" --config "from-configurer"`, cmd)
 
 	h.Role = "controller+worker"
 	h.Metadata.IsK0sLeader = true
 	cmd, err = h.K0sInstallCommand()
 	require.NoError(t, err)
-	require.Equal(t, `k0s install controller --data-dir=/tmp/k0s --enable-worker --config "from-configurer"`, cmd)
+	require.Equal(t, `/usr/local/bin/k0s --data-dir=/tmp/k0s install controller --enable-worker --config "from-configurer"`, cmd)
 	h.Metadata.IsK0sLeader = false
 	cmd, err = h.K0sInstallCommand()
 	require.NoError(t, err)
-	require.Equal(t, `k0s install controller --data-dir=/tmp/k0s --enable-worker --token-file "from-configurer" --config "from-configurer"`, cmd)
+	require.Equal(t, `/usr/local/bin/k0s --data-dir=/tmp/k0s install controller --enable-worker --token-file "from-configurer" --config "from-configurer"`, cmd)
 
 	h.Role = "worker"
 	h.PrivateAddress = "10.0.0.9"
 	cmd, err = h.K0sInstallCommand()
 	require.NoError(t, err)
-	require.Equal(t, `k0s install worker --data-dir=/tmp/k0s --token-file "from-configurer" --kubelet-extra-args="--node-ip=10.0.0.9"`, cmd)
+	require.Equal(t, `/usr/local/bin/k0s --data-dir=/tmp/k0s install worker --token-file "from-configurer" --kubelet-extra-args="--node-ip=10.0.0.9"`, cmd)
 
 	h.InstallFlags = []string{`--kubelet-extra-args="--foo bar"`}
 	cmd, err = h.K0sInstallCommand()
 	require.NoError(t, err)
-	require.Equal(t, `k0s install worker --kubelet-extra-args="--foo bar --node-ip=10.0.0.9" --data-dir=/tmp/k0s --token-file "from-configurer"`, cmd)
+	require.Equal(t, `/usr/local/bin/k0s --data-dir=/tmp/k0s install worker --kubelet-extra-args="--foo bar --node-ip=10.0.0.9" --token-file "from-configurer"`, cmd)
 
 	h.InstallFlags = []string{`--enable-cloud-provider`}
 	cmd, err = h.K0sInstallCommand()
 	require.NoError(t, err)
-	require.Equal(t, `k0s install worker --enable-cloud-provider --data-dir=/tmp/k0s --token-file "from-configurer"`, cmd)
+	require.Equal(t, `/usr/local/bin/k0s --data-dir=/tmp/k0s install worker --enable-cloud-provider --token-file "from-configurer"`, cmd)
 }

--- a/pkg/apis/k0sctl.k0sproject.io/v1beta1/cluster/k0s.go
+++ b/pkg/apis/k0sctl.k0sproject.io/v1beta1/cluster/k0s.go
@@ -139,7 +139,7 @@ func (k K0s) GenerateToken(h *Host, role string, expiry time.Duration) (string, 
 	k0sFlags.Add(fmt.Sprintf("--role %s", role))
 	k0sFlags.Add(fmt.Sprintf("--expiry %s", expiry))
 
-	out, err := h.ExecOutput(h.Configurer.K0sCmdf("token create --help"), exec.Sudo(h))
+	out, err := h.ExecOutput(h.K0sCmdf("token create --help"), exec.Sudo(h))
 	if err == nil && strings.Contains(out, "--config") {
 		k0sFlags.Add(fmt.Sprintf("--config %s", shellescape.Quote(h.K0sConfigPath())))
 	}
@@ -149,7 +149,7 @@ func (k K0s) GenerateToken(h *Host, role string, expiry time.Duration) (string, 
 	var token string
 	err = retry.Do(
 		func() error {
-			output, err := h.ExecOutput(h.Configurer.K0sCmdf("token create %s", k0sFlags.Join()), exec.HideOutput(), exec.Sudo(h))
+			output, err := h.ExecOutput(h.K0sCmdf("token create %s", k0sFlags.Join()), exec.HideOutput(), exec.Sudo(h))
 			if err != nil {
 				return err
 			}
@@ -167,7 +167,7 @@ func (k K0s) GenerateToken(h *Host, role string, expiry time.Duration) (string, 
 
 // GetClusterID uses kubectl to fetch the kube-system namespace uid
 func (k K0s) GetClusterID(h *Host) (string, error) {
-	return h.ExecOutput(h.Configurer.KubectlCmdf(h, h.K0sDataDir(), "get -n kube-system namespace kube-system -o template={{.metadata.uid}}"), exec.Sudo(h))
+	return h.ExecOutput(h.KubectlCmdf("get -n kube-system namespace kube-system -o template={{.metadata.uid}}"), exec.Sudo(h))
 }
 
 // VersionEqual returns true if the configured k0s version is equal to the given version string


### PR DESCRIPTION
This simplifies the interface a bit and removes the need to pass datadir/host around.
