### PR TITLE
Default k0s API address to privateAddress when onlyBindToAddress enabled

### DIFF
--- a/phase/configure_k0s.go
+++ b/phase/configure_k0s.go
@@ -292,6 +292,12 @@ func (p *ConfigureK0s) configFor(h *cluster.Host) (string, error) {
 		addr = h.Address()
 	}
 
+	if cfg.DigString("spec", "api", "address") == "" {
+		if onlyBindAddr, ok := cfg.Dig("spec", "api", "onlyBindToAddress").(bool); ok && onlyBindAddr {
+			cfg.DigMapping("spec", "api")["address"] = addr
+		}
+	}
+
 	if cfg.Dig("spec", "storage", "etcd", "peerAddress") != nil || h.PrivateAddress != "" {
 		cfg.DigMapping("spec", "storage", "etcd")["peerAddress"] = addr
 	}


### PR DESCRIPTION
See https://github.com/k0sproject/k0sctl/issues/773#issuecomment-2448376081: with this change the default API server address is provided based on `privateAddress` if `onlyBindToAddress` is true.