### PR TITLE
Remove self-update check

### DIFF
--- a/cmd/apply.go
+++ b/cmd/apply.go
@@ -56,15 +56,14 @@ var applyCommand = &cli.Command{
 		retryIntervalFlag,
 		retryTimeoutFlag,
 		analyticsFlag,
-		upgradeCheckFlag,
 	},
-	Before: actions(initLogging, startCheckUpgrade, initConfig, initManager, displayLogo, initAnalytics, displayCopyright, warnOldCache),
-	After:  actions(reportCheckUpgrade, closeAnalytics),
+	Before: actions(initLogging, initConfig, initManager, displayLogo, initAnalytics, displayCopyright, warnOldCache),
+	After:  actions(closeAnalytics),
 	Action: func(ctx *cli.Context) error {
 		var kubeconfigOut io.Writer
 
 		if kc := ctx.String("kubeconfig-out"); kc != "" {
-			out, err := os.OpenFile(kc, os.O_CREATE|os.O_WRONLY, 0600)
+			out, err := os.OpenFile(kc, os.O_CREATE|os.O_WRONLY, 0o600)
 			if err != nil {
 				return fmt.Errorf("failed to open kubeconfig-out file: %w", err)
 			}

--- a/cmd/backup.go
+++ b/cmd/backup.go
@@ -21,10 +21,9 @@ var backupCommand = &cli.Command{
 		retryIntervalFlag,
 		retryTimeoutFlag,
 		analyticsFlag,
-		upgradeCheckFlag,
 	},
-	Before: actions(initLogging, startCheckUpgrade, initConfig, initManager, displayLogo, initAnalytics, displayCopyright),
-	After:  actions(reportCheckUpgrade, closeAnalytics),
+	Before: actions(initLogging, initConfig, initManager, displayLogo, initAnalytics, displayCopyright),
+	After:  actions(closeAnalytics),
 	Action: func(ctx *cli.Context) error {
 		backupAction := action.Backup{
 			Manager: ctx.Context.Value(ctxManagerKey{}).(*phase.Manager),

--- a/cmd/config_edit.go
+++ b/cmd/config_edit.go
@@ -16,10 +16,9 @@ var configEditCommand = &cli.Command{
 		traceFlag,
 		redactFlag,
 		analyticsFlag,
-		upgradeCheckFlag,
 	},
-	Before: actions(initLogging, startCheckUpgrade, initConfig, initAnalytics),
-	After:  actions(reportCheckUpgrade, closeAnalytics),
+	Before: actions(initLogging, initConfig, initAnalytics),
+	After:  actions(closeAnalytics),
 	Action: func(ctx *cli.Context) error {
 		configEditAction := action.ConfigEdit{
 			Config: ctx.Context.Value(ctxConfigKey{}).(*v1beta1.Cluster),

--- a/cmd/config_status.go
+++ b/cmd/config_status.go
@@ -16,15 +16,14 @@ var configStatusCommand = &cli.Command{
 		traceFlag,
 		redactFlag,
 		analyticsFlag,
-		upgradeCheckFlag,
 		&cli.StringFlag{
 			Name:    "output",
 			Usage:   "kubectl output formatting",
 			Aliases: []string{"o"},
 		},
 	},
-	Before: actions(initLogging, startCheckUpgrade, initConfig, initAnalytics),
-	After:  actions(reportCheckUpgrade, closeAnalytics),
+	Before: actions(initLogging, initConfig, initAnalytics),
+	After:  actions(closeAnalytics),
 	Action: func(ctx *cli.Context) error {
 		configStatusAction := action.ConfigStatus{
 			Config: ctx.Context.Value(ctxConfigKey{}).(*v1beta1.Cluster),

--- a/cmd/reset.go
+++ b/cmd/reset.go
@@ -22,15 +22,14 @@ var resetCommand = &cli.Command{
 		retryIntervalFlag,
 		retryTimeoutFlag,
 		analyticsFlag,
-		upgradeCheckFlag,
 		&cli.BoolFlag{
 			Name:    "force",
 			Usage:   "Don't ask for confirmation",
 			Aliases: []string{"f"},
 		},
 	},
-	Before: actions(initLogging, startCheckUpgrade, initConfig, initManager, initAnalytics, displayCopyright),
-	After:  actions(reportCheckUpgrade, closeAnalytics),
+	Before: actions(initLogging, initConfig, initManager, initAnalytics, displayCopyright),
+	After:  actions(closeAnalytics),
 	Action: func(ctx *cli.Context) error {
 		resetAction := action.Reset{
 			Manager: ctx.Context.Value(ctxManagerKey{}).(*phase.Manager),


### PR DESCRIPTION
Fixes #678 

Removes the self-update check feature (`A new version v0.17.6 of k0sctl is available: http://github.com/.....`)

