### PR TITLE
Show a warning when online k0s version defaulting fails

### DIFF
--- a/pkg/apis/k0sctl.k0sproject.io/v1beta1/cluster/k0s_test.go
+++ b/pkg/apis/k0sctl.k0sproject.io/v1beta1/cluster/k0s_test.go
@@ -43,14 +43,13 @@ func TestVersionDefaulting(t *testing.T) {
 	})
 
 	t.Run("version not given", func(t *testing.T) {
+		latestVersionFunc = func(_ bool) (*version.Version, error) {
+			return version.MustParse("v1.28.0+k0s.1"), nil
+		}
 		k0s := &K0s{}
 		require.NoError(t, defaults.Set(k0s))
 		require.NoError(t, k0s.Validate())
-		require.NotEmpty(t, k0s.Version.String())
-		require.True(t, len(k0s.Version.String()) > 6, "version too short")
-		newV, err := version.NewVersion(k0s.Version.String())
-		require.NoError(t, err)
-		require.Equal(t, newV.String(), k0s.Version.String())
+		require.Equal(t, k0s.Version.String(), "v1.28.0+k0s.1")
 		require.True(t, k0s.Metadata.VersionDefaulted)
 	})
 }


### PR DESCRIPTION
Fixes #569 
Closes #571 (alternate)

Shows a warning when the version defaulting fails. The test was modified to use a mocked latest version getter.
