### PR TITLE
Set a conenct timeout of 20 seconds HTTPStatus

### DIFF
--- a/configurer/linux.go
+++ b/configurer/linux.go
@@ -161,7 +161,7 @@ func (l Linux) KubectlCmdf(h os.Host, dataDir, s string, args ...interface{}) st
 
 // HTTPStatus makes a HTTP GET request to the url and returns the status code or an error
 func (l Linux) HTTPStatus(h os.Host, url string) (int, error) {
-	output, err := h.ExecOutput(fmt.Sprintf(`curl -kso /dev/null -w "%%{http_code}" "%s"`, url))
+	output, err := h.ExecOutput(fmt.Sprintf(`curl -kso /dev/null --connect-timeout 20 -w "%%{http_code}" "%s"`, url))
 	if err != nil {
 		return -1, err
 	}


### PR DESCRIPTION
Curl has 5 minutes of connect timeout by default[1]. This can make the installer stuck for 10 minutes if a firewall drops the packets instead of rejecting them[2]

References:
1- https://github.com/curl/curl/blob/master/lib/connect.h#L40
2- https://forums.k8slens.dev/t/1144