### PR TITLE
Suggest reset after k0s install has already run

### DIFF
--- a/phase/initialize_k0s.go
+++ b/phase/initialize_k0s.go
@@ -72,6 +72,8 @@ func (p *InitializeK0s) Run() error {
 		return err
 	}
 
+	h.Metadata.K0sInstalled = true
+
 	if len(h.Environment) > 0 {
 		log.Infof("%s: updating service environment", h)
 		if err := h.Configurer.UpdateServiceEnvironment(h, h.K0sServiceName(), h.Environment); err != nil {

--- a/phase/install_controllers.go
+++ b/phase/install_controllers.go
@@ -119,6 +119,7 @@ func (p *InstallControllers) Run() error {
 		if err = h.Exec(cmd); err != nil {
 			return err
 		}
+		h.Metadata.K0sInstalled = true
 
 		if len(h.Environment) > 0 {
 			log.Infof("%s: updating service environment", h)

--- a/phase/install_workers.go
+++ b/phase/install_workers.go
@@ -137,6 +137,8 @@ func (p *InstallWorkers) Run() error {
 			return err
 		}
 
+		h.Metadata.K0sInstalled = true
+
 		if len(h.Environment) > 0 {
 			log.Infof("%s: updating service environment", h)
 			if err := h.Configurer.UpdateServiceEnvironment(h, h.K0sServiceName(), h.Environment); err != nil {

--- a/pkg/apis/k0sctl.k0sproject.io/v1beta1/cluster/host.go
+++ b/pkg/apis/k0sctl.k0sproject.io/v1beta1/cluster/host.go
@@ -175,6 +175,7 @@ type HostMetadata struct {
 	K0sBinaryVersion  *version.Version
 	K0sBinaryTempFile string
 	K0sRunningVersion *version.Version
+	K0sInstalled      bool
 	Arch              string
 	IsK0sLeader       bool
 	Hostname          string


### PR DESCRIPTION
Fixes #572
Closes #582 (alternative)

If the cluster installation fails after "k0s install" has already been run on some of the hosts, display a warning telling that it's advisable to run reset on them before retry.

An alternative would be to actually run k0s reset.
