### PR TITLE
Restore k0s spec.api.sans updating that was removed in #772

### DIFF
--- a/phase/configure_k0s.go
+++ b/phase/configure_k0s.go
@@ -75,6 +75,42 @@ func (p *ConfigureK0s) Prepare(config *v1beta1.Cluster) error {
 		}
 	}
 
+	// convert sans from unmarshaled config into []string
+	var sans []string
+	oldsans := p.newBaseConfig.Dig("spec", "api", "sans")
+	switch oldsans := oldsans.(type) {
+	case []interface{}:
+		for _, v := range oldsans {
+			if s, ok := v.(string); ok {
+				sans = append(sans, s)
+			}
+		}
+		log.Tracef("converted sans from %T to []string", oldsans)
+	case []string:
+		sans = append(sans, oldsans...)
+		log.Tracef("sans was readily %T", oldsans)
+	default:
+		// do nothing - base k0s config does not contain any existing SANs
+	}
+
+	// populate SANs with all controller addresses
+	for i, c := range p.Config.Spec.Hosts.Controllers() {
+		if c.Reset {
+			continue
+		}
+		if !slices.Contains(sans, c.Address()) {
+			sans = append(sans, c.Address())
+			log.Debugf("added controller %d address %s to spec.api.sans", i+1, c.Address())
+		}
+		if c.PrivateAddress != "" && !slices.Contains(sans, c.PrivateAddress) {
+			sans = append(sans, c.PrivateAddress)
+			log.Debugf("added controller %d private address %s to spec.api.sans", i+1, c.PrivateAddress)
+		}
+	}
+
+	// assign populated sans to the base config
+	p.newBaseConfig.DigMapping("spec", "api")["sans"] = sans
+
 	for _, h := range p.Config.Spec.Hosts.Controllers() {
 		if h.Reset {
 			continue
@@ -286,48 +322,13 @@ func (p *ConfigureK0s) configFor(h *cluster.Host) (string, error) {
 		cfg = p.newBaseConfig.Dup()
 	}
 
-	var (
-		sans []string
-		addr string
-	)
+	var addr string
 
 	if h.PrivateAddress != "" {
 		addr = h.PrivateAddress
 	} else {
 		addr = h.Address()
 	}
-
-	// convert sans from unmarshaled config into []string
-	oldsans := cfg.Dig("spec", "api", "sans")
-	switch oldsans := oldsans.(type) {
-	case []interface{}:
-		for _, v := range oldsans {
-			if s, ok := v.(string); ok {
-				sans = append(sans, s)
-			}
-		}
-	case []string:
-		sans = append(sans, oldsans...)
-	}
-
-	if !slices.Contains(sans, addr) {
-		sans = append(sans, addr)
-		log.Infof("%s: added %s to spec.api.sans", h, addr)
-	}
-
-	for i, c := range p.Config.Spec.Hosts.Controllers() {
-		if !slices.Contains(sans, c.Address()) {
-			sans = append(sans, c.Address())
-			log.Infof("%s: added controller %d address %s to spec.api.sans", h, i+1, c.Address())
-		}
-		if c.PrivateAddress != "" && !slices.Contains(sans, c.PrivateAddress) {
-			sans = append(sans, c.PrivateAddress)
-			log.Infof("%s: added controller %d private address %s to spec.api.sans", h, i+1, c.PrivateAddress)
-		}
-	}
-
-	log.Debugf("%s: using k0s spec.api.sans: %v", h, sans)
-	cfg.DigMapping("spec", "api")["sans"] = sans
 
 	if cfg.DigString("spec", "api", "address") == "" {
 		if onlyBindAddr, ok := cfg.Dig("spec", "api", "onlyBindToAddress").(bool); ok && onlyBindAddr {


### PR DESCRIPTION
Fixes #782

Closes https://github.com/k0sproject/k0s/pull/5157 (skip v0.19.2 bump)

Brings back and improves the k0s config `spec.api.sans` manipulation that was removed in #772 commit https://github.com/k0sproject/k0sctl/pull/772/commits/fd0ba50f48005339846446ffc2452db015e90272 - turns out adding at least the controller's public address is required as k0s will not always get it from `iface.AllAddresses()` (NAT, fqdn, etc). Also restored the adding of the addresses of all the other controllers.

Now a single list of SANs is built globally just once and it should be identical between controllers. The list includes the addresses and possibly private addresses of all controllers.
