### PR TITLE
Perform a daemon-reload after reset

### DIFF
--- a/action/reset.go
+++ b/action/reset.go
@@ -61,6 +61,7 @@ func (r Reset) Run() error {
 			NoLeave:  true,
 		},
 		&phase.ResetLeader{},
+		&phase.DaemonReload{},
 		&phase.RunHooks{Stage: "after", Action: "reset"},
 		&phase.Unlock{Cancel: lockPhase.Cancel},
 		&phase.Disconnect{},

--- a/phase/daemon_reload.go
+++ b/phase/daemon_reload.go
@@ -1,0 +1,32 @@
+package phase
+
+import (
+	"github.com/k0sproject/k0sctl/pkg/apis/k0sctl.k0sproject.io/v1beta1/cluster"
+	log "github.com/sirupsen/logrus"
+)
+
+// DaemonReload phase runs `systemctl daemon-reload` or equivalent on all hosts.
+type DaemonReload struct {
+	GenericPhase
+}
+
+// Title for the phase
+func (p *DaemonReload) Title() string {
+	return "Reload service manager"
+}
+
+// ShouldRun is true when there are controllers that needs to be reset
+func (p *DaemonReload) ShouldRun() bool {
+	return len(p.Config.Spec.Hosts) > 0
+}
+
+// Run the phase
+func (p *DaemonReload) Run() error {
+	return p.parallelDo(p.Config.Spec.Hosts, func(h *cluster.Host) error {
+		log.Infof("%s: reloading service manager", h)
+		if err := h.Configurer.DaemonReload(h); err != nil {
+			log.Warnf("%s: failed to reload service manager: %s", h, err.Error())
+		}
+		return nil
+	})
+}


### PR DESCRIPTION
Runs a `systemctl daemon-reload` or equivalent for other init systems after cluster reset.
