### PR TITLE
Modifiable action.Apply for when using k0sctl as a library

### DIFF
--- a/cmd/apply.go
+++ b/cmd/apply.go
@@ -72,7 +72,7 @@ var applyCommand = &cli.Command{
 			kubeconfigOut = out
 		}
 
-		applyAction := action.Apply{
+		applyOpts := action.ApplyOptions{
 			Force:                 ctx.Bool("force"),
 			Manager:               ctx.Context.Value(ctxManagerKey{}).(*phase.Manager),
 			KubeconfigOut:         kubeconfigOut,
@@ -83,6 +83,8 @@ var applyCommand = &cli.Command{
 			RestoreFrom:           ctx.String("restore-from"),
 			ConfigPath:            ctx.String("config"),
 		}
+
+		applyAction := action.NewApply(applyOpts)
 
 		if err := applyAction.Run(); err != nil {
 			return fmt.Errorf("apply failed - log file saved to %s: %w", ctx.Context.Value(ctxLogFileKey{}).(string), err)

--- a/phase/backup.go
+++ b/phase/backup.go
@@ -14,7 +14,7 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
-var _ phase = &Backup{}
+var _ Phase = &Backup{}
 
 var backupSinceVersion = version.MustConstraint(">= v1.21.0-rc.1+k0s.0")
 

--- a/phase/lock.go
+++ b/phase/lock.go
@@ -52,6 +52,11 @@ func (p *Lock) CleanUp() {
 	p.Cancel()
 }
 
+// UnlockPhase returns an unlock phase for this lock phase
+func (p *Lock) UnlockPhase() Phase {
+	return &Unlock{Cancel: p.Cancel}
+}
+
 // Run the phase
 func (p *Lock) Run() error {
 	if err := p.parallelDo(p.Config.Spec.Hosts, p.startLock); err != nil {

--- a/phase/manager.go
+++ b/phase/manager.go
@@ -19,7 +19,8 @@ var Force bool
 // Colorize is an instance of "aurora", used to colorize the output
 var Colorize = aurora.NewAurora(false)
 
-type phase interface {
+// Phase represents a runnable phase which can be added to Manager.
+type Phase interface {
 	Run() error
 	Title() string
 }
@@ -60,7 +61,7 @@ type withDryRun interface {
 
 // Manager executes phases to construct the cluster
 type Manager struct {
-	phases            []phase
+	phases            []Phase
 	Config            *v1beta1.Cluster
 	Concurrency       int
 	ConcurrentUploads int
@@ -80,7 +81,7 @@ func NewManager(config *v1beta1.Cluster) (*Manager, error) {
 }
 
 // AddPhase adds a Phase to Manager
-func (m *Manager) AddPhase(p ...phase) {
+func (m *Manager) AddPhase(p ...Phase) {
 	m.phases = append(m.phases, p...)
 }
 
@@ -124,7 +125,7 @@ func (m *Manager) Wet(host fmt.Stringer, msg string, funcs ...errorfunc) error {
 
 // Run executes all the added Phases in order
 func (m *Manager) Run() error {
-	var ran []phase
+	var ran []Phase
 	var result error
 
 	defer func() {

--- a/phase/manager.go
+++ b/phase/manager.go
@@ -134,6 +134,11 @@ func (m *Manager) AddPhase(p ...Phase) {
 	m.phases = append(m.phases, p...)
 }
 
+// SetPhases sets the list of phases
+func (m *Manager) SetPhases(p Phases) {
+	m.phases = p
+}
+
 type errorfunc func() error
 
 // DryMsg prints a message in dry-run mode

--- a/phase/manager.go
+++ b/phase/manager.go
@@ -25,6 +25,55 @@ type Phase interface {
 	Title() string
 }
 
+// Phases is a slice of Phases
+type Phases []Phase
+
+// Index returns the index of the first occurrence matching the given phase title or -1 if not found
+func (p Phases) Index(title string) int {
+	for i, phase := range p {
+		if phase.Title() == title {
+			return i
+		}
+	}
+	return -1
+}
+
+// Remove removes the first occurrence of a phase with the given title
+func (p *Phases) Remove(title string) {
+	i := p.Index(title)
+	if i == -1 {
+		return
+	}
+	*p = append((*p)[:i], (*p)[i+1:]...)
+}
+
+// InsertAfter inserts a phase after the first occurrence of a phase with the given title
+func (p *Phases) InsertAfter(title string, phase Phase) {
+	i := p.Index(title)
+	if i == -1 {
+		return
+	}
+	*p = append((*p)[:i+1], append(Phases{phase}, (*p)[i+1:]...)...)
+}
+
+// InsertBefore inserts a phase before the first occurrence of a phase with the given title
+func (p *Phases) InsertBefore(title string, phase Phase) {
+	i := p.Index(title)
+	if i == -1 {
+		return
+	}
+	*p = append((*p)[:i], append(Phases{phase}, (*p)[i:]...)...)
+}
+
+// Replace replaces the first occurrence of a phase with the given title
+func (p *Phases) Replace(title string, phase Phase) {
+	i := p.Index(title)
+	if i == -1 {
+		return
+	}
+	(*p)[i] = phase
+}
+
 type withconfig interface {
 	Title() string
 	Prepare(*v1beta1.Cluster) error
@@ -61,7 +110,7 @@ type withDryRun interface {
 
 // Manager executes phases to construct the cluster
 type Manager struct {
-	phases            []Phase
+	phases            Phases
 	Config            *v1beta1.Cluster
 	Concurrency       int
 	ConcurrentUploads int

--- a/phase/runhooks.go
+++ b/phase/runhooks.go
@@ -10,7 +10,7 @@ import (
 	"github.com/k0sproject/k0sctl/pkg/apis/k0sctl.k0sproject.io/v1beta1/cluster"
 )
 
-var _ phase = &RunHooks{}
+var _ Phase = &RunHooks{}
 
 // RunHooks phase runs a set of hooks configured for the host
 type RunHooks struct {


### PR DESCRIPTION
A bit crudelly crammed-in way to make the apply action's (can be replicated fro other actions if needed) phase list modifiable.

Before:

```go
applyAction := &action.Apply{
   Force: false
}
err := applyAction.Run()
```

After:

```go
applyAction := action.NewApply(action.ApplyOpts: {
   Force: false
})
validateFacts := &phase.ValidateFacts{} 
applyAction.Phases.InsertAfter(validateFacts.Title(), &myCustomPhase{})
err := applyAction.Run()
```

This allows adding custom phases or modifying/removing existing ones to the apply action without duplicating the action code. 

While creating this it became obvious that there's plenty of room for improvement in the way the phase manager / actions are set up.
