### PR TITLE
Include k0sctl config path in "k0sctl kubeconfig" tip on apply success

### DIFF
--- a/cmd/apply.go
+++ b/cmd/apply.go
@@ -81,6 +81,7 @@ var applyCommand = &cli.Command{
 			NoDrain:               ctx.Bool("no-drain"),
 			DisableDowngradeCheck: ctx.Bool("disable-downgrade-check"),
 			RestoreFrom:           ctx.String("restore-from"),
+			ConfigPath:            ctx.String("config"),
 		}
 
 		if err := applyAction.Run(); err != nil {


### PR DESCRIPTION
Fixes #675

When cluster apply is completed successfully, a tip is shown about how to get the admin kubeconfig.

This command needs access to the same k0sctl config that was used to run the apply and some users get confused when the command doesn't work by copypasting the example.

This PR adds the `--config <k0sctl-config-path.yaml>` flag to the tip (unless default or stdin was used).
