### PR TITLE
Use sudo when downloading k0s to /usr/local/bin

### DIFF
--- a/configurer/linux.go
+++ b/configurer/linux.go
@@ -168,10 +168,10 @@ func (l *Linux) DownloadURL(h os.Host, url, destination string, opts ...exec.Opt
 }
 
 // DownloadK0s performs k0s binary download from github on the host
-func (l *Linux) DownloadK0s(h os.Host, path string, version *version.Version, arch string) error {
+func (l *Linux) DownloadK0s(h os.Host, path string, version *version.Version, arch string, opts ...exec.Option) error {
 	v := strings.ReplaceAll(strings.TrimPrefix(version.String(), "v"), "+", "%2B")
 	url := fmt.Sprintf("https://github.com/k0sproject/k0s/releases/download/v%[1]s/k0s-v%[1]s-%[2]s", v, arch)
-	if err := l.DownloadURL(h, url, path); err != nil {
+	if err := l.DownloadURL(h, url, path, opts...); err != nil {
 		return fmt.Errorf("failed to download k0s - check connectivity and k0s version validity: %w", err)
 	}
 

--- a/phase/download_k0s.go
+++ b/phase/download_k0s.go
@@ -66,10 +66,10 @@ func (p *DownloadK0s) downloadK0s(h *cluster.Host) error {
 	if h.K0sDownloadURL != "" {
 		expandedURL := h.ExpandTokens(h.K0sDownloadURL, p.Config.Spec.K0s.Version)
 		log.Infof("%s: downloading k0s binary from %s", h, expandedURL)
-		if err := h.Configurer.DownloadURL(h, expandedURL, tmp); err != nil {
+		if err := h.Configurer.DownloadURL(h, expandedURL, tmp, exec.Sudo(h)); err != nil {
 			return fmt.Errorf("failed to download k0s binary: %w", err)
 		}
-	} else if err := h.Configurer.DownloadK0s(h, tmp, p.Config.Spec.K0s.Version, h.Metadata.Arch); err != nil {
+	} else if err := h.Configurer.DownloadK0s(h, tmp, p.Config.Spec.K0s.Version, h.Metadata.Arch, exec.Sudo(h)); err != nil {
 		return err
 	}
 

--- a/pkg/apis/k0sctl.k0sproject.io/v1beta1/cluster/host.go
+++ b/pkg/apis/k0sctl.k0sproject.io/v1beta1/cluster/host.go
@@ -144,7 +144,7 @@ type configurer interface {
 	ReadFile(os.Host, string) (string, error)
 	FileExist(os.Host, string) bool
 	Chmod(os.Host, string, string, ...exec.Option) error
-	DownloadK0s(os.Host, string, *version.Version, string) error
+	DownloadK0s(os.Host, string, *version.Version, string, ...exec.Option) error
 	DownloadURL(os.Host, string, string, ...exec.Option) error
 	InstallPackage(os.Host, ...string) error
 	FileContains(os.Host, string, string) bool


### PR DESCRIPTION
Fixes #701 

Uses sudo when downloading k0s binaries directly to `/usr/local/bin` or `K0sBinaryPath()`.
