### PR TITLE
Use the correct field in custom binary version check

### DIFF
--- a/phase/validate_hosts.go
+++ b/phase/validate_hosts.go
@@ -58,8 +58,8 @@ func (p *ValidateHosts) Run() error {
 }
 
 func (p *ValidateHosts) warnK0sBinaryPath(h *cluster.Host) error {
-	if h.Configurer.K0sBinaryPath() != "" {
-		log.Warnf("%s: k0s binary path is set to %q, version checking for the host is disabled. The k0s version for other hosts is %q.", h, h.Configurer.K0sBinaryPath(), p.Config.Spec.K0s.Version)
+	if h.K0sBinaryPath != "" {
+		log.Warnf("%s: k0s binary path is set to %q, version checking for the host is disabled. The k0s version for other hosts is %s.", h, h.K0sBinaryPath, p.Config.Spec.K0s.Version)
 	}
 
 	return nil


### PR DESCRIPTION
#745 made k0sctl skip version equality checking when custom k0s binary is uploaded.

The check was incorrectly looking at `host.Configurer.K0sBinaryPath()` which always returns a value (the k0s binary path on the host) when it should have been looking at `host.K0sBinaryPath` which is set to whatever user has in `spec.hosts[*].k0sBinaryPath`.
