### PR TITLE
bug: reconnect ssh upon environment change

### DIFF
--- a/phase/prepare_hosts.go
+++ b/phase/prepare_hosts.go
@@ -51,8 +51,8 @@ func (p *PrepareHosts) updateEnvironment(h *cluster.Host) error {
 	// preserved across multiple ssh sessions. We need to write the environment
 	// and then reopen the ssh session. Go's ssh client.Setenv() depends on ssh
 	// server configuration (sshd only accepts LC_* variables by default).
+	log.Infof("%s: reconnecting to apply new environment", h)
 	h.Disconnect()
-	log.Infof("%s: Reconnecting", h)
 	return retry.Timeout(context.TODO(), 10*time.Minute, func(_ context.Context) error {
 		if err := h.Connect(); err != nil {
 			if errors.Is(err, rig.ErrCantConnect) || strings.Contains(err.Error(), "host key mismatch") {


### PR DESCRIPTION
This is a workaround. UpdateEnvironment on rig's os/linux.go writes the environment to /etc/environment and then exports the same variables using 'export' command.

Unfortunately this is not enough for the environment to be preserved across multiple ssh sessions. We need to write the environment and then reopen the ssh connection. Go's ssh client.Setenv() depends on ssh server configuration (sshd only accepts LC_* variables by default).

This problem happens, for example, when we need to deploy k0s behing a proxy. We set the necessary environment variables in k0sctl.yaml but the command fails when attempting to use `apt` to install `curl`.

As `HTTP_PROXY`, and any other variable, are not set when we run the apt command it fail as it can't reach the remote servers.

I am leaving this as a DRAFT for now, hopefully someone will take a peak and tell me what else should I do (or tests are going to fail).