### PR TITLE
Fix host_test

### DIFF
--- a/phase/initialize_k0s.go
+++ b/phase/initialize_k0s.go
@@ -79,7 +79,7 @@ func (p *InitializeK0s) Run() error {
 	}
 
 	err = p.Wet(p.leader, fmt.Sprintf("install first k0s controller using `%s`", strings.ReplaceAll(cmd, p.leader.Configurer.K0sBinaryPath(), "k0s")), func() error {
-		return h.Exec(cmd)
+		return h.Exec(cmd, exec.Sudo(h))
 	}, func() error {
 		p.leader.Metadata.DryRunFakeLeader = true
 		return nil

--- a/phase/install_controllers.go
+++ b/phase/install_controllers.go
@@ -154,7 +154,7 @@ func (p *InstallControllers) Run() error {
 		}
 		log.Infof("%s: installing k0s controller", h)
 		err = p.Wet(h, fmt.Sprintf("install k0s controller using `%s", strings.ReplaceAll(cmd, h.Configurer.K0sBinaryPath(), "k0s")), func() error {
-			return h.Exec(cmd)
+			return h.Exec(cmd, exec.Sudo(h))
 		})
 		if err != nil {
 			return err

--- a/phase/install_workers.go
+++ b/phase/install_workers.go
@@ -187,7 +187,7 @@ func (p *InstallWorkers) Run() error {
 			return err
 		}
 		err = p.Wet(h, fmt.Sprintf("install k0s worker with `%s`", strings.ReplaceAll(cmd, h.Configurer.K0sBinaryPath(), "k0s")), func() error {
-			return h.Exec(cmd)
+			return h.Exec(cmd, exec.Sudo(h))
 		})
 		if err != nil {
 			return err

--- a/pkg/apis/k0sctl.k0sproject.io/v1beta1/cluster/host.go
+++ b/pkg/apis/k0sctl.k0sproject.io/v1beta1/cluster/host.go
@@ -337,13 +337,7 @@ func (h *Host) K0sInstallCommand() (string, error) {
 		flags.Delete("--force")
 	}
 
-	cmd := h.Configurer.K0sCmdf("install %s %s", role, flags.Join())
-	sudocmd, err := h.Sudo(cmd)
-	if err != nil {
-		log.Warnf("%s: %s", h, err.Error())
-		return cmd, nil
-	}
-	return sudocmd, nil
+	return h.Configurer.K0sCmdf("install %s %s", role, flags.Join()), nil
 }
 
 // K0sBackupCommand returns a full command to be used as run k0s backup

--- a/pkg/apis/k0sctl.k0sproject.io/v1beta1/cluster/host_test.go
+++ b/pkg/apis/k0sctl.k0sproject.io/v1beta1/cluster/host_test.go
@@ -2,7 +2,6 @@ package cluster
 
 import (
 	"fmt"
-	"strings"
 	"testing"
 
 	cfg "github.com/k0sproject/k0sctl/configurer"
@@ -79,44 +78,45 @@ func TestK0sInstallCommand(t *testing.T) {
 
 	cmd, err := h.K0sInstallCommand()
 	require.NoError(t, err)
-	require.True(t, strings.HasSuffix(cmd, `k0s install worker --data-dir=/tmp/k0s --token-file "from-configurer"`))
+	require.Equal(t, `k0s install worker --data-dir=/tmp/k0s --token-file "from-configurer"`, cmd)
 
 	h.Role = "controller"
 	h.Metadata.IsK0sLeader = true
 	cmd, err = h.K0sInstallCommand()
 	require.NoError(t, err)
-	require.True(t, strings.HasSuffix(cmd, `k0s install controller --data-dir=/tmp/k0s --config "from-configurer"`))
+	require.Equal(t, `k0s install controller --data-dir=/tmp/k0s --config "from-configurer"`, cmd)
 
 	h.Metadata.IsK0sLeader = false
 	cmd, err = h.K0sInstallCommand()
 	require.NoError(t, err)
-	require.True(t, strings.HasSuffix(cmd, `k0s install controller --data-dir=/tmp/k0s --token-file "from-configurer" --config "from-configurer"`))
+	require.Equal(t, `k0s install controller --data-dir=/tmp/k0s --token-file "from-configurer" --config "from-configurer"`, cmd)
 
 	h.Role = "controller+worker"
 	h.Metadata.IsK0sLeader = true
 	cmd, err = h.K0sInstallCommand()
 	require.NoError(t, err)
-	require.True(t, strings.HasSuffix(cmd, `k0s install controller --data-dir=/tmp/k0s --enable-worker --config "from-configurer"`))
+	require.Equal(t, `k0s install controller --data-dir=/tmp/k0s --enable-worker --config "from-configurer"`, cmd)
+
 	h.Metadata.IsK0sLeader = false
 	cmd, err = h.K0sInstallCommand()
 	require.NoError(t, err)
-	require.True(t, strings.HasSuffix(cmd, `k0s install controller --data-dir=/tmp/k0s --enable-worker --token-file "from-configurer" --config "from-configurer"`))
+	require.Equal(t, `k0s install controller --data-dir=/tmp/k0s --enable-worker --token-file "from-configurer" --config "from-configurer"`, cmd)
 
 	h.Role = "worker"
 	h.PrivateAddress = "10.0.0.9"
 	cmd, err = h.K0sInstallCommand()
 	require.NoError(t, err)
-	require.True(t, strings.HasSuffix(cmd, `k0s install worker --data-dir=/tmp/k0s --token-file "from-configurer" --kubelet-extra-args="--node-ip=10.0.0.9"`))
+	require.Equal(t, `k0s install worker --data-dir=/tmp/k0s --token-file "from-configurer" --kubelet-extra-args="--node-ip=10.0.0.9"`, cmd)
 
 	h.InstallFlags = []string{`--kubelet-extra-args="--foo bar"`}
 	cmd, err = h.K0sInstallCommand()
 	require.NoError(t, err)
-	require.True(t, strings.HasSuffix(cmd, `k0s install worker --kubelet-extra-args="--foo bar --node-ip=10.0.0.9" --data-dir=/tmp/k0s --token-file "from-configurer"`))
+	require.Equal(t, `k0s install worker --kubelet-extra-args="--foo bar --node-ip=10.0.0.9" --data-dir=/tmp/k0s --token-file "from-configurer"`, cmd)
 
 	h.InstallFlags = []string{`--enable-cloud-provider`}
 	cmd, err = h.K0sInstallCommand()
 	require.NoError(t, err)
-	require.True(t, strings.HasSuffix(cmd, `k0s install worker --enable-cloud-provider --data-dir=/tmp/k0s --token-file "from-configurer"`))
+	require.Equal(t, `k0s install worker --enable-cloud-provider --data-dir=/tmp/k0s --token-file "from-configurer"`, cmd)
 }
 
 func TestValidation(t *testing.T) {


### PR DESCRIPTION
Fixes #630 

Made `K0sInstallCommand` return a non-sudo version of the command, the usages of its output have been modified to use `exec.Sudo()`. After this, the `host_test.go` can compare the output against "non-sudofied" strings.
