### PR TITLE
Move k0s version defaulting into a phase

### DIFF
--- a/README.md
+++ b/README.md
@@ -571,6 +571,12 @@ If set to `true` k0sctl will remove the node from kubernetes and reset k0s on th
 
 The version of k0s to deploy. When left out, k0sctl will default to using the latest released version of k0s or the version already running on the cluster.
 
+##### `spec.k0s.versionChannel` &lt;string&gt; (optional) (default: `stable`)
+
+Possible values are `stable` and `latest`.
+
+When `spec.k0s.version` is left undefined, this setting can be set to `latest` to allow k0sctl to include k0s pre-releases when looking for the latest version. The default is to only look for stable releases.
+
 ##### `spec.k0s.dynamicConfig` &lt;boolean&gt; (optional) (default: false)
 
 Enable k0s dynamic config. The setting will be automatically set to true if:

--- a/action/apply.go
+++ b/action/apply.go
@@ -39,6 +39,7 @@ func (a Apply) Run() error {
 	lockPhase := &phase.Lock{}
 
 	a.Manager.AddPhase(
+		&phase.DefaultK0sVersion{},
 		&phase.Connect{},
 		&phase.DetectOS{},
 		lockPhase,

--- a/phase/default_k0s_version.go
+++ b/phase/default_k0s_version.go
@@ -1,0 +1,43 @@
+package phase
+
+import (
+	"fmt"
+
+	"github.com/k0sproject/version"
+
+	log "github.com/sirupsen/logrus"
+)
+
+type DefaultK0sVersion struct {
+	GenericPhase
+}
+
+func (p *DefaultK0sVersion) ShouldRun() bool {
+	return p.Config.Spec.K0s.Version == nil || p.Config.Spec.K0s.Version.IsZero()
+}
+
+func (p *DefaultK0sVersion) Title() string {
+	return "Set k0s version"
+}
+
+func (p *DefaultK0sVersion) Run() error {
+	isStable := p.Config.Spec.K0s.VersionChannel == "stable"
+
+	var msg string
+	if isStable {
+		msg = "latest stable k0s version"
+	} else {
+		msg = "latest k0s version including pre-releases"
+	}
+
+	log.Info("Looking up ", msg)
+	latest, err := version.LatestByPrerelease(!isStable)
+	if err != nil {
+		return fmt.Errorf("failed to look up k0s version online - try setting spec.k0s.version manually: %w", err)
+	}
+	log.Infof("Using k0s version %s", latest)
+	p.Config.Spec.K0s.Version = latest
+	p.Config.Spec.K0s.Metadata.VersionDefaulted = true
+
+	return nil
+}

--- a/phase/gather_k0s_facts.go
+++ b/phase/gather_k0s_facts.go
@@ -156,6 +156,10 @@ func (p *GatherK0sFacts) investigateK0s(h *cluster.Host) error {
 	}
 
 	h.Metadata.K0sRunningVersion = status.Version
+	if p.Config.Spec.K0s.Version == nil {
+		p.Config.Spec.K0s.Version = status.Version
+	}
+
 	h.Metadata.NeedsUpgrade = p.needsUpgrade(h)
 
 	log.Infof("%s: is running k0s %s version %s", h, h.Role, h.Metadata.K0sRunningVersion)
@@ -203,6 +207,10 @@ func (p *GatherK0sFacts) investigateK0s(h *cluster.Host) error {
 }
 
 func (p *GatherK0sFacts) needsUpgrade(h *cluster.Host) bool {
+	if h.Reset {
+		return false
+	}
+
 	// If supplimental files or a k0s binary have been specified explicitly,
 	// always upgrade.  This covers the scenario where a user moves from a
 	// default-install cluster to one fed by OCI image bundles (ie. airgap)

--- a/phase/prepare_hosts.go
+++ b/phase/prepare_hosts.go
@@ -51,7 +51,7 @@ func (p *PrepareHosts) prepareHost(h *cluster.Host) error {
 	}
 
 	// iptables is only required for very old versions of k0s
-	if !iptablesEmbeddedSince.Check(p.Config.Spec.K0s.Version) && h.NeedIPTables() { //nolint:staticcheck
+	if p.Config.Spec.K0s.Version != nil && !iptablesEmbeddedSince.Check(p.Config.Spec.K0s.Version) && h.NeedIPTables() { //nolint:staticcheck
 		pkgs = append(pkgs, "iptables")
 	}
 

--- a/pkg/apis/k0sctl.k0sproject.io/v1beta1/cluster.go
+++ b/pkg/apis/k0sctl.k0sproject.io/v1beta1/cluster.go
@@ -1,7 +1,11 @@
 package v1beta1
 
 import (
+	"fmt"
+
+	"github.com/creasty/defaults"
 	"github.com/jellydator/validation"
+
 	"github.com/k0sproject/k0sctl/pkg/apis/k0sctl.k0sproject.io/v1beta1/cluster"
 )
 
@@ -34,6 +38,10 @@ func (c *Cluster) UnmarshalYAML(unmarshal func(interface{}) error) error {
 
 	if err := unmarshal(yc); err != nil {
 		return err
+	}
+
+	if err := defaults.Set(c); err != nil {
+		return fmt.Errorf("failed to set defaults: %w", err)
 	}
 
 	return nil

--- a/pkg/apis/k0sctl.k0sproject.io/v1beta1/cluster/k0s_test.go
+++ b/pkg/apis/k0sctl.k0sproject.io/v1beta1/cluster/k0s_test.go
@@ -39,18 +39,5 @@ func TestVersionDefaulting(t *testing.T) {
 		k0s := &K0s{Version: version.MustParse("v0.11.0-rc1")}
 		require.NoError(t, defaults.Set(k0s))
 		require.NoError(t, k0s.Validate())
-		require.False(t, k0s.Metadata.VersionDefaulted)
-	})
-
-	t.Run("version not given", func(t *testing.T) {
-		k0s := &K0s{}
-		require.NoError(t, defaults.Set(k0s))
-		require.NoError(t, k0s.Validate())
-		require.NotEmpty(t, k0s.Version.String())
-		require.True(t, len(k0s.Version.String()) > 6, "version too short")
-		newV, err := version.NewVersion(k0s.Version.String())
-		require.NoError(t, err)
-		require.Equal(t, newV.String(), k0s.Version.String())
-		require.True(t, k0s.Metadata.VersionDefaulted)
 	})
 }

--- a/pkg/apis/k0sctl.k0sproject.io/v1beta1/cluster/spec.go
+++ b/pkg/apis/k0sctl.k0sproject.io/v1beta1/cluster/spec.go
@@ -28,6 +28,14 @@ func (s *Spec) UnmarshalYAML(unmarshal func(interface{}) error) error {
 	return defaults.Set(s)
 }
 
+// SetDefaults sets defaults
+func (s *Spec) SetDefaults() {
+	if s.K0s == nil {
+		s.K0s = &K0s{}
+		_ = defaults.Set(s.K0s)
+	}
+}
+
 // K0sLeader returns a controller host that is selected to be a "leader",
 // or an initial node, a node that creates join tokens for other controllers.
 func (s *Spec) K0sLeader() *Host {


### PR DESCRIPTION
Fixes #569 
Closes #570 (alternate)

Adds a `DefaultK0sVersion` phase that sets the k0s version when it has been left undefined.

Adds a `spec.k0s.versionChannel` config key for selecting between "stable" and "latest" channels for version lookups.

