### PR TITLE
Don't try to use gotest as "go test"

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -56,7 +56,7 @@ smoketests := smoke-basic smoke-basic-rootless smoke-files smoke-upgrade smoke-r
 $(smoketests): k0sctl
 	$(MAKE) -C smoke-test $@
 
-golint := $(shell which golangci-lint)
+golint := $(shell which golangci-lint 2>/dev/null)
 ifeq ($(golint),)
 golint := $(shell go env GOPATH)/bin/golangci-lint
 endif

--- a/Makefile
+++ b/Makefile
@@ -61,11 +61,6 @@ ifeq ($(golint),)
 golint := $(shell go env GOPATH)/bin/golangci-lint
 endif
 
-gotest := $(shell which gotest)
-ifeq ($(gotest),)
-gotest := go test
-endif
-
 $(golint):
 	go install github.com/golangci/golangci-lint/cmd/golangci-lint@latest
 
@@ -75,7 +70,7 @@ lint: $(golint)
 
 .PHONY: test
 test: $(GO_SRCS) $(GO_TESTS)
-	$(gotest) -v ./...
+	go test -v ./...
 
 .PHONY: install
 install: k0sctl


### PR DESCRIPTION
Remove gotest stuff from Makefile. It was just used for colored output. The which statement was rather chatty when building k0sctl without having gotest in the path, too. Suppress which stderr output for golangci-lint for the same reason.

Alternative to #710.