### PR TITLE
Don't require the Go patch version

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/k0sproject/k0sctl
 
-go 1.23.2
+go 1.23
 
 toolchain go1.23.3
 


### PR DESCRIPTION
This makes it compile with any Go 1.23 toolchain.