### PR TITLE
Run reset after k0s install has been run but host doesn't come up

### DIFF
--- a/action/apply.go
+++ b/action/apply.go
@@ -84,6 +84,7 @@ func (a Apply) Run() error {
 
 	if result = a.Manager.Run(); result != nil {
 		analytics.Client.Publish("apply-failure", map[string]interface{}{"clusterID": a.Manager.Config.Spec.K0s.Metadata.ClusterID})
+		log.Info(phase.Colorize.Red("==> Apply failed").String())
 		return result
 	}
 

--- a/pkg/apis/k0sctl.k0sproject.io/v1beta1/cluster/host.go
+++ b/pkg/apis/k0sctl.k0sproject.io/v1beta1/cluster/host.go
@@ -175,6 +175,7 @@ type HostMetadata struct {
 	K0sBinaryVersion  *version.Version
 	K0sBinaryTempFile string
 	K0sRunningVersion *version.Version
+	K0sInstalled      bool
 	Arch              string
 	IsK0sLeader       bool
 	Hostname          string


### PR DESCRIPTION
Fixes #572
Closes #581 (alternative)

If `k0s install` has already been run on a host but the host fails to become ready, run "k0s reset" on it in the phase's cleanup.
