### PR TITLE
Check new controllers against etcd member-list to detect replaced hosts

### DIFF
--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -364,6 +364,34 @@ jobs:
         env:
           LINUX_IMAGE: ${{ matrix.image }}
         run: make smoke-backup-restore
+  
+  smoke-controller-swap:
+    strategy:
+      matrix:
+        image:
+          - quay.io/k0sproject/bootloose-alpine3.18
+
+    name: Controller swap
+    needs: build
+    runs-on: ubuntu-20.04
+
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+          check-latest: true
+
+      - {"name":"Compiled binary cache","uses":"actions/download-artifact@v4","with":{"name":"k0sctl","path":"."}}
+      - {"name":"K0sctl cache","uses":"actions/cache@v3","with":{"path":"/var/cache/k0sctl/k0s\n~/.cache/k0sctl/k0s\n","key":"k0sctl-cache"}}
+      - {"name":"Kubectl cache","uses":"actions/cache@v3","with":{"path":"smoke-test/kubectl\n","key":"kubectl-${{ hashFiles('smoke-test/smoke.common.sh') }}","restore-keys":"kubectl-"}}
+      - {"name":"Make binaries executable","run":"chmod +x k0sctl || true\nchmod +x smoke-test/kubectl || true"}
+
+      - name: Run smoke tests
+        env:
+          LINUX_IMAGE: ${{ matrix.image }}
+        run: make smoke-controller-swap
 
   smoke-init:
     name: Init sub-command smoke test

--- a/Makefile
+++ b/Makefile
@@ -51,7 +51,7 @@ build-all: $(addprefix bin/,$(bins)) bin/checksums.md
 clean:
 	rm -rf bin/ k0sctl
 
-smoketests := smoke-basic smoke-basic-rootless smoke-files smoke-upgrade smoke-reset smoke-os-override smoke-init smoke-backup-restore smoke-dynamic smoke-basic-openssh smoke-dryrun smoke-downloadurl
+smoketests := smoke-basic smoke-basic-rootless smoke-files smoke-upgrade smoke-reset smoke-os-override smoke-init smoke-backup-restore smoke-dynamic smoke-basic-openssh smoke-dryrun smoke-downloadurl smoke-controller-swap
 .PHONY: $(smoketests)
 $(smoketests): k0sctl
 	$(MAKE) -C smoke-test $@

--- a/phase/configure_k0s.go
+++ b/phase/configure_k0s.go
@@ -181,7 +181,9 @@ func (p *ConfigureK0s) generateDefaultConfig() (string, error) {
 
 // Run the phase
 func (p *ConfigureK0s) Run() error {
-	controllers := p.Config.Spec.Hosts.Controllers()
+	controllers := p.Config.Spec.Hosts.Controllers().Filter(func(h *cluster.Host) bool {
+		return !h.Reset && len(h.Metadata.K0sNewConfig) > 0
+	})	
 	return p.parallelDo(controllers, p.configureK0s)
 }
 

--- a/phase/reset_controllers.go
+++ b/phase/reset_controllers.go
@@ -90,11 +90,7 @@ func (p *ResetControllers) Run() error {
 		if !p.NoLeave {
 			log.Debugf("%s: leaving etcd...", h)
 
-			etcdAddress := h.SSH.Address
-			if h.PrivateAddress != "" {
-				etcdAddress = h.PrivateAddress
-			}
-			if err := h.Exec(h.Configurer.K0sCmdf("etcd leave --peer-address %s --datadir %s", etcdAddress, h.K0sDataDir()), exec.Sudo(h)); err != nil {
+			if err := h.Exec(h.Configurer.K0sCmdf("etcd leave --peer-address %s --datadir %s", h.PrivateAddress, h.K0sDataDir()), exec.Sudo(h)); err != nil {
 				log.Warnf("%s: failed to leave etcd: %s", h, err.Error())
 			}
 			log.Debugf("%s: leaving etcd completed", h)

--- a/pkg/apis/k0sctl.k0sproject.io/v1beta1/cluster.go
+++ b/pkg/apis/k0sctl.k0sproject.io/v1beta1/cluster.go
@@ -14,8 +14,9 @@ const APIVersion = "k0sctl.k0sproject.io/v1beta1"
 
 // ClusterMetadata defines cluster metadata
 type ClusterMetadata struct {
-	Name       string `yaml:"name" validate:"required" default:"k0s-cluster"`
-	Kubeconfig string `yaml:"-"`
+	Name        string   `yaml:"name" validate:"required" default:"k0s-cluster"`
+	Kubeconfig  string   `yaml:"-"`
+	EtcdMembers []string `yaml:"-"`
 }
 
 // Cluster describes launchpad.yaml configuration

--- a/smoke-test/Makefile
+++ b/smoke-test/Makefile
@@ -55,5 +55,8 @@ smoke-downloadurl: $(bootloose) id_rsa_k0s k0sctl
 smoke-backup-restore: $(bootloose) id_rsa_k0s k0sctl
 	./smoke-backup-restore.sh
 
+smoke-controller-swap: $(bootloose) id_rsa_k0s k0sctl
+	BOOTLOOSE_TEMPLATE=bootloose-controller-swap.yaml.tpl K0SCTL_CONFIG=k0sctl-controller-swap.yaml ./smoke-controller-swap.sh
+
 %.iid: Dockerfile.%
 	docker build --iidfile '$@' - < '$<'

--- a/smoke-test/bootloose-controller-swap.yaml.tpl
+++ b/smoke-test/bootloose-controller-swap.yaml.tpl
@@ -1,0 +1,23 @@
+cluster:
+  name: k0s
+  privateKey: ./id_rsa_k0s
+machines:
+- count: 3
+  backend: docker
+  spec:
+    image: $LINUX_IMAGE
+    name: manager%d
+    privileged: true
+    volumes:
+    - type: bind
+      source: /lib/modules
+      destination: /lib/modules
+    - type: volume
+      destination: /var/lib/k0s
+    portMappings:
+    - containerPort: 22
+      hostPort: 9022
+    - containerPort: 443
+      hostPort: 443
+    - containerPort: 6443
+      hostPort: 6443

--- a/smoke-test/k0sctl-controller-swap.yaml
+++ b/smoke-test/k0sctl-controller-swap.yaml
@@ -1,0 +1,29 @@
+apiVersion: k0sctl.k0sproject.io/v1beta1
+kind: cluster
+spec:
+  hosts:
+    - role: controller
+      uploadBinary: true
+      ssh:
+        address: "127.0.0.1"
+        port: 9022
+        keyPath: ./id_rsa_k0s
+    - role: controller
+      uploadBinary: true
+      ssh:
+        address: "127.0.0.1"
+        port: 9023
+        keyPath: ./id_rsa_k0s
+    - role: controller
+      uploadBinary: true
+      ssh:
+        address: "127.0.0.1"
+        port: 9024
+        keyPath: ./id_rsa_k0s
+  k0s:
+    version: "${K0S_VERSION}"
+    config:
+      spec:
+        telemetry:
+          enabled: false
+

--- a/smoke-test/smoke-controller-swap.sh
+++ b/smoke-test/smoke-controller-swap.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env sh
+
+K0SCTL_CONFIG=${K0SCTL_CONFIG:-"k0sctl-controller-swap.yaml"}
+
+set -ex
+
+
+. ./smoke.common.sh
+trap cleanup EXIT
+
+deleteCluster
+createCluster
+
+echo "* Starting apply"
+../k0sctl apply --config "${K0SCTL_CONFIG}" --debug
+echo "* Apply OK"
+
+echo "* Get the ip of the last controller"
+controllerip=$(bootloose show manager2 -o json | grep '"ip"' | head -1 | cut -d'"' -f4)
+
+echo "* Wipe controller 3"
+docker rm -fv "$(bootloose show manager2 -o json | grep '"container"' | head -1 | cut -d'"' -f4)"
+
+echo "* Verify its gone"
+bootloose show manager2 | grep "Not created"
+
+echo "* Recreate controller2"
+createCluster
+
+echo "* Verify its back and IP is the same"
+bootloose show manager2 | grep "Running"
+newip=$(bootloose show manager2 -o json | grep '"ip"' | head -1 | cut -d'"' -f4)
+if [ "$controllerip" != "$newip" ]; then
+  echo "IP mismatch: $controllerip != $newip - ip should get reused"
+  exit 1
+fi
+
+echo "* Re-apply should fail because of known hosts"
+if ../k0sctl apply --config "${K0SCTL_CONFIG}" --debug; then
+  echo "Re-apply should have failed because of known hosts"
+  exit 1
+fi
+
+echo "* Clear known hosts"
+truncate -s 0 ~/.ssh/known_hosts
+
+echo "* Re-apply should fail because of replaced controller"
+if ../k0sctl apply --config "${K0SCTL_CONFIG}" --debug; then
+  echo "Re-apply should have failed because of replaced controller"
+  exit 1
+fi
+
+echo "* Perform etcd member removal"
+bootloose ssh root@manager0 -- k0s etcd leave --peer-address "$controllerip"
+
+echo "* Re-apply should succeed"
+../k0sctl apply --config "${K0SCTL_CONFIG}" --debug
+
+echo "* Done"


### PR DESCRIPTION
Addresses #603 

Before installing new controllers, check if the address is already found from `k0s etcd member-list`. If a match with the same address is found, the `apply` process is aborted. K0sctl can try to perform the `etcd leave` for the vanished address automatically when `--force` is used. This check is skipped when kine or an external etcd is used.

This protects against situations when a controller host in k0sctl.yaml gets completely wiped or replaced with a fresh one between two runs. Previously k0sctl would have treated it as a regular new controller and caused the etcd to get confused / split brained. 

There was also a bug when adding new controllers in general, writing the config on the previously existing clusters could have failed with "empty content on file write" error.

