### PR TITLE
Clean up version: null from "k0sctl init" output

### DIFF
--- a/phase/default_k0s_version.go
+++ b/phase/default_k0s_version.go
@@ -21,7 +21,7 @@ func (p *DefaultK0sVersion) Title() string {
 }
 
 func (p *DefaultK0sVersion) Run() error {
-	isStable := p.Config.Spec.K0s.VersionChannel == "stable"
+	isStable := p.Config.Spec.K0s.VersionChannel == "" || p.Config.Spec.K0s.VersionChannel == "stable"
 
 	var msg string
 	if isStable {

--- a/pkg/apis/k0sctl.k0sproject.io/v1beta1/cluster/spec.go
+++ b/pkg/apis/k0sctl.k0sproject.io/v1beta1/cluster/spec.go
@@ -9,8 +9,8 @@ import (
 
 // Spec defines cluster config spec section
 type Spec struct {
-	Hosts Hosts `yaml:"hosts"`
-	K0s   *K0s  `yaml:"k0s"`
+	Hosts Hosts `yaml:"hosts,omitempty"`
+	K0s   *K0s  `yaml:"k0s,omitempty"`
 
 	k0sLeader *Host
 }
@@ -26,6 +26,19 @@ func (s *Spec) UnmarshalYAML(unmarshal func(interface{}) error) error {
 	}
 
 	return defaults.Set(s)
+}
+
+// MarshalYAML implements yaml.Marshaler interface
+func (s *Spec) MarshalYAML() (interface{}, error) {
+	k0s, err := s.K0s.MarshalYAML()
+	if err != nil {
+		return nil, err
+	}
+	if k0s == nil {
+		return Spec{Hosts: s.Hosts}, nil
+	}
+
+	return s, nil
 }
 
 // SetDefaults sets defaults


### PR DESCRIPTION
Before:

```yaml
apiVersion: k0sctl.k0sproject.io/v1beta1
kind: Cluster
metadata:
  name: k0s-cluster
spec:
  hosts:
  - ssh:
      address: 10.0.0.1
      user: root
      port: 22
      keyPath: null
    role: controller
  - ssh:
      address: 10.0.0.2
      user: root
      port: 22
      keyPath: null
    role: worker
  k0s:
    version: null
    versionChannel: stable
    dynamicConfig: false
    config: {}
```

After:

```yaml
apiVersion: k0sctl.k0sproject.io/v1beta1
kind: Cluster
metadata:
  name: k0s-cluster
spec:
  hosts:
  - ssh:
      address: 10.0.0.1
      user: root
      port: 22
      keyPath: null
    role: controller
  - ssh:
      address: 10.0.0.2
      user: root
      port: 22
      keyPath: null
    role: worker
```

With `--k0s`:

```yaml
apiVersion: k0sctl.k0sproject.io/v1beta1
kind: Cluster
metadata:
  name: k0s-cluster
spec:
  hosts:
  - ssh:
      address: 10.0.0.1
      user: root
      port: 22
      keyPath: null
    role: controller
  - ssh:
      address: 10.0.0.2
      user: root
      port: 22
      keyPath: null
    role: worker
  k0s:
    config:
      apiVersion: k0s.k0sproject.io/v1beta1
      kind: Cluster
      metadata:
        name: k0s
      spec:
        api:
          k0sApiPort: 9443
          port: 6443
        installConfig:
          users:
            etcdUser: etcd
            kineUser: kube-apiserver
            konnectivityUser: konnectivity-server
            kubeAPIserverUser: kube-apiserver
            kubeSchedulerUser: kube-scheduler
        konnectivity:
          adminPort: 8133
          agentPort: 8132
        network:
          kubeProxy:
            disabled: false
            mode: iptables
          kuberouter:
            autoMTU: true
            mtu: 0
            peerRouterASNs: ""
            peerRouterIPs: ""
          podCIDR: 10.244.0.0/16
          provider: kuberouter
          serviceCIDR: 10.96.0.0/12
        podSecurityPolicy:
          defaultPolicy: 00-k0s-privileged
        storage:
          type: etcd
        telemetry:
          enabled: true
```
