### PR TITLE
Don't cordon all workers at once before upgrading

### DIFF
--- a/phase/upgrade_workers.go
+++ b/phase/upgrade_workers.go
@@ -83,14 +83,9 @@ func (p *UpgradeWorkers) Run() error {
 	}
 
 	log.Infof("Upgrading max %d workers in parallel", concurrentUpgrades)
-	err := p.hosts.BatchedParallelEach(concurrentUpgrades,
+	return p.hosts.BatchedParallelEach(concurrentUpgrades,
 		p.start,
 		p.cordonWorker,
-	)
-	if err != nil {
-		return err
-	}
-	return p.hosts.BatchedParallelEach(concurrentUpgrades,
 		p.drainWorker,
 		p.upgradeWorker,
 		p.uncordonWorker,


### PR DESCRIPTION
https://github.com/k0sproject/k0sctl/pull/672 does not fix that cordon all workers at once when upgrading.

BatchedParallelEach runs a function (or multiple functions chained) on every Host parallelly in groups of batchSize hosts.
https://github.com/k0sproject/k0sctl/blob/main/pkg/apis/k0sctl.k0sproject.io/v1beta1/cluster/hosts.go#L141

So running BatchedParallelEach before BatchedParallelEach means cordoning all workers at once when upgrading

my update log was followings:
```
k0sctl apply --config k0sctl.yaml                                                                                                  [ ~  ]

⠀⣿⣿⡇⠀⠀⢀⣴⣾⣿⠟⠁⢸⣿⣿⣿⣿⣿⣿⣿⡿⠛⠁⠀⢸⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⠀█████████ █████████ ███
⠀⣿⣿⡇⣠⣶⣿⡿⠋⠀⠀⠀⢸⣿⡇⠀⠀⠀⣠⠀⠀⢀⣠⡆⢸⣿⣿⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀███          ███    ███
⠀⣿⣿⣿⣿⣟⠋⠀⠀⠀⠀⠀⢸⣿⡇⠀⢰⣾⣿⠀⠀⣿⣿⡇⢸⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⣿⠀███          ███    ███
⠀⣿⣿⡏⠻⣿⣷⣤⡀⠀⠀⠀⠸⠛⠁⠀⠸⠋⠁⠀⠀⣿⣿⡇⠈⠉⠉⠉⠉⠉⠉⠉⠉⢹⣿⣿⠀███          ███    ███
⠀⣿⣿⡇⠀⠀⠙⢿⣿⣦⣀⠀⠀⠀⣠⣶⣶⣶⣶⣶⣶⣿⣿⡇⢰⣶⣶⣶⣶⣶⣶⣶⣶⣾⣿⣿⠀█████████    ███    ██████████
k0sctl v0.17.8 Copyright 2023, k0sctl authors.
Anonymized telemetry of usage will be sent to the authors.
By continuing to use k0sctl you agree to these terms:
https://k0sproject.io/licenses/eula
INFO ==> Running phase: Connect to hosts
INFO [ssh] 192.168.11.119:22: connected
INFO [ssh] 192.168.11.118:22: connected
INFO [ssh] 192.168.11.126:22: connected
INFO [ssh] 192.168.11.123:22: connected
INFO [ssh] 192.168.11.114:22: connected
INFO ==> Running phase: Detect host operating systems
INFO [ssh] 192.168.11.126:22: is running Ubuntu 24.04 LTS
INFO [ssh] 192.168.11.114:22: is running Ubuntu 24.04 LTS
INFO [ssh] 192.168.11.119:22: is running Ubuntu 22.04.2 LTS
INFO [ssh] 192.168.11.118:22: is running Ubuntu 24.04 LTS
INFO [ssh] 192.168.11.123:22: is running Ubuntu 24.04 LTS
INFO ==> Running phase: Acquire exclusive host lock
INFO ==> Running phase: Prepare hosts
INFO [ssh] 192.168.11.126:22: updating environment
INFO [ssh] 192.168.11.114:22: updating environment
INFO [ssh] 192.168.11.119:22: updating environment
INFO [ssh] 192.168.11.123:22: updating environment
INFO [ssh] 192.168.11.118:22: updating environment
INFO [ssh] 192.168.11.119:22: reconnecting to apply new environment
INFO [ssh] 192.168.11.126:22: reconnecting to apply new environment
INFO [ssh] 192.168.11.118:22: reconnecting to apply new environment
INFO [ssh] 192.168.11.114:22: reconnecting to apply new environment
INFO [ssh] 192.168.11.123:22: reconnecting to apply new environment
INFO ==> Running phase: Gather host facts
INFO [ssh] 192.168.11.119:22: using cp as hostname
INFO [ssh] 192.168.11.126:22: using worker14 as hostname
INFO [ssh] 192.168.11.118:22: using worker12 as hostname
INFO [ssh] 192.168.11.123:22: using worker13 as hostname
INFO [ssh] 192.168.11.114:22: using worker11 as hostname
INFO [ssh] 192.168.11.126:22: discovered enp5s0 as private interface
INFO [ssh] 192.168.11.119:22: discovered enp5s0 as private interface
INFO [ssh] 192.168.11.118:22: discovered enp5s0 as private interface
INFO [ssh] 192.168.11.123:22: discovered enp5s0 as private interface
INFO [ssh] 192.168.11.114:22: discovered enp5s0 as private interface
INFO [ssh] 192.168.11.126:22: discovered 10.148.131.86 as private address
INFO [ssh] 192.168.11.119:22: discovered 10.148.131.176 as private address
INFO [ssh] 192.168.11.118:22: discovered 10.148.131.103 as private address
INFO [ssh] 192.168.11.123:22: discovered 10.148.131.35 as private address
INFO [ssh] 192.168.11.114:22: discovered 10.148.131.29 as private address
INFO ==> Running phase: Validate hosts
INFO ==> Running phase: Gather k0s facts
INFO [ssh] 192.168.11.119:22: using cp as hostname
INFO [ssh] 192.168.11.126:22: using worker14 as hostname
INFO [ssh] 192.168.11.118:22: using worker12 as hostname
INFO [ssh] 192.168.11.123:22: using worker13 as hostname
INFO [ssh] 192.168.11.114:22: using worker11 as hostname
INFO [ssh] 192.168.11.126:22: discovered enp5s0 as private interface
INFO [ssh] 192.168.11.119:22: discovered enp5s0 as private interface
INFO [ssh] 192.168.11.118:22: discovered enp5s0 as private interface
INFO [ssh] 192.168.11.123:22: discovered enp5s0 as private interface
INFO [ssh] 192.168.11.114:22: discovered enp5s0 as private interface
INFO [ssh] 192.168.11.126:22: discovered 10.148.131.86 as private address
INFO [ssh] 192.168.11.119:22: discovered 10.148.131.176 as private address
INFO [ssh] 192.168.11.118:22: discovered 10.148.131.103 as private address
INFO [ssh] 192.168.11.123:22: discovered 10.148.131.35 as private address
INFO [ssh] 192.168.11.114:22: discovered 10.148.131.29 as private address
INFO ==> Running phase: Validate hosts
INFO ==> Running phase: Gather k0s facts
INFO [ssh] 192.168.11.119:22: found existing configuration
INFO [ssh] 192.168.11.119:22: is running k0s controller+worker version v1.30.0+k0s.0
WARN [ssh] 192.168.11.119:22: the controller+worker node will not schedule regular workloads without toleration for node-role.kubernetes.io/master:NoSchedule unless 'noTaints: true' is set
WARN [ssh] 192.168.11.119:22: k0s will be upgraded
INFO [ssh] 192.168.11.123:22: is running k0s worker version v1.30.0+k0s.0
WARN [ssh] 192.168.11.123:22: k0s will be upgraded
INFO [ssh] 192.168.11.119:22: checking if worker worker13 has joined
INFO [ssh] 192.168.11.114:22: is running k0s worker version v1.30.0+k0s.0
WARN [ssh] 192.168.11.114:22: k0s will be upgraded
INFO [ssh] 192.168.11.118:22: is running k0s worker version v1.30.0+k0s.0
INFO [ssh] 192.168.11.126:22: is running k0s worker version v1.30.0+k0s.0
INFO [ssh] 192.168.11.119:22: checking if worker worker11 has joined
WARN [ssh] 192.168.11.126:22: k0s will be upgraded
INFO [ssh] 192.168.11.119:22: checking if worker worker14 has joined
WARN [ssh] 192.168.11.118:22: k0s will be upgraded
INFO [ssh] 192.168.11.119:22: checking if worker worker12 has joined
INFO ==> Running phase: Validate facts
INFO ==> Running phase: Download k0s on hosts
INFO [ssh] 192.168.11.126:22: downloading k0s v1.30.1+k0s.0
INFO [ssh] 192.168.11.114:22: downloading k0s v1.30.1+k0s.0
INFO [ssh] 192.168.11.119:22: downloading k0s v1.30.1+k0s.0
INFO [ssh] 192.168.11.123:22: downloading k0s v1.30.1+k0s.0
INFO [ssh] 192.168.11.118:22: downloading k0s v1.30.1+k0s.0
INFO [ssh] 192.168.11.119:22: validating configuration
INFO ==> Running phase: Upgrade controllers
INFO [ssh] 192.168.11.119:22: starting upgrade
INFO [ssh] 192.168.11.119:22: updating service environment
INFO [ssh] 192.168.11.119:22: waiting for the k0s service to start
INFO [ssh] 192.168.11.119:22: waiting for the scheduler to become ready
INFO [ssh] 192.168.11.119:22: waiting for system pods to become ready
INFO ==> Running phase: Upgrade workers
INFO Upgrading max 1 workers in parallel
INFO [ssh] 192.168.11.114:22: starting upgrade
INFO [ssh] 192.168.11.118:22: starting upgrade
INFO [ssh] 192.168.11.123:22: starting upgrade
INFO [ssh] 192.168.11.126:22: starting upgrade 
INFO [ssh] 192.168.11.114:22: updating service environment
INFO [ssh] 192.168.11.114:22: waiting for node to become ready again
INFO [ssh] 192.168.11.114:22: upgrade finished
```

This cluster has 1 control plane and 4 workers.