### PR TITLE
Conditional iptables installation based on k0s version

### DIFF
--- a/pkg/apis/k0sctl.k0sproject.io/v1beta1/cluster/host.go
+++ b/pkg/apis/k0sctl.k0sproject.io/v1beta1/cluster/host.go
@@ -437,6 +437,9 @@ func (h *Host) NeedCurl() bool {
 }
 
 // NeedIPTables returns true when the iptables package is needed on the host
+//
+// Deprecated: iptables is only required for k0s versions that are unsupported
+// for a long time already (< v1.22.1+k0s.0).
 func (h *Host) NeedIPTables() bool {
 	// Windows does not need iptables
 	if h.Configurer.Kind() == "windows" {


### PR DESCRIPTION
Recreated #547 because github closed it on merge of #551 which was the base for #547 and now doesn't allow me to reopen or edit its base.
--
Only install `iptables` if the k0s version requires it. Mark the corresponding host method as deprecated, as that code path can probably be completely removed in upcoming versions.

Fixes #363.
