### PR TITLE
Enable stderr logging for file uploads

### DIFF
--- a/phase/restore.go
+++ b/phase/restore.go
@@ -56,7 +56,7 @@ func (p *Restore) Run() error {
 		return err
 	}
 	dstFile := path.Join(tmpDir, "k0s_backup.tar.gz")
-	if err := h.Upload(p.RestoreFrom, dstFile); err != nil {
+	if err := h.Upload(p.RestoreFrom, dstFile, exec.LogError(true)); err != nil {
 		return err
 	}
 

--- a/phase/upload_k0s.go
+++ b/phase/upload_k0s.go
@@ -67,7 +67,7 @@ func (p *UploadK0s) uploadBinary(h *cluster.Host) error {
 	}
 
 	log.Infof("%s: uploading k0s binary from %s to %s", h, h.UploadBinaryPath, tmp)
-	if err := h.Upload(h.UploadBinaryPath, tmp, exec.Sudo(h)); err != nil {
+	if err := h.Upload(h.UploadBinaryPath, tmp, exec.Sudo(h), exec.LogError(true)); err != nil {
 		return fmt.Errorf("upload k0s binary: %w", err)
 	}
 

--- a/phase/uploadfiles.go
+++ b/phase/uploadfiles.go
@@ -119,7 +119,7 @@ func (p *UploadFiles) uploadFile(h *cluster.Host, f *cluster.UploadFile) error {
 
 		if h.FileChanged(src, dest) {
 			err := p.Wet(h, fmt.Sprintf("upload file %s => %s", src, dest), func() error {
-				return h.Upload(path.Join(f.Base, s.Path), dest, exec.Sudo(h))
+				return h.Upload(path.Join(f.Base, s.Path), dest, exec.Sudo(h), exec.LogError(true))
 			})
 			if err != nil {
 				return err


### PR DESCRIPTION
Under normal circumstances, the upload process won't write anything to stderr. However, if there are problems, it will. Log the stderr, which will help in troubleshooting any problems.

Requires k0sproject/rig#203 to be effective, though.