### PR TITLE
Detect 404 not found error when downloading using curl

### DIFF
--- a/configurer/linux.go
+++ b/configurer/linux.go
@@ -172,7 +172,7 @@ func (l *Linux) DownloadK0s(h os.Host, path string, version *version.Version, ar
 	v := strings.ReplaceAll(strings.TrimPrefix(version.String(), "v"), "+", "%2B")
 	url := fmt.Sprintf("https://github.com/k0sproject/k0s/releases/download/v%[1]s/k0s-v%[1]s-%[2]s", v, arch)
 	if err := l.DownloadURL(h, url, path); err != nil {
-		return fmt.Errorf("download k0s: %w", err)
+		return fmt.Errorf("failed to download k0s - check connectivity and k0s version validity: %w", err)
 	}
 
 	return nil


### PR DESCRIPTION
Fixes #656

Instead of:

> download k0s: command failed: client exec: command wait: exit status 22 

You now get:

> failed to download k0s - check connectivity and k0s version validity: download failed: command failed: http 404 - not found: client exec: command wait: exit status 22
