### PR TITLE
Longer timeout for lint workflow

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -24,4 +24,4 @@ jobs:
           version: latest
           skip-cache: true
           only-new-issues: false
-          args: --verbose
+          args: --verbose --timeout=10m


### PR DESCRIPTION
It's now timing out every second run
