### PR TITLE
Allow setting a custom kubeconfig username 

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,6 +194,7 @@ apiVersion: k0sctl.k0sproject.io/v1beta1
 kind: Cluster
 metadata:
   name: my-k0s-cluster
+  user: admin
 spec:
   hosts:
   - role: controller
@@ -256,6 +257,7 @@ Example:
 ```yaml
 metadata:
   name: k0s-cluster-name
+  user: kubernetes-admin
 ```
 
 ### Spec Fields

--- a/action/apply.go
+++ b/action/apply.go
@@ -32,6 +32,10 @@ type ApplyOptions struct {
 	KubeconfigOut io.Writer
 	// KubeconfigAPIAddress is the API address to use in the kubeconfig
 	KubeconfigAPIAddress string
+	// KubeconfigUser is the username to use in the kubeconfig
+	KubeconfigUser string
+	// KubeconfigCluster is the cluster name to use in the kubeconfig
+	KubeconfigCluster string
 	// ConfigPath is the path to the configuration file (used for kubeconfig command tip on success)
 	ConfigPath string
 }
@@ -92,7 +96,7 @@ func NewApply(opts ApplyOptions) *Apply {
 		},
 	}
 	if opts.KubeconfigOut != nil {
-		apply.Phases.InsertBefore(unlockPhase.Title(), &phase.GetKubeconfig{APIAddress: opts.KubeconfigAPIAddress})
+		apply.Phases.InsertBefore(unlockPhase.Title(), &phase.GetKubeconfig{APIAddress: opts.KubeconfigAPIAddress, User: opts.KubeconfigUser, Cluster: opts.KubeconfigCluster})
 	}
 
 	return apply

--- a/action/kubeconfig.go
+++ b/action/kubeconfig.go
@@ -9,6 +9,8 @@ type Kubeconfig struct {
 	// Manager is the phase manager
 	Manager              *phase.Manager
 	KubeconfigAPIAddress string
+	KubeconfigUser       string
+	KubeconfigCluster    string
 
 	Kubeconfig string
 }
@@ -21,7 +23,7 @@ func (k *Kubeconfig) Run() error {
 	k.Manager.AddPhase(
 		&phase.Connect{},
 		&phase.DetectOS{},
-		&phase.GetKubeconfig{APIAddress: k.KubeconfigAPIAddress},
+		&phase.GetKubeconfig{APIAddress: k.KubeconfigAPIAddress, User: k.KubeconfigUser, Cluster: k.KubeconfigCluster},
 		&phase.Disconnect{},
 	)
 

--- a/cmd/apply.go
+++ b/cmd/apply.go
@@ -41,6 +41,16 @@ var applyCommand = &cli.Command{
 			Name:  "kubeconfig-api-address",
 			Usage: "Override the API address in the kubeconfig when kubeconfig-out is set",
 		},
+		&cli.StringFlag{
+			Name:        "kubeconfig-user",
+			Usage:       "Set kubernetes username",
+			DefaultText: "admin",
+		},
+		&cli.StringFlag{
+			Name:        "kubeconfig-cluster",
+			Usage:       "Set kubernetes cluster name",
+			DefaultText: "k0s-cluster",
+		},
 		&cli.BoolFlag{
 			Name:   "disable-downgrade-check",
 			Usage:  "Skip downgrade check",
@@ -77,6 +87,8 @@ var applyCommand = &cli.Command{
 			Manager:               ctx.Context.Value(ctxManagerKey{}).(*phase.Manager),
 			KubeconfigOut:         kubeconfigOut,
 			KubeconfigAPIAddress:  ctx.String("kubeconfig-api-address"),
+			KubeconfigUser:        ctx.String("kubeconfig-user"),
+			KubeconfigCluster:     ctx.String("kubeconfig-cluster"),
 			NoWait:                ctx.Bool("no-wait"),
 			NoDrain:               ctx.Bool("no-drain"),
 			DisableDowngradeCheck: ctx.Bool("disable-downgrade-check"),

--- a/cmd/kubeconfig.go
+++ b/cmd/kubeconfig.go
@@ -14,9 +14,21 @@ var kubeconfigCommand = &cli.Command{
 	Usage: "Output the admin kubeconfig of the cluster",
 	Flags: []cli.Flag{
 		&cli.StringFlag{
-			Name:  "address",
-			Usage: "Set kubernetes API address (default: auto-detect)",
-			Value: "",
+			Name:        "address",
+			Value:       "",
+			DefaultText: "auto-detect",
+		},
+		&cli.StringFlag{
+			Name:        "user",
+			Usage:       "Set kubernetes cluster username",
+			Aliases:     []string{"u"},
+			DefaultText: "admin",
+		},
+		&cli.StringFlag{
+			Name:        "cluster",
+			Usage:       "Set kubernetes cluster name",
+			Aliases:     []string{"n"},
+			DefaultText: "k0s-cluster",
 		},
 		configFlag,
 		dryRunFlag,
@@ -36,6 +48,8 @@ var kubeconfigCommand = &cli.Command{
 		kubeconfigAction := action.Kubeconfig{
 			Manager:              ctx.Context.Value(ctxManagerKey{}).(*phase.Manager),
 			KubeconfigAPIAddress: ctx.String("address"),
+			KubeconfigUser:       ctx.String("user"),
+			KubeconfigCluster:    ctx.String("cluster"),
 		}
 
 		if err := kubeconfigAction.Run(); err != nil {

--- a/pkg/apis/k0sctl.k0sproject.io/v1beta1/cluster.go
+++ b/pkg/apis/k0sctl.k0sproject.io/v1beta1/cluster.go
@@ -15,6 +15,7 @@ const APIVersion = "k0sctl.k0sproject.io/v1beta1"
 // ClusterMetadata defines cluster metadata
 type ClusterMetadata struct {
 	Name        string   `yaml:"name" validate:"required" default:"k0s-cluster"`
+	User        string   `yaml:"user" default:"admin"`
 	Kubeconfig  string   `yaml:"-"`
 	EtcdMembers []string `yaml:"-"`
 }

--- a/smoke-test/smoke-basic.sh
+++ b/smoke-test/smoke-basic.sh
@@ -31,11 +31,11 @@ echo "* Using the kubectl from apply"
 ./kubectl --kubeconfig applykubeconfig get nodes
 
 echo "* Using k0sctl kubecofig locally"
-../k0sctl kubeconfig --config k0sctl.yaml > kubeconfig
+../k0sctl kubeconfig --config k0sctl.yaml --user smoke --cluster test > kubeconfig
 
 echo "* Output:"
 grep -v -- -data kubeconfig
 
 echo "* Running kubectl"
-./kubectl --kubeconfig kubeconfig get nodes
+./kubectl --kubeconfig kubeconfig --user smoke --cluster test get nodes
 echo "* Done"


### PR DESCRIPTION
Fixes #792 

Allow setting the generated kubeconfig username using `--user` in `k0sctl kubeconfig` command. Alternatively the username will be set in k0sctl.yaml `metadata.user`. When using `--kubeconfig-out` in apply, the user can be set via `--kubeconfig-user`.

The cluster name can also be now set using `--cluster` flag or `--kubeconfig-cluster` in apply.

Example:

```console
$ k0sctl kubeconfig --user example --cluster example-cluster > example-kubeconfig
$ kubeconfig --kubeconfig example-kubeconfig --user example --cluster example-cluster get nodes
```

