### PR TITLE
Fix getting host address on OpenSSH connections

### DIFF
--- a/pkg/apis/k0sctl.k0sproject.io/v1beta1/cluster/host.go
+++ b/pkg/apis/k0sctl.k0sproject.io/v1beta1/cluster/host.go
@@ -210,14 +210,9 @@ func (h *Host) UnmarshalYAML(unmarshal func(interface{}) error) error {
 
 // Address returns an address for the host
 func (h *Host) Address() string {
-	if h.SSH != nil {
-		return h.SSH.Address
+	if addr := h.Connection.Address(); addr != "" {
+		return addr
 	}
-
-	if h.WinRM != nil {
-		return h.WinRM.Address
-	}
-
 	return "127.0.0.1"
 }
 


### PR DESCRIPTION
OpenSSH connections were getting 127.0.0.1 from the `h.Address()` function.
