### PR TITLE
Relax version checking when using a custom K0sBinaryPath

### DIFF
--- a/phase/validate_hosts.go
+++ b/phase/validate_hosts.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	"github.com/k0sproject/k0sctl/pkg/apis/k0sctl.k0sproject.io/v1beta1/cluster"
+	log "github.com/sirupsen/logrus"
 )
 
 // ValidateHosts performs remote OS detection
@@ -48,11 +49,20 @@ func (p *ValidateHosts) Run() error {
 
 	return p.parallelDo(
 		p.Config.Spec.Hosts,
+		p.warnK0sBinaryPath,
 		p.validateUniqueHostname,
 		p.validateUniqueMachineID,
 		p.validateUniquePrivateAddress,
 		p.validateSudo,
 	)
+}
+
+func (p *ValidateHosts) warnK0sBinaryPath(h *cluster.Host) error {
+	if h.Configurer.K0sBinaryPath() != "" {
+		log.Warnf("%s: k0s binary path is set to %q, version checking for the host is disabled. The k0s version for other hosts is %q.", h, h.Configurer.K0sBinaryPath(), p.Config.Spec.K0s.Version)
+	}
+
+	return nil
 }
 
 func (p *ValidateHosts) validateUniqueHostname(h *cluster.Host) error {

--- a/pkg/apis/k0sctl.k0sproject.io/v1beta1/cluster/host.go
+++ b/pkg/apis/k0sctl.k0sproject.io/v1beta1/cluster/host.go
@@ -400,7 +400,7 @@ func (h *Host) UpdateK0sBinary(path string, version *version.Version) error {
 		return fmt.Errorf("failed to get updated k0s binary version: %w", err)
 	}
 	// verify the installed version matches the expected version, unless a custom k0sbinarypath is used
-	if !version.Equal(updatedVersion) && h.K0sBinaryPath == "" {
+	if h.K0sBinaryPath == "" && !version.Equal(updatedVersion) {
 		return fmt.Errorf("updated k0s binary version is %s not %s", updatedVersion, version)
 	}
 

--- a/pkg/apis/k0sctl.k0sproject.io/v1beta1/cluster/host.go
+++ b/pkg/apis/k0sctl.k0sproject.io/v1beta1/cluster/host.go
@@ -399,7 +399,8 @@ func (h *Host) UpdateK0sBinary(path string, version *version.Version) error {
 	if err != nil {
 		return fmt.Errorf("failed to get updated k0s binary version: %w", err)
 	}
-	if !version.Equal(updatedVersion) {
+	// verify the installed version matches the expected version, unless a custom k0sbinarypath is used
+	if !version.Equal(updatedVersion) && h.K0sBinaryPath == "" {
 		return fmt.Errorf("updated k0s binary version is %s not %s", updatedVersion, version)
 	}
 


### PR DESCRIPTION
Fixes #740 

Removes the remote k0s version check after binary installation when using a custom `K0sBinaryPath`.
