### PR TITLE
Add --confirm-exec flag to promp confirmation before remote commands

### DIFF
--- a/cmd/apply.go
+++ b/cmd/apply.go
@@ -18,6 +18,7 @@ var applyCommand = &cli.Command{
 		configFlag,
 		concurrencyFlag,
 		concurrentUploadsFlag,
+		confirmFlag,
 		&cli.BoolFlag{
 			Name:  "no-wait",
 			Usage: "Do not wait for worker nodes to join",

--- a/cmd/backup.go
+++ b/cmd/backup.go
@@ -14,6 +14,7 @@ var backupCommand = &cli.Command{
 	Flags: []cli.Flag{
 		configFlag,
 		concurrencyFlag,
+		confirmFlag,
 		debugFlag,
 		traceFlag,
 		redactFlag,

--- a/cmd/config_edit.go
+++ b/cmd/config_edit.go
@@ -12,6 +12,7 @@ var configEditCommand = &cli.Command{
 	Usage: "Edit k0s dynamic config in SHELL's default editor",
 	Flags: []cli.Flag{
 		configFlag,
+		confirmFlag,
 		debugFlag,
 		traceFlag,
 		redactFlag,

--- a/cmd/config_status.go
+++ b/cmd/config_status.go
@@ -12,6 +12,7 @@ var configStatusCommand = &cli.Command{
 	Usage: "Show k0s dynamic config reconciliation events",
 	Flags: []cli.Flag{
 		configFlag,
+		confirmFlag,
 		debugFlag,
 		traceFlag,
 		redactFlag,

--- a/cmd/flags.go
+++ b/cmd/flags.go
@@ -34,6 +34,15 @@ type ctxManagerKey struct{}
 type ctxLogFileKey struct{}
 
 var (
+	confirmFlag = &cli.BoolFlag{
+		Name:  "confirm-exec",
+		Usage: "Prompt for confirmation before running remote commands",
+		Action: func(_ *cli.Context, confirm bool) error {
+			exec.Confirm = confirm
+			return nil
+		},
+	}
+
 	debugFlag = &cli.BoolFlag{
 		Name:    "debug",
 		Usage:   "Enable debug logging",

--- a/cmd/kubeconfig.go
+++ b/cmd/kubeconfig.go
@@ -19,6 +19,7 @@ var kubeconfigCommand = &cli.Command{
 			Value: "",
 		},
 		configFlag,
+		confirmFlag,
 		debugFlag,
 		traceFlag,
 		redactFlag,

--- a/cmd/reset.go
+++ b/cmd/reset.go
@@ -15,6 +15,7 @@ var resetCommand = &cli.Command{
 	Flags: []cli.Flag{
 		configFlag,
 		concurrencyFlag,
+		confirmFlag,
 		debugFlag,
 		traceFlag,
 		redactFlag,


### PR DESCRIPTION
As mentioned in #586 - I thought this feature was already there.

When used, k0sctl will ask for confirmation before every single remote command is executed. It may not be very useful.
