### PR TITLE
Use kubernetes URL from join token to validate node connectivity

### DIFF
--- a/phase/reinstall.go
+++ b/phase/reinstall.go
@@ -107,9 +107,5 @@ func (p *Reinstall) reinstall(h *cluster.Host) error {
 		return fmt.Errorf("restart after reinstall: %w", err)
 	}
 
-	if h != p.Config.Spec.K0sLeader() {
-		return nil
-	}
-
 	return nil
 }

--- a/pkg/apis/k0sctl.k0sproject.io/v1beta1/cluster/host.go
+++ b/pkg/apis/k0sctl.k0sproject.io/v1beta1/cluster/host.go
@@ -179,8 +179,7 @@ type HostMetadata struct {
 	K0sInstalled      bool
 	K0sExistingConfig string
 	K0sNewConfig      string
-	K0sJoinToken      string
-	K0sJoinTokenID    string
+	K0sTokenData  TokenData
 	K0sStatusArgs     Flags
 	Arch              string
 	IsK0sLeader       bool

--- a/pkg/apis/k0sctl.k0sproject.io/v1beta1/cluster/k0s_test.go
+++ b/pkg/apis/k0sctl.k0sproject.io/v1beta1/cluster/k0s_test.go
@@ -9,12 +9,13 @@ import (
 	"gopkg.in/yaml.v2"
 )
 
-func TestTokenID(t *testing.T) {
+func TestParseToken(t *testing.T) {
 	token := "H4sIAAAAAAAC/2xVXY/iOBZ9r1/BH6geO4GeAWkfKiEmGGLKjn1N/BbidAFOgjuk+Frtf18V3SPtSvN2fc/ROdaVfc9L6Q9Q9+fDqZuNLvilaj7PQ92fZy+vo9/17GU0Go3OdX+p+9loPwz+PPvjD/xn8A3/+Q19C2bfx+Pwyanqfjj8OFTlUL+Wn8P+1B+G+6sth3I2WudoWOc4FspSeYjmAqjKlaEcESWeGBpih2muRCQSNucavEEkzBWNDGoApDV1t19W6uNSbJsyRzS1mPc7TVdiDknV0qNFQmjl1zvsaZmao3RECHVd8YZEFtlEgGW8ISmXBIQiY6km+wwbr5v9yoIvVHs71pL81CAio0yYpQ2DJMFSe1InWHEZMZHQveiqa/3hf2Eg+v/FpKJdnZifHCA2aKK5IwwSsbVzYnZgJkWLdUZ8IbfCZA5CE1hSKhxliZ2rkKRxw2hxZIlSEHMgwFWCckUTi8iTmyNy+ZqJUtktO2Y9C8Wpuk8DsTUT7ehnjt9uBTQ0T7yDB9nyw+A4Tlb5wt2NbHgB5LSJpwvR2Ytpp6oKm/lG2ZvUZoDERjs9vubzamxJcZEaX6vDwLKWFeUWIoOqi7z/hWx7c2q77DfcJ5BkQQFAyxYw6xix8BZILAar8Ha3GM7l420ssZ/UZE/rrQtUytSus4ssXGKOissKkdgiOskw1fowPKRqxnFLPy0hj1pPvV6IC0t4AOhGgZDlZjFdGYdXLBVZBozKrUccW6Ra2mQNm5sF9bsHXRVqv8lB7E3XmNyZjKHTSm7Jp82HyxoJDom56HY8zgFa6/xCoOtdIL8qF8t71rDUYBZAI247ZHnpiluZn+9WNu8GsvEusFuOpvNS20J/+GUN1aN2U2kfpFQouVaBj3PsW6VgXwXVeJfSd4DlLdN2JR+gqoAed8hEBcB7OXc4J3Dl2jLuSCQCL0pHo9jhiCU2ygCcSC3hh2moFEQWNTFvfaQS2snGLJXDMdfFWCiquBKRUh8XqZZXgZIbaJEYTLbcUQnBtLDkY8VbWuzmMAhH97ka1tWWKN1lvQFLICEb3tq+0vu+VNXEPqKvN/gQjkQSsejLv3BsUjTRNk8mpNbMF46d1Ju/SURPRWihBOJtS5eVwp9ZQhvIB8+UCo1ksSXg7IPcS2wNc35cphHKVKNE4rebbSR2ODpxd5uYAA/VfH+JW9Jt1GRv231eJ9mj1uao2+Z7pRrB2ulP4+xF5kOxDtUF3PLKJXmXCb4XgQmzuRFVmmGZnCaA/nrIBdCvuRduvMpVs8lcNi7UcDVhRG0A93JLYpP66yqYgJoLoZumlQ9x2xFD8znIkux77oacdWqSdZSVyjCWnkKmb+9WDz/Nh5+b9O1SIDIUHaC6bW5V4qFsYSnSRmUIloXCuV1MaE7IsQAxBkR5ndqASRZtFDVGm7VszHGzwEfhJqzUzTV2tMi1iG369dfsmjVvkxKKfhMPgjsccEUPLMmCTcJCsTDrfGHGdXsOJcBpo4ezQd7sQroC3EQrdLtVD+Z16lZCY58rEO8SrX7vZiId/+AIckiaRa5YBIl67uU1P/3rZTTqyraejRw6v1Snbqhvw6+U+FX/Som/I+PJ+mp8np+nz13d1MPr7nQazkNf+v9X++z7uhte/1Z6Nt2hs7NRfOp+HD5efF//qPu6q+rzbPTv/7x8qT7Nf4v8g/zT+HmF4eTqbjY6fD+E949vVzeZ7vHx8mM6uPCATi//DQAA//+MVAsnAgcAAA=="
 
-	id, err := TokenID(token)
+	tokendata, err := ParseToken(token)
 	require.NoError(t, err)
-	require.Equal(t, "i6i3yg", id)
+	require.Equal(t, "i6i3yg", tokendata.ID)
+	require.Equal(t, "https://172.17.0.2:6443", tokendata.URL)
 }
 
 func TestUnmarshal(t *testing.T) {

--- a/pkg/node/statusfunc.go
+++ b/pkg/node/statusfunc.go
@@ -7,7 +7,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/k0sproject/k0sctl/pkg/apis/k0sctl.k0sproject.io/v1beta1"
 	"github.com/k0sproject/k0sctl/pkg/apis/k0sctl.k0sproject.io/v1beta1/cluster"
 	"github.com/k0sproject/rig/exec"
 
@@ -136,11 +135,4 @@ func ServiceStoppedFunc(h *cluster.Host, service string) retryFunc {
 		}
 		return nil
 	}
-}
-
-// KubeAPIReadyFunc returns a function that returns an error unless the host's local kube api responds to /version
-func KubeAPIReadyFunc(h *cluster.Host, config *v1beta1.Cluster) retryFunc {
-	// If the anon-auth is disabled on kube api the version endpoint will give 401
-	// thus we need to accept both 200 and 401 as valid statuses when checking kube api
-	return HTTPStatusFunc(h, fmt.Sprintf("%s/version", config.Spec.NodeInternalKubeAPIURL(h)), 200, 401)
 }

--- a/smoke-test/k0sctl-controller-swap.yaml
+++ b/smoke-test/k0sctl-controller-swap.yaml
@@ -14,7 +14,7 @@ spec:
         address: "127.0.0.1"
         port: 9023
         keyPath: ./id_rsa_k0s
-    - role: controller
+    - role: controller+worker
       uploadBinary: true
       ssh:
         address: "127.0.0.1"


### PR DESCRIPTION
Fixes #798 

The join token, once decoded, contains the kube (workers) or k0s (controllers) API URL that the node will use to communicate to the control plane.

Instead of trying to replicate the logic of k0s choosing which address to validate against, use the address (and certs) provided by k0s inside the token, because that is what the node will do.
