### PR TITLE
More k0s version constraints

### DIFF
--- a/phase/configure_k0s.go
+++ b/phase/configure_k0s.go
@@ -72,8 +72,9 @@ func (p *ConfigureK0s) Run() error {
 
 func (p *ConfigureK0s) validateConfig(h *cluster.Host, configPath string) error {
 	log.Infof("%s: validating configuration", h)
+
 	var cmd string
-	if h.Exec(h.Configurer.K0sCmdf("config validate --help"), exec.Sudo(h)) == nil {
+	if configCreateSinceVersion.Check(p.Config.Spec.K0s.Version) {
 		cmd = h.Configurer.K0sCmdf(`config validate --config "%s"`, configPath)
 	} else {
 		cmd = h.Configurer.K0sCmdf(`validate config --config "%s"`, configPath)

--- a/phase/configure_k0s.go
+++ b/phase/configure_k0s.go
@@ -15,9 +15,13 @@ import (
 	"github.com/k0sproject/k0sctl/pkg/node"
 	"github.com/k0sproject/k0sctl/pkg/retry"
 	"github.com/k0sproject/rig/exec"
+	"github.com/k0sproject/version"
 	log "github.com/sirupsen/logrus"
 	"gopkg.in/yaml.v2"
 )
+
+// "k0s default-config" was replaced with "k0s config create" in v1.23.1+k0s.0
+var configCreateSinceVersion = version.MustConstraint(">= v1.23.1+k0s.0")
 
 // ConfigureK0s writes the k0s configuration to host k0s config dir
 type ConfigureK0s struct {
@@ -44,7 +48,7 @@ func (p *ConfigureK0s) Run() error {
 		log.Warnf("%s: generating default configuration", p.leader)
 
 		var cmd string
-		if p.leader.Exec(p.leader.Configurer.K0sCmdf("config create --help"), exec.Sudo(p.leader)) == nil {
+		if configCreateSinceVersion.Check(p.Config.Spec.K0s.Version) {
 			cmd = p.leader.Configurer.K0sCmdf("config create --data-dir=%s", p.leader.K0sDataDir())
 		} else {
 			cmd = p.leader.Configurer.K0sCmdf("default-config")

--- a/phase/restore.go
+++ b/phase/restore.go
@@ -29,13 +29,18 @@ func (p *Restore) ShouldRun() bool {
 
 // Prepare the phase
 func (p *Restore) Prepare(config *v1beta1.Cluster) error {
-	log.Tracef("restore from: %s", p.RestoreFrom)
 	p.Config = config
-	p.leader = p.Config.Spec.K0sLeader()
 
-	if p.RestoreFrom != "" && p.leader.Exec(p.leader.Configurer.K0sCmdf("restore --help"), exec.Sudo(p.leader)) != nil {
+	if p.RestoreFrom == "" {
+		return nil
+	}
+
+	// defined in backup.go
+	if !backupSinceVersion.Check(p.Config.Spec.K0s.Version) {
 		return fmt.Errorf("the version of k0s on the host does not support restoring backups")
 	}
+
+	p.leader = p.Config.Spec.K0sLeader()
 
 	log.Tracef("restore leader: %s", p.leader)
 	log.Tracef("restore leader state: %+v", p.leader.Metadata)

--- a/pkg/apis/k0sctl.k0sproject.io/v1beta1/cluster/k0s.go
+++ b/pkg/apis/k0sctl.k0sproject.io/v1beta1/cluster/k0s.go
@@ -126,7 +126,7 @@ func (k *K0s) NodeConfig() dig.Mapping {
 }
 
 // GenerateToken runs the k0s token create command
-func (k K0s) GenerateToken(h *Host, role string, expiry time.Duration) (string, error) {
+func (k *K0s) GenerateToken(h *Host, role string, expiry time.Duration) (string, error) {
 	var k0sFlags Flags
 	k0sFlags.Add(fmt.Sprintf("--role %s", role))
 	k0sFlags.Add(fmt.Sprintf("--expiry %s", expiry))
@@ -150,7 +150,7 @@ func (k K0s) GenerateToken(h *Host, role string, expiry time.Duration) (string, 
 }
 
 // GetClusterID uses kubectl to fetch the kube-system namespace uid
-func (k K0s) GetClusterID(h *Host) (string, error) {
+func (k *K0s) GetClusterID(h *Host) (string, error) {
 	return h.ExecOutput(h.Configurer.KubectlCmdf(h, h.K0sDataDir(), "get -n kube-system namespace kube-system -o template={{.metadata.uid}}"), exec.Sudo(h))
 }
 


### PR DESCRIPTION
There were several occasions of using `--help` to figure out if a feature was supported or not.

Changed those to use version constraints.
