### PR TITLE
Add a hidden ignored --disable-upgrade-check flag

### DIFF
--- a/cmd/apply.go
+++ b/cmd/apply.go
@@ -55,6 +55,7 @@ var applyCommand = &cli.Command{
 		redactFlag,
 		retryIntervalFlag,
 		retryTimeoutFlag,
+		ignoredUpgradeCheckFlag,
 		analyticsFlag,
 	},
 	Before: actions(initLogging, initConfig, initManager, displayLogo, initAnalytics, displayCopyright, warnOldCache),

--- a/cmd/flags.go
+++ b/cmd/flags.go
@@ -27,9 +27,11 @@ import (
 	"gopkg.in/yaml.v2"
 )
 
-type ctxConfigKey struct{}
-type ctxManagerKey struct{}
-type ctxLogFileKey struct{}
+type (
+	ctxConfigKey  struct{}
+	ctxManagerKey struct{}
+	ctxLogFileKey struct{}
+)
 
 var (
 	debugFlag = &cli.BoolFlag{
@@ -70,6 +72,13 @@ var (
 		Name:    "disable-telemetry",
 		Usage:   "Do not send anonymous telemetry",
 		EnvVars: []string{"DISABLE_TELEMETRY"},
+	}
+
+	ignoredUpgradeCheckFlag = &cli.BoolFlag{
+		Name:    "disable-upgrade-check",
+		Usage:   "Do not check for a k0sctl upgrade",
+		EnvVars: []string{"DISABLE_UPGRADE_CHECK"},
+		Hidden:  true,
 	}
 
 	concurrencyFlag = &cli.IntFlag{
@@ -288,7 +297,7 @@ func LogFile() (*os.File, error) {
 		}
 	}
 
-	logFile, err := os.OpenFile(fn, os.O_RDWR|os.O_CREATE|os.O_APPEND|os.O_SYNC, 0600)
+	logFile, err := os.OpenFile(fn, os.O_RDWR|os.O_CREATE|os.O_APPEND|os.O_SYNC, 0o600)
 	if err != nil {
 		return nil, fmt.Errorf("Failed to open log %s: %s", fn, err.Error())
 	}

--- a/cmd/reset.go
+++ b/cmd/reset.go
@@ -21,6 +21,7 @@ var resetCommand = &cli.Command{
 		redactFlag,
 		retryIntervalFlag,
 		retryTimeoutFlag,
+		ignoredUpgradeCheckFlag,
 		analyticsFlag,
 		&cli.BoolFlag{
 			Name:    "force",


### PR DESCRIPTION
Adds a hidden ignored flag to allow keeping the `--disable-upgrade-check` flag that was removed in #681 
