### PR TITLE
Look for fallback OS support through ID_LIKE field

### DIFF
--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -96,6 +96,35 @@ jobs:
           LINUX_IMAGE: ${{ matrix.image }}
         run: make smoke-basic
   
+  smoke-basic-idlike:
+    name: Basic 1+1 smoke (ID_LIKE fallback)
+    needs: build
+    runs-on: ubuntu-20.04
+
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Go
+        uses: actions/setup-go@v4
+        with:
+          go-version-file: go.mod
+          check-latest: true
+
+      - {"name":"Go modules cache","uses":"actions/cache@v3","with":{"path":"~/go/pkg/mod\n~/.cache/go-build\n~/Library/Caches/go-build\n%LocalAppData%\\go-build\n","key":"${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}","restore-keys":"${{ runner.os }}-go-\n"}}
+      - {"name":"Compiled binary cache","uses":"actions/download-artifact@v3","with":{"name":"k0sctl","path":"."}}
+      - {"name":"Make executable","run":"chmod +x k0sctl"}
+      - {"name":"K0sctl cache","uses":"actions/cache@v3","with":{"path":"/var/cache/k0sctl\n~/.cache/k0sctl\n!*.log\n","key":"k0sctl-cache"}}
+      - {"name":"Kubectl cache","uses":"actions/cache@v3","with":{"path":"smoke-test/kubectl\n","key":"kubectl-1.21.3"}}
+      - {"name":"Go modules cache","uses":"actions/cache@v3","with":{"path":"~/go/pkg/mod\n~/.cache/go-build\n~/Library/Caches/go-build\n%LocalAppData%\\go-build\n","key":"${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}","restore-keys":"${{ runner.os }}-go-\n"}}
+      - {"name":"Docker Layer Caching For Bootloose","uses":"satackey/action-docker-layer-caching@v0.0.11","continue-on-error":true}
+
+      - name: Build image
+        run: |
+          make -C smoke-test kalilinux.iid
+          echo "LINUX_IMAGE=$(cat smoke-test/kalilinux.iid)" >> "$GITHUB_ENV"
+
+      - name: Run smoke tests
+        run: make smoke-basic
+  
   smoke-basic-openssh:
     strategy:
       matrix:

--- a/smoke-test/.gitignore
+++ b/smoke-test/.gitignore
@@ -1,4 +1,5 @@
-footloose.yaml
+bootloose.yaml
 id_rsa*
 k0sctl_040
 *.tar.gz
+*.iid

--- a/smoke-test/Dockerfile.kalilinux
+++ b/smoke-test/Dockerfile.kalilinux
@@ -1,0 +1,47 @@
+FROM kalilinux/kali-rolling:latest
+
+ENV container docker
+
+# Don't start any optional services except for the few we need.
+RUN find /etc/systemd/system \
+    /lib/systemd/system \
+    -path '*.wants/*' \
+    -not -name '*journald*' \
+    -not -name '*systemd-tmpfiles*' \
+    -not -name '*systemd-user-sessions*' \
+    -exec rm \{} \;
+
+RUN apt-get update && \
+    apt-get install -y \
+    dbus systemd openssh-server net-tools iproute2 iputils-ping curl wget vim-tiny sudo && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/*
+
+# Truncate machine ID files to trigger regeneration.
+RUN >/etc/machine-id
+RUN >/var/lib/dbus/machine-id
+
+EXPOSE 22
+
+RUN systemctl set-default multi-user.target
+RUN systemctl mask \
+    dev-hugepages.mount \
+    sys-fs-fuse-connections.mount \
+    systemd-update-utmp.service \
+    systemd-tmpfiles-setup.service \
+    console-getty.service
+
+# This container image doesn't have locales installed. Disable forwarding the
+# user locale env variables or we get warnings such as:
+#  bash: warning: setlocale: LC_ALL: cannot change locale
+RUN sed -i -e 's/^AcceptEnv LANG LC_\*$/#AcceptEnv LANG LC_*/' /etc/ssh/sshd_config
+RUN systemctl enable ssh
+
+# This may be needed for some systemd services to start properly.
+RUN echo "#!/bin/sh\nexit 0" > /usr/sbin/policy-rc.d
+
+# https://www.freedesktop.org/wiki/Software/systemd/ContainerInterface/
+STOPSIGNAL SIGRTMIN+3
+
+CMD ["/bin/bash"]
+

--- a/smoke-test/Makefile
+++ b/smoke-test/Makefile
@@ -46,3 +46,5 @@ smoke-os-override: $(bootloose) id_rsa_k0s k0sctl
 smoke-backup-restore: $(bootloose) id_rsa_k0s k0sctl
 	./smoke-backup-restore.sh
 
+%.iid: Dockerfile.%
+	docker build --iidfile '$@' - < '$<'


### PR DESCRIPTION
Uses the ID_LIKE field (when not empty) to look for a fallback OS support module. A warning is displayed when fallback is used.

Added a test using kali linux (debian).

It's worth noting that not all distros have ID_LIKE at all, some have multiple values like `ID_LIKE="fedora rhel"` and for example clearlinux has `ID_LIKE=clear-linux-os` (same as ID).
