### PR TITLE
Capture error output of k0s reset

### DIFF
--- a/phase/reset_workers.go
+++ b/phase/reset_workers.go
@@ -1,7 +1,9 @@
 package phase
 
 import (
+	"bytes"
 	"context"
+	"fmt"
 
 	"github.com/k0sproject/k0sctl/pkg/apis/k0sctl.k0sproject.io/v1beta1"
 	"github.com/k0sproject/k0sctl/pkg/apis/k0sctl.k0sproject.io/v1beta1/cluster"
@@ -87,10 +89,13 @@ func (p *ResetWorkers) Run() error {
 		}
 
 		log.Debugf("%s: resetting k0s...", h)
-		out, err := h.ExecOutput(h.Configurer.K0sCmdf("reset --data-dir=%s", h.K0sDataDir()), exec.Sudo(h))
+		var stdoutbuf, stderrbuf bytes.Buffer
+		cmd, err := h.ExecStreams(h.Configurer.K0sCmdf("reset --data-dir=%s", h.K0sDataDir()), nil, &stdoutbuf, &stderrbuf, exec.Sudo(h))
 		if err != nil {
-			log.Debugf("%s: k0s reset failed: %s", h, out)
-			log.Warnf("%s: k0s reported failure: %v", h, err)
+			return fmt.Errorf("failed to run k0s reset: %w", err)
+		}
+		if err := cmd.Wait(); err != nil {
+			log.Warnf("%s: k0s reset reported failure: %s %s", h, stderrbuf.String(), stdoutbuf.String())
 		}
 		log.Debugf("%s: resetting k0s completed", h)
 
@@ -99,7 +104,7 @@ func (p *ResetWorkers) Run() error {
 			log.Warnf("%s: failed to remove existing configuration %s: %s", h, h.Configurer.K0sConfigPath(), dErr)
 		}
 		log.Debugf("%s: removing config completed", h)
-		
+
 		if len(h.Environment) > 0 {
 			if err := h.Configurer.CleanupServiceEnvironment(h, h.K0sServiceName()); err != nil {
 				log.Warnf("%s: failed to clean up service environment: %s", h, err.Error())
@@ -107,6 +112,6 @@ func (p *ResetWorkers) Run() error {
 		}
 
 		log.Infof("%s: reset", h)
-		return err
+		return nil
 	})
 }


### PR DESCRIPTION
Fixes #807

- Capture and report the output of `k0s reset` when performing a reset on nodes.
- Ignore `k0s reset` failures and proceed to attempt resetting remaining nodes.

