### PR TITLE
Use "true" as value for "--enable-worker"

### DIFF
--- a/pkg/apis/k0sctl.k0sproject.io/v1beta1/cluster/host.go
+++ b/pkg/apis/k0sctl.k0sproject.io/v1beta1/cluster/host.go
@@ -289,7 +289,7 @@ func (h *Host) K0sInstallFlags() (Flags, error) {
 
 	switch h.Role {
 	case "controller+worker":
-		flags.AddUnlessExist("--enable-worker")
+		flags.AddUnlessExist("--enable-worker=true")
 		if h.NoTaints {
 			flags.AddUnlessExist("--no-taints")
 		}

--- a/pkg/apis/k0sctl.k0sproject.io/v1beta1/cluster/host_test.go
+++ b/pkg/apis/k0sctl.k0sproject.io/v1beta1/cluster/host_test.go
@@ -90,12 +90,12 @@ func TestK0sInstallCommand(t *testing.T) {
 	h.Metadata.IsK0sLeader = true
 	cmd, err = h.K0sInstallCommand()
 	require.NoError(t, err)
-	require.Equal(t, `k0s install controller --data-dir=/tmp/k0s --enable-worker --config=from-configurer`, cmd)
+	require.Equal(t, `k0s install controller --data-dir=/tmp/k0s --enable-worker=true --config=from-configurer`, cmd)
 
 	h.Metadata.IsK0sLeader = false
 	cmd, err = h.K0sInstallCommand()
 	require.NoError(t, err)
-	require.Equal(t, `k0s install controller --data-dir=/tmp/k0s --enable-worker --token-file=from-configurer --config=from-configurer`, cmd)
+	require.Equal(t, `k0s install controller --data-dir=/tmp/k0s --enable-worker=true --token-file=from-configurer --config=from-configurer`, cmd)
 
 	h.Role = "worker"
 	h.PrivateAddress = "10.0.0.9"


### PR DESCRIPTION
Fixes #801 

K0sctl receives the `--enable-worker` flag as `--enable-worker=true` because of how cobra works, but it itself adds the flag as `--enable-worker` without the value. This causes the `installFlags` change detection to always incorrectly detect that the flags have changed and cause a reinstall every time.
