### PR TITLE
Don't check for unique machine IDs for k0s >= v1.30

### DIFF
--- a/action/backup.go
+++ b/action/backup.go
@@ -24,7 +24,7 @@ func (b Backup) Run() error {
 		&phase.DetectOS{},
 		lockPhase,
 		&phase.PrepareHosts{},
-		&phase.GatherFacts{},
+		&phase.GatherFacts{SkipMachineIDs: true},
 		&phase.GatherK0sFacts{},
 		&phase.RunHooks{Stage: "before", Action: "backup"},
 		&phase.Backup{},

--- a/action/reset.go
+++ b/action/reset.go
@@ -48,7 +48,7 @@ func (r Reset) Run() error {
 		&phase.DetectOS{},
 		lockPhase,
 		&phase.PrepareHosts{},
-		&phase.GatherFacts{},
+		&phase.GatherFacts{SkipMachineIDs: true},
 		&phase.GatherK0sFacts{},
 		&phase.RunHooks{Stage: "before", Action: "reset"},
 		&phase.ResetWorkers{

--- a/phase/validate_hosts.go
+++ b/phase/validate_hosts.go
@@ -22,14 +22,18 @@ func (p *ValidateHosts) Title() string {
 // Run the phase
 func (p *ValidateHosts) Run() error {
 	p.hncount = make(map[string]int, len(p.Config.Spec.Hosts))
-	p.machineidcount = make(map[string]int, len(p.Config.Spec.Hosts))
+	if uniqueMachineIDVersion.Check(p.Config.Spec.K0s.Version) {
+		p.machineidcount = make(map[string]int, len(p.Config.Spec.Hosts))
+	}
 	p.privateaddrcount = make(map[string]int, len(p.Config.Spec.Hosts))
 
 	controllerCount := len(p.Config.Spec.Hosts.Controllers())
 	var resetControllerCount int
 	for _, h := range p.Config.Spec.Hosts {
 		p.hncount[h.Metadata.Hostname]++
-		p.machineidcount[h.Metadata.MachineID]++
+		if p.machineidcount != nil {
+			p.machineidcount[h.Metadata.MachineID]++
+		}
 		if h.PrivateAddress != "" {
 			p.privateaddrcount[h.PrivateAddress]++
 		}


### PR DESCRIPTION
K0s doesn't use machine IDs since v1.30. Only check for them if the target k0s version is before 1.30.

See:
* k0sproject/k0s#3983
* k0sproject/k0s#4230

There's a failure on k0s's OS testing matrix for CentOS 7 because of this:
https://github.com/k0sproject/k0s/actions/runs/8933334285/job/24541048016
> │ level=fatal msg="apply failed - log file saved to
> │ /home/runner/.cache/k0sctl/k0sctl.log: failed on 5 hosts:\n - [ssh]
> │ 3.214.144.101:22: machine id 9e065f0961d84ecf8bec2457d927e012 is not
> │ unique: ip-172-31-13-247.ec2.internal\n - [ssh] 44.200.255.25:22: machine
> │ id 9e065f0961d84ecf8bec2457d927e012 is not unique:
> │ ip-172-31-1-137.ec2.internal\n - [ssh] 3.238.193.59:22: machine id
> │ 9e065f0961d84ecf8bec2457d927e012 is not unique:
> │ ip-172-31-9-188.ec2.internal\n - [ssh] 3.231.150.37:22: machine id
> │ 9e065f0961d84ecf8bec2457d927e012 is not unique:
> │ ip-172-31-5-43.ec2.internal\n - [ssh] 3.237.92.58:22: machine id
> │ 9e065f0961d84ecf8bec2457d927e012 is not unique:
> │ ip-172-31-11-179.ec2.internal"