### PR TITLE
Add GatherFacts phase to reset command

### DIFF
--- a/action/reset.go
+++ b/action/reset.go
@@ -48,6 +48,7 @@ func (r Reset) Run() error {
 		&phase.DetectOS{},
 		lockPhase,
 		&phase.PrepareHosts{},
+		&phase.GatherFacts{},
 		&phase.GatherK0sFacts{},
 		&phase.RunHooks{Stage: "before", Action: "reset"},
 		&phase.ResetWorkers{


### PR DESCRIPTION
So that the hostnames are collected and the GatherK0sFacts phase can access them when printing progress messages.

This prevents messages like `checking if worker  has joined`.