### PR TITLE
Reinstall already installed k0s to reconfigure installFlags

### DIFF
--- a/.github/actions/smoke-test-cache/action.yaml
+++ b/.github/actions/smoke-test-cache/action.yaml
@@ -1,4 +1,5 @@
 name: Smoke test cache steps
+description: Cache smoke test binaries
 runs:
   using: composite
   steps:

--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -262,6 +262,25 @@ jobs:
         env:
           LINUX_IMAGE: ${{ matrix.image }}
         run: make smoke-controller-swap
+  
+  smoke-reinstall:
+    strategy:
+      matrix:
+        image:
+          - quay.io/k0sproject/bootloose-alpine3.18
+          - quay.io/k0sproject/bootloose-ubuntu20.04
+
+    name: Reinstall (modify install flags)
+    needs: build
+    runs-on: ubuntu-20.04
+
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ./.github/actions/smoke-test-cache
+      - name: Run smoke tests
+        env:
+          LINUX_IMAGE: ${{ matrix.image }}
+        run: make smoke-reinstall
 
   smoke-init:
     name: Init sub-command smoke test

--- a/Makefile
+++ b/Makefile
@@ -51,7 +51,7 @@ build-all: $(addprefix bin/,$(bins)) bin/checksums.md
 clean:
 	rm -rf bin/ k0sctl
 
-smoketests := smoke-basic smoke-basic-rootless smoke-files smoke-upgrade smoke-reset smoke-os-override smoke-init smoke-backup-restore smoke-dynamic smoke-basic-openssh smoke-dryrun smoke-downloadurl smoke-controller-swap
+smoketests := smoke-basic smoke-basic-rootless smoke-files smoke-upgrade smoke-reset smoke-os-override smoke-init smoke-backup-restore smoke-dynamic smoke-basic-openssh smoke-dryrun smoke-downloadurl smoke-controller-swap smoke-reinstall
 .PHONY: $(smoketests)
 $(smoketests): k0sctl
 	$(MAKE) -C smoke-test $@

--- a/action/apply.go
+++ b/action/apply.go
@@ -143,7 +143,7 @@ func (a Apply) Run() error {
 		}
 
 		log.Info("Tip: To access the cluster you can now fetch the admin kubeconfig using:")
-		log.Infof("     " + phase.Colorize.Cyan(cmd.String()).String())
+		log.Info("     " + phase.Colorize.Cyan(cmd.String()).String())
 	}
 
 	return nil

--- a/action/apply.go
+++ b/action/apply.go
@@ -75,6 +75,7 @@ func (a Apply) Run() error {
 		&phase.InstallWorkers{},
 		&phase.UpgradeControllers{},
 		&phase.UpgradeWorkers{NoDrain: a.NoDrain},
+		&phase.Reinstall{},
 		&phase.ResetWorkers{NoDrain: a.NoDrain},
 		&phase.ResetControllers{NoDrain: a.NoDrain},
 		&phase.RunHooks{Stage: "after", Action: "apply"},
@@ -108,7 +109,7 @@ func (a Apply) Run() error {
 
 	duration := time.Since(start).Truncate(time.Second)
 	text := fmt.Sprintf("==> Finished in %s", duration)
-	log.Infof(phase.Colorize.Green(text).String())
+	log.Info(phase.Colorize.Green(text).String())
 
 	for _, host := range a.Manager.Config.Spec.Hosts {
 		if host.Reset {
@@ -141,7 +142,7 @@ func (a Apply) Run() error {
 			cmd.WriteString(a.ConfigPath)
 		}
 
-		log.Infof("Tip: To access the cluster you can now fetch the admin kubeconfig using:")
+		log.Info("Tip: To access the cluster you can now fetch the admin kubeconfig using:")
 		log.Infof("     " + phase.Colorize.Cyan(cmd.String()).String())
 	}
 

--- a/action/backup.go
+++ b/action/backup.go
@@ -44,6 +44,6 @@ func (b Backup) Run() error {
 
 	duration := time.Since(start).Truncate(time.Second)
 	text := fmt.Sprintf("==> Finished in %s", duration)
-	log.Infof(phase.Colorize.Green(text).String())
+	log.Info(phase.Colorize.Green(text).String())
 	return nil
 }

--- a/action/reset.go
+++ b/action/reset.go
@@ -78,7 +78,7 @@ func (r Reset) Run() error {
 
 	duration := time.Since(start).Truncate(time.Second)
 	text := fmt.Sprintf("==> Finished in %s", duration)
-	log.Infof(phase.Colorize.Green(text).String())
+	log.Info(phase.Colorize.Green(text).String())
 
 	return nil
 }

--- a/phase/install_controllers.go
+++ b/phase/install_controllers.go
@@ -77,7 +77,6 @@ func (p *InstallControllers) After() error {
 			log.Warnf("%s: failed to invalidate worker join token: %v", p.leader, err)
 		}
 		_ = p.Wet(h, "overwrite k0s join token file", func() error {
-
 			if err := h.Configurer.WriteFile(h, h.K0sJoinTokenPath(), "# overwritten by k0sctl after join\n", "0600"); err != nil {
 				log.Warnf("%s: failed to overwrite the join token file at %s", h, h.K0sJoinTokenPath())
 			}
@@ -105,7 +104,6 @@ func (p *InstallControllers) Run() error {
 		}
 		return nil
 	})
-
 	if err != nil {
 		return err
 	}
@@ -162,6 +160,7 @@ func (p *InstallControllers) Run() error {
 			return err
 		}
 		h.Metadata.K0sInstalled = true
+		h.Metadata.K0sRunningVersion = p.Config.Spec.K0s.Version
 
 		if p.IsWet() {
 			if len(h.Environment) > 0 {

--- a/phase/reinstall.go
+++ b/phase/reinstall.go
@@ -1,0 +1,137 @@
+package phase
+
+import (
+	"context"
+	"fmt"
+	"math"
+	"strings"
+	"time"
+
+	"github.com/k0sproject/k0sctl/pkg/apis/k0sctl.k0sproject.io/v1beta1"
+	"github.com/k0sproject/k0sctl/pkg/apis/k0sctl.k0sproject.io/v1beta1/cluster"
+	"github.com/k0sproject/k0sctl/pkg/node"
+	"github.com/k0sproject/k0sctl/pkg/retry"
+	"github.com/k0sproject/rig/exec"
+	log "github.com/sirupsen/logrus"
+)
+
+type Reinstall struct {
+	GenericPhase
+	hosts cluster.Hosts
+}
+
+// Title for the phase
+func (p *Reinstall) Title() string {
+	return "Reinstall"
+}
+
+// Prepare the phase
+func (p *Reinstall) Prepare(config *v1beta1.Cluster) error {
+	p.Config = config
+	p.hosts = p.Config.Spec.Hosts.Filter(func(h *cluster.Host) bool {
+		return !h.Metadata.K0sInstalled && h.Metadata.K0sRunningVersion != nil && !h.Reset && h.FlagsChanged()
+	})
+
+	return nil
+}
+
+// ShouldRun is true when there are hosts that needs to be reinstalled
+func (p *Reinstall) ShouldRun() bool {
+	return cluster.K0sForceFlagSince.Check(p.Config.Spec.K0s.Version) && len(p.hosts) > 0
+}
+
+// Run the phase
+func (p *Reinstall) Run() error {
+	if !cluster.K0sForceFlagSince.Check(p.Config.Spec.K0s.Version) {
+		log.Warnf("k0s version %s does not support install --force flag, installFlags won't be reconfigured", p.Config.Spec.K0s.Version)
+		return nil
+	}
+	controllers := p.hosts.Controllers()
+	if len(controllers) > 0 {
+		log.Infof("Reinstalling %d controllers sequentially", len(controllers))
+		err := controllers.Each(func(h *cluster.Host) error {
+			return p.reinstall(h)
+		})
+		if err != nil {
+			return err
+		}
+	}
+
+	workers := p.hosts.Workers()
+	if len(workers) == 0 {
+		return nil
+	}
+
+	concurrentReinstalls := int(math.Floor(float64(len(p.hosts)) * 0.10))
+	if concurrentReinstalls == 0 {
+		concurrentReinstalls = 1
+	}
+
+	log.Infof("Reinstalling max %d workers in parallel", concurrentReinstalls)
+
+	return p.hosts.BatchedParallelEach(concurrentReinstalls, p.reinstall)
+}
+
+func (p *Reinstall) reinstall(h *cluster.Host) error {
+	if p.Config.Spec.K0s.DynamicConfig && h.Role != "worker" {
+		h.InstallFlags.AddOrReplace("--enable-dynamic-config")
+	}
+
+	h.InstallFlags.AddOrReplace("--force")
+
+	cmd, err := h.K0sInstallCommand()
+	if err != nil {
+		return err
+	}
+	log.Infof("%s: reinstalling k0s", h)
+	err = p.Wet(h, fmt.Sprintf("reinstall k0s using `%s", strings.ReplaceAll(cmd, h.Configurer.K0sBinaryPath(), "k0s")), func() error {
+		if err := h.Exec(cmd, exec.Sudo(h)); err != nil {
+			return fmt.Errorf("failed to reinstall k0s: %w", err)
+		}
+		return nil
+	})
+	if err != nil {
+		return err
+	}
+
+	err = p.Wet(h, "restart k0s service", func() error {
+		if err := h.Configurer.RestartService(h, h.K0sServiceName()); err != nil {
+			return fmt.Errorf("failed to restart k0s: %w", err)
+		}
+		log.Infof("%s: waiting for the k0s service to start", h)
+		if err := retry.Timeout(context.TODO(), retry.DefaultTimeout, node.ServiceRunningFunc(h, h.K0sServiceName())); err != nil {
+			return fmt.Errorf("k0s did not restart: %w", err)
+		}
+		return nil
+	})
+	if err != nil {
+		return fmt.Errorf("restart after reinstall: %w", err)
+	}
+
+	if h != p.Config.Spec.K0sLeader() {
+		return nil
+	}
+
+	if NoWait || !p.IsWet() {
+		log.Warnf("%s: skipping scheduler and system pod checks because --no-wait given", h)
+		return nil
+	}
+
+	log.Infof("%s: waiting for the scheduler to become ready", h)
+	if err := retry.Timeout(context.TODO(), retry.DefaultTimeout, node.ScheduledEventsAfterFunc(h, time.Now())); err != nil {
+		if !Force {
+			return fmt.Errorf("failed to observe scheduling events after api start-up, you can ignore this check by using --force: %w", err)
+		}
+		log.Warnf("%s: failed to observe scheduling events after api start-up: %s", h, err)
+	}
+
+	log.Infof("%s: waiting for system pods to become ready", h)
+	if err := retry.Timeout(context.TODO(), retry.DefaultTimeout, node.SystemPodsRunningFunc(h)); err != nil {
+		if !Force {
+			return fmt.Errorf("all system pods not running after api start-up, you can ignore this check by using --force: %w", err)
+		}
+		log.Warnf("%s: failed to observe system pods running after api start-up: %s", h, err)
+	}
+
+	return nil
+}

--- a/smoke-test/Makefile
+++ b/smoke-test/Makefile
@@ -31,6 +31,9 @@ smoke-basic-openssh: $(bootloose) id_rsa_k0s k0sctl
 smoke-dynamic: $(bootloose) id_rsa_k0s k0sctl
 	./smoke-dynamic.sh
 
+smoke-reinstall: $(bootloose) id_rsa_k0s k0sctl
+	./smoke-reinstall.sh
+
 smoke-files: $(bootloose) id_rsa_k0s k0sctl
 	./smoke-files.sh
 

--- a/smoke-test/k0sctl-installflags.yaml.tpl
+++ b/smoke-test/k0sctl-installflags.yaml.tpl
@@ -1,0 +1,26 @@
+apiVersion: k0sctl.k0sproject.io/v1beta1
+kind: cluster
+spec:
+  hosts:
+    - role: controller
+      uploadBinary: true
+      installFlags:
+        - "${K0S_CONTROLLER_FLAG}"
+      ssh:
+        address: "127.0.0.1"
+        port: 9022
+        keyPath: ./id_rsa_k0s
+    - role: worker
+      uploadBinary: true
+      installFlags:
+        - "${K0S_WORKER_FLAG}"
+      ssh:
+        address: "127.0.0.1"
+        port: 9023
+        keyPath: ./id_rsa_k0s
+  k0s:
+    version: "${K0S_VERSION}"
+    config:
+      spec:
+        telemetry:
+          enabled: false

--- a/smoke-test/smoke-reinstall.sh
+++ b/smoke-test/smoke-reinstall.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+
+K0SCTL_CONFIG="k0sctl-installflags.yaml"
+
+export K0S_CONTROLLER_FLAG="--labels=smoke-stage=1"
+export K0S_WORKER_FLAG="--labels=smoke-stage=1"
+envsubst < "k0sctl-installflags.yaml.tpl" > "${K0SCTL_CONFIG}"
+
+set -e
+
+. ./smoke.common.sh
+trap cleanup EXIT
+
+deleteCluster
+createCluster
+
+remoteCommand() {
+  local userhost="$1"
+  shift
+  echo "* Running command on ${userhost}: $*"
+  bootloose ssh "${userhost}" -- "$*"
+}
+
+echo "Installing ${K0S_VERSION}"
+../k0sctl apply --config "${K0SCTL_CONFIG}" --debug
+remoteCommand "root@manager0" "k0s status -o json | grep -q -- ${K0S_CONTROLLER_FLAG}"
+remoteCommand "root@worker0" "k0s status -o json | grep -q -- ${K0S_WORKER_FLAG}"
+
+export K0S_CONTROLLER_FLAG="--labels=smoke-stage=2" 
+export K0S_WORKER_FLAG="--labels=smoke-stage=2" 
+envsubst < "k0sctl-installflags.yaml.tpl" > "${K0SCTL_CONFIG}"
+
+echo "Re-applying ${K0S_VERSION} with modified installFlags"
+../k0sctl apply --config "${K0SCTL_CONFIG}" --debug
+remoteCommand "root@manager0" "k0s status -o json | grep -q -- ${K0S_CONTROLLER_FLAG}"
+remoteCommand "root@worker0" "k0s status -o json | grep -q -- ${K0S_WORKER_FLAG}"


### PR DESCRIPTION
Fixes #302 

If k0s is already installed, use `k0s install --force` to reinstall it if installFlags have changed. 

Also, reinstall will now be performed during upgrades.

Note that changing the flags on an existing cluster may cause problems.

