### PR TITLE
Upload new k0s binary directly to final directory

### DIFF
--- a/phase/upload_k0s.go
+++ b/phase/upload_k0s.go
@@ -9,7 +9,6 @@ import (
 	"github.com/k0sproject/k0sctl/pkg/apis/k0sctl.k0sproject.io/v1beta1"
 	"github.com/k0sproject/k0sctl/pkg/apis/k0sctl.k0sproject.io/v1beta1/cluster"
 	"github.com/k0sproject/rig/exec"
-	"github.com/sirupsen/logrus"
 	log "github.com/sirupsen/logrus"
 )
 
@@ -76,7 +75,7 @@ func (p *UploadK0s) uploadBinary(h *cluster.Host) error {
 		return fmt.Errorf("failed to touch %s: %w", tmp, err)
 	}
 	if err := h.Execf(`chmod +x "%s"`, tmp, exec.Sudo(h)); err != nil {
-		logrus.Warnf("%s: failed to chmod k0s temp binary: %v", h, err.Error())
+		log.Warnf("%s: failed to chmod k0s temp binary: %v", h, err.Error())
 	}
 
 	h.Metadata.K0sBinaryTempFile = tmp

--- a/phase/upload_k0s.go
+++ b/phase/upload_k0s.go
@@ -3,6 +3,8 @@ package phase
 import (
 	"fmt"
 	"os"
+	"strconv"
+	"time"
 
 	"github.com/k0sproject/k0sctl/pkg/apis/k0sctl.k0sproject.io/v1beta1"
 	"github.com/k0sproject/k0sctl/pkg/apis/k0sctl.k0sproject.io/v1beta1/cluster"
@@ -58,17 +60,14 @@ func (p *UploadK0s) Run() error {
 }
 
 func (p *UploadK0s) uploadBinary(h *cluster.Host) error {
-	tmp, err := h.Configurer.TempFile(h)
-	if err != nil {
-		return fmt.Errorf("failed to create tempfile %w", err)
-	}
+	tmp := h.Configurer.K0sBinaryPath() + ".tmp." + strconv.Itoa(int(time.Now().UnixNano()))
 
 	stat, err := os.Stat(h.UploadBinaryPath)
 	if err != nil {
 		return fmt.Errorf("stat %s: %w", h.UploadBinaryPath, err)
 	}
 
-	log.Infof("%s: uploading k0s binary from %s", h, h.UploadBinaryPath)
+	log.Infof("%s: uploading k0s binary from %s to %s", h, h.UploadBinaryPath, tmp)
 	if err := h.Upload(h.UploadBinaryPath, tmp); err != nil {
 		return fmt.Errorf("upload k0s binary: %w", err)
 	}


### PR DESCRIPTION
Fixes #679 

To avoid problems with `noexec` TMPDIR, upload the k0s binary directly to `K0sBinaryPath() + ".tmp." + timestamp` instead of using the tempdir given by `mktemp`.

Another option would be to keep uploading to TMPDIR but install it temporarily to a similar path.


