### PR TITLE
Don't rely on PATH for k0s existence detection

### DIFF
--- a/phase/gather_k0s_facts.go
+++ b/phase/gather_k0s_facts.go
@@ -54,7 +54,7 @@ func (p *GatherK0sFacts) Title() string {
 func (p *GatherK0sFacts) Prepare(config *v1beta1.Cluster) error {
 	p.Config = config
 	p.hosts = config.Spec.Hosts.Filter(func(h *cluster.Host) bool {
-		return h.Configurer.CommandExist(h, "k0s")
+		return h.Exec(h.Configurer.K0sCmdf("version"), exec.Sudo(h)) == nil
 	})
 
 	return nil


### PR DESCRIPTION
Fixes #690

`command -v k0s` was being used to detect if k0s already exists on the remote hosts. This does not work on systems with `secure_path` setting enabled causing k0sctl to upload/download the k0s binary again even if it exists already.

This PR changes the detection to use `K0sBinaryPath()` which is an absolute path.
