### PR TITLE
Allow reading k0s config from a separate or multidoc YAML document

### DIFF
--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -108,6 +108,23 @@ jobs:
         env:
           LINUX_IMAGE: ${{ matrix.image }}
         run: make smoke-basic-openssh
+  
+  smoke-multidoc:
+    strategy:
+      matrix:
+        image:
+          - quay.io/k0sproject/bootloose-alpine3.18
+    name: Basic 1+1 smoke using multidoc yamls
+    needs: build
+    runs-on: ubuntu-20.04
+
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ./.github/actions/smoke-test-cache
+      - name: Run smoke tests
+        env:
+          LINUX_IMAGE: ${{ matrix.image }}
+        run: make smoke-multidoc
 
   smoke-files:
     strategy:

--- a/Makefile
+++ b/Makefile
@@ -51,7 +51,7 @@ build-all: $(addprefix bin/,$(bins)) bin/checksums.md
 clean:
 	rm -rf bin/ k0sctl
 
-smoketests := smoke-basic smoke-basic-rootless smoke-files smoke-upgrade smoke-reset smoke-os-override smoke-init smoke-backup-restore smoke-dynamic smoke-basic-openssh smoke-dryrun smoke-downloadurl smoke-controller-swap smoke-reinstall
+smoketests := smoke-basic smoke-basic-rootless smoke-files smoke-upgrade smoke-reset smoke-os-override smoke-init smoke-backup-restore smoke-dynamic smoke-basic-openssh smoke-dryrun smoke-downloadurl smoke-controller-swap smoke-reinstall smoke-multidoc
 .PHONY: $(smoketests)
 $(smoketests): k0sctl
 	$(MAKE) -C smoke-test $@

--- a/README.md
+++ b/README.md
@@ -582,6 +582,26 @@ Embedded k0s cluster configuration. See [k0s configuration documentation](https:
 
 When left out, the output of `k0s config create` will be used.
 
+You can also host the configuration in a separate file or as a separate YAML document in the same file in the standard k0s configuration format.
+
+```yaml
+apiVersion: k0sctl.k0sproject.io/v1beta1
+kind: Cluster
+spec:
+  hosts:
+    - role: single
+      ssh:
+        address: 10.0.0.1
+---
+apiVersion: k0s.k0sproject.io/v1beta1
+kind: ClusterConfig
+metadata:
+  name: my-k0s-cluster
+spec:
+  api:
+    externalAddress: 10.0.0.2
+```
+
 #### Tokens
 
 The following tokens can be used in the `k0sDownloadURL` and `files.[*].src` fields:

--- a/action/apply.go
+++ b/action/apply.go
@@ -35,8 +35,8 @@ type ApplyOptions struct {
 	KubeconfigUser string
 	// KubeconfigCluster is the cluster name to use in the kubeconfig
 	KubeconfigCluster string
-	// ConfigPath is the path to the configuration file (used for kubeconfig command tip on success)
-	ConfigPath string
+	// ConfigPaths is the list of paths to the configuration files (used for kubeconfig command tip on success)
+	ConfigPaths []string
 }
 
 type Apply struct {
@@ -158,9 +158,11 @@ func (a Apply) Run() error {
 		cmd.WriteString(executable)
 		cmd.WriteString(" kubeconfig")
 
-		if a.ConfigPath != "" && a.ConfigPath != "-" && a.ConfigPath != "k0sctl.yaml" {
-			cmd.WriteString(" --config ")
-			cmd.WriteString(a.ConfigPath)
+		if len(a.ConfigPaths) > 0 && (len(a.ConfigPaths) != 1 && a.ConfigPaths[0] != "-" && a.ConfigPaths[0] != "k0sctl.yaml") {
+			for _, path := range a.ConfigPaths {
+				cmd.WriteString(" --config ")
+				cmd.WriteString(path)
+			}
 		}
 
 		log.Info("Tip: To access the cluster you can now fetch the admin kubeconfig using:")

--- a/cmd/apply.go
+++ b/cmd/apply.go
@@ -90,7 +90,7 @@ var applyCommand = &cli.Command{
 			NoDrain:               ctx.Bool("no-drain"),
 			DisableDowngradeCheck: ctx.Bool("disable-downgrade-check"),
 			RestoreFrom:           ctx.String("restore-from"),
-			ConfigPath:            ctx.String("config"),
+			ConfigPaths:           ctx.StringSlice("config"),
 		}
 
 		applyAction := action.NewApply(applyOpts)

--- a/cmd/config_edit.go
+++ b/cmd/config_edit.go
@@ -19,7 +19,7 @@ var configEditCommand = &cli.Command{
 	Before: actions(initLogging, initConfig),
 	Action: func(ctx *cli.Context) error {
 		configEditAction := action.ConfigEdit{
-			Config: ctx.Context.Value(ctxConfigKey{}).(*v1beta1.Cluster),
+			Config: ctx.Context.Value(ctxConfigsKey{}).(*v1beta1.Cluster),
 			Stdout: ctx.App.Writer,
 			Stderr: ctx.App.ErrWriter,
 			Stdin:  ctx.App.Reader,

--- a/cmd/config_status.go
+++ b/cmd/config_status.go
@@ -2,7 +2,6 @@ package cmd
 
 import (
 	"github.com/k0sproject/k0sctl/action"
-	"github.com/k0sproject/k0sctl/pkg/apis/k0sctl.k0sproject.io/v1beta1"
 
 	"github.com/urfave/cli/v2"
 )
@@ -23,8 +22,13 @@ var configStatusCommand = &cli.Command{
 	},
 	Before: actions(initLogging, initConfig),
 	Action: func(ctx *cli.Context) error {
+		cfg, err := readConfig(ctx)
+		if err != nil {
+			return err
+		}
+
 		configStatusAction := action.ConfigStatus{
-			Config: ctx.Context.Value(ctxConfigKey{}).(*v1beta1.Cluster),
+			Config: cfg,
 			Format: ctx.String("output"),
 			Writer: ctx.App.Writer,
 		}

--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,7 @@ require (
 	github.com/creasty/defaults v1.8.0
 	github.com/gofrs/uuid v4.4.0+incompatible // indirect
 	github.com/hashicorp/go-version v1.7.0 // indirect
-	github.com/k0sproject/dig v0.3.1
+	github.com/k0sproject/dig v0.4.0
 	github.com/k0sproject/rig v0.19.0
 	github.com/logrusorgru/aurora v2.0.3+incompatible
 	github.com/masterzen/simplexml v0.0.0-20190410153822-31eea3082786 // indirect

--- a/go.sum
+++ b/go.sum
@@ -109,8 +109,8 @@ github.com/josharian/intern v1.0.0 h1:vlS4z54oSdjm0bgjRigI+G1HpF+tI+9rE5LLzOg8Hm
 github.com/josharian/intern v1.0.0/go.mod h1:5DoeVV0s6jJacbCEi61lwdGj/aVlrQvzHFFd8Hwg//Y=
 github.com/json-iterator/go v1.1.12 h1:PV8peI4a0ysnczrg+LtxykD8LfKY9ML6u2jnxaEnrnM=
 github.com/json-iterator/go v1.1.12/go.mod h1:e30LSqwooZae/UwlEbR2852Gd8hjQvJoHmT4TnhNGBo=
-github.com/k0sproject/dig v0.3.1 h1:/QK40lXQ/HEE3LMT3r/kST1ANhMVZiajNDXI+spbL9o=
-github.com/k0sproject/dig v0.3.1/go.mod h1:rlZ7N7ZEcB4Fi96TPXkZ4dqyAiDWOGLapyL9YpZ7Qz4=
+github.com/k0sproject/dig v0.4.0 h1:yBxFUUxNXAMGBg6b7c6ypxdx/o3RmhoI5v5ABOw5tn0=
+github.com/k0sproject/dig v0.4.0/go.mod h1:rlZ7N7ZEcB4Fi96TPXkZ4dqyAiDWOGLapyL9YpZ7Qz4=
 github.com/k0sproject/rig v0.19.0 h1:aF/wJDfK45Ho2Z75Uap+u4Q4jHgr/1WfrHcOg2U9/n0=
 github.com/k0sproject/rig v0.19.0/go.mod h1:SNa9+xeVA6zQVYx+SINaa4ZihFPWrmo/6crHcdvJRFI=
 github.com/k0sproject/version v0.6.0 h1:Wi8wu9j+H36+okIQA47o/YHbzNpKeIYj8IjGdJOdqsI=

--- a/pkg/apis/k0sctl.k0sproject.io/v1beta1/cluster.go
+++ b/pkg/apis/k0sctl.k0sproject.io/v1beta1/cluster.go
@@ -14,10 +14,10 @@ const APIVersion = "k0sctl.k0sproject.io/v1beta1"
 
 // ClusterMetadata defines cluster metadata
 type ClusterMetadata struct {
-	Name        string   `yaml:"name" validate:"required" default:"k0s-cluster"`
-	User        string   `yaml:"user" default:"admin"`
-	Kubeconfig  string   `yaml:"-"`
-	EtcdMembers []string `yaml:"-"`
+	Name        string            `yaml:"name" validate:"required" default:"k0s-cluster"`
+	User        string            `yaml:"user" default:"admin"`
+	Kubeconfig  string            `yaml:"-"`
+	EtcdMembers []string          `yaml:"-"`
 }
 
 // Cluster describes launchpad.yaml configuration

--- a/pkg/manifest/reader.go
+++ b/pkg/manifest/reader.go
@@ -1,0 +1,182 @@
+package manifest
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"io"
+	"os"
+	"path"
+	"regexp"
+	"strings"
+	"time"
+
+	"gopkg.in/yaml.v2"
+)
+
+// ResourceDefinition represents a single Kubernetes resource definition.
+type ResourceDefinition struct {
+	APIVersion string `yaml:"apiVersion"`
+	Kind       string `yaml:"kind"`
+	Metadata   struct {
+		Name string `yaml:"name"`
+	} `yaml:"metadata"`
+	Origin string `yaml:"-"`
+	Raw    []byte `yaml:"-"`
+}
+
+var fnRe = regexp.MustCompile(`[^\w\-\.]`)
+
+func safeFn(input string) string {
+	safe := fnRe.ReplaceAllString(input, "_")
+	safe = strings.Trim(safe, "._")
+	return safe
+}
+
+// Filename returns a filename compatible name of the resource definition.
+func (rd *ResourceDefinition) Filename() string {
+	if strings.HasSuffix(rd.Origin, ".yaml") || strings.HasSuffix(rd.Origin, ".yml") {
+		return path.Base(rd.Origin)
+	}
+
+	if rd.Metadata.Name != "" {
+		return fmt.Sprintf("%s-%s.yaml", safeFn(rd.Kind), safeFn(rd.Metadata.Name))
+	}
+
+	return fmt.Sprintf("%s-%s-%d.yaml", safeFn(rd.APIVersion), safeFn(rd.Kind), time.Now().UnixNano())
+}
+
+// returns a Reader that reads the raw resource definition
+func (rd *ResourceDefinition) Reader() *bytes.Reader {
+	return bytes.NewReader(rd.Raw)
+}
+
+// Bytes returns the raw resource definition.
+func (rd *ResourceDefinition) Bytes() []byte {
+	return rd.Raw
+}
+
+// Unmarshal unmarshals the raw resource definition into the provided object.
+func (rd *ResourceDefinition) Unmarshal(obj any) error {
+	if err := yaml.UnmarshalStrict(rd.Bytes(), obj); err != nil {
+		return fmt.Errorf("failed to unmarshal %s: %w", rd.Origin, err)
+	}
+	return nil
+}
+
+func yamlDocumentSplit(data []byte, atEOF bool) (advance int, token []byte, err error) {
+	if atEOF && len(data) == 0 {
+		return 0, nil, nil
+	}
+
+	// Look for the document separator
+	sepIndex := bytes.Index(data, []byte("\n---"))
+	if sepIndex >= 0 {
+		// Return everything up to the separator
+		return sepIndex + len("\n---"), data[:sepIndex], nil
+	}
+
+	// If at EOF, return the remaining data
+	if atEOF {
+		return len(data), data, nil
+	}
+
+	// Request more data
+	return 0, nil, nil
+}
+
+// Reader reads Kubernetes resource definitions from input streams.
+type Reader struct {
+	IgnoreErrors bool
+	manifests    []*ResourceDefinition
+}
+
+func name(r io.Reader) string {
+	if n, ok := r.(*os.File); ok {
+		return n.Name()
+	}
+	return "manifest"
+}
+
+// Parse parses Kubernetes resource definitions from the provided input stream. They are then available via the Resources() or GetResources(apiVersion, kind) methods.
+func (r *Reader) Parse(input io.Reader) error {
+	scanner := bufio.NewScanner(input)
+	scanner.Split(yamlDocumentSplit)
+
+	for scanner.Scan() {
+		rawChunk := scanner.Bytes()
+
+		// Skip empty chunks
+		if len(rawChunk) == 0 {
+			continue
+		}
+
+		rd := &ResourceDefinition{}
+		if err := yaml.Unmarshal(rawChunk, rd); err != nil {
+			if r.IgnoreErrors {
+				continue
+			}
+			return fmt.Errorf("failed to decode resource %s: %w", name(input), err)
+		}
+
+		if rd.APIVersion == "" || rd.Kind == "" {
+			if r.IgnoreErrors {
+				continue
+			}
+			return fmt.Errorf("missing apiVersion or kind in resource %s", name(input))
+		}
+
+		// Store the raw chunk
+		rd.Raw = append([]byte{}, rawChunk...)
+		r.manifests = append(r.manifests, rd)
+	}
+
+	if err := scanner.Err(); err != nil {
+		return fmt.Errorf("error reading input: %w", err)
+	}
+
+	return nil
+}
+
+// ParseString parses Kubernetes resource definitions from the provided string.
+func (r *Reader) ParseString(input string) error {
+	return r.Parse(strings.NewReader(input))
+}
+
+// ParseBytes parses Kubernetes resource definitions from the provided byte slice.
+func (r *Reader) ParseBytes(input []byte) error {
+	return r.Parse(bytes.NewReader(input))
+}
+
+// Resources returns all parsed Kubernetes resource definitions.
+func (r *Reader) Resources() []*ResourceDefinition {
+	return r.manifests
+}
+
+// Len returns the number of parsed Kubernetes resource definitions.
+func (r *Reader) Len() int {
+	return len(r.manifests)
+}
+
+// FilterResources returns all parsed Kubernetes resource definitions that match the provided filter function.
+func (r *Reader) FilterResources(filter func(rd *ResourceDefinition) bool) []*ResourceDefinition {
+	var resources []*ResourceDefinition
+	for _, rd := range r.manifests {
+		if filter(rd) {
+			resources = append(resources, rd)
+		}
+	}
+	return resources
+}
+
+// GetResources returns all parsed Kubernetes resource definitions that match the provided apiVersion and kind. The matching is case-insensitive.
+func (r *Reader) GetResources(apiVersion, kind string) ([]*ResourceDefinition, error) {
+	resources := r.FilterResources(func(rd *ResourceDefinition) bool {
+		return strings.EqualFold(rd.APIVersion, apiVersion) && strings.EqualFold(rd.Kind, kind)
+	})
+
+	if len(resources) == 0 {
+		return nil, fmt.Errorf("no resources found for apiVersion=%s, kind=%s", apiVersion, kind)
+	}
+	return resources, nil
+}

--- a/pkg/manifest/reader_test.go
+++ b/pkg/manifest/reader_test.go
@@ -1,0 +1,151 @@
+package manifest_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/k0sproject/k0sctl/pkg/manifest"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestReader_ParseIgnoreErrors(t *testing.T) {
+	input := `
+apiVersion: v1
+kind: Pod
+metadata:
+  name: pod1
+---
+invalid_yaml
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: service1
+`
+	reader := strings.NewReader(input)
+	r := &manifest.Reader{IgnoreErrors: true}
+
+	err := r.Parse(reader)
+
+	// Ensure no critical errors even with invalid YAML
+	require.NoError(t, err, "Parse should not return an error with IgnoreErrors=true")
+
+	// Assert that only valid manifests are parsed
+	require.Equal(t, 2, r.Len(), "Expected 2 valid manifests to be parsed")
+
+	// Validate the parsed manifests
+	assert.Equal(t, "v1", r.Resources()[0].APIVersion, "Unexpected apiVersion for Pod")
+	assert.Equal(t, "Pod", r.Resources()[0].Kind, "Unexpected kind for Pod")
+	assert.Equal(t, "v1", r.Resources()[1].APIVersion, "Unexpected apiVersion for Service")
+	assert.Equal(t, "Service", r.Resources()[1].Kind, "Unexpected kind for Service")
+}
+
+func TestReader_ParseMultipleReaders(t *testing.T) {
+	input1 := `
+apiVersion: v1
+kind: Pod
+metadata:
+  name: pod1
+`
+	input2 := `
+apiVersion: v1
+kind: Service
+metadata:
+  name: service1
+`
+	r := &manifest.Reader{}
+
+	// Parse first reader
+	err := r.Parse(strings.NewReader(input1))
+	require.NoError(t, err, "Parse should not return an error for input1")
+
+	// Parse second reader
+	err = r.Parse(strings.NewReader(input2))
+	require.NoError(t, err, "Parse should not return an error for input2")
+
+	// Assert that both manifests are parsed
+	require.Equal(t, 2, r.Len(), "Expected 2 manifests to be parsed")
+
+	// Validate the parsed manifests
+	pod := r.Resources()[0]
+	assert.Equal(t, "v1", pod.APIVersion, "Unexpected apiVersion for Pod")
+	assert.Equal(t, "Pod", pod.Kind, "Unexpected kind for Pod")
+	require.Len(t, pod.Raw, len(input1))
+
+	service := r.Resources()[1]
+	assert.Equal(t, "v1", service.APIVersion, "Unexpected apiVersion for Service")
+	assert.Equal(t, "Service", service.Kind, "Unexpected kind for Service")
+	require.Len(t, service.Raw, len(input2))
+}
+
+func TestReader_FilterResources(t *testing.T) {
+	input := `
+apiVersion: v1
+kind: Pod
+metadata:
+  name: pod1
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: service1
+---
+apiVersion: v2
+kind: Pod
+metadata:
+  name: pod2
+`
+	r := &manifest.Reader{}
+	require.NoError(t, r.Parse(strings.NewReader(input)))
+	v1Pods := r.FilterResources(func(rd *manifest.ResourceDefinition) bool {
+		return rd.APIVersion == "v1" && rd.Kind == "Pod"
+	})
+	v2Pods := r.FilterResources(func(rd *manifest.ResourceDefinition) bool {
+		return rd.APIVersion == "v2" && rd.Kind == "Pod"
+	})
+	assert.Len(t, v1Pods, 1, "Expected 2 v1 Pod to be returned")
+	assert.Len(t, v2Pods, 1, "Expected 1 v2 Pod to be returned")
+	assert.Equal(t, "pod1", v1Pods[0].Metadata.Name, "Unexpected name for v1 Pod")
+	assert.Equal(t, "pod2", v2Pods[0].Metadata.Name, "Unexpected name for v2 Pod")
+	assert.NotEmpty(t, v1Pods[0].Raw, "Expected raw data to be populated")
+	assert.NotEmpty(t, v2Pods[0].Raw, "Expected raw data to be populated")
+}
+
+func TestReader_GetResources(t *testing.T) {
+	input := `
+apiVersion: v1
+kind: Pod
+metadata:
+  name: pod1
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: service1
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: pod2
+`
+	reader := strings.NewReader(input)
+	r := &manifest.Reader{}
+
+	err := r.Parse(reader)
+	require.NoError(t, err, "Parse should not return an error")
+
+	// Query for Pods
+	pods, err := r.GetResources("v1", "Pod")
+	require.NoError(t, err, "GetResources should not return an error for Pods")
+	assert.Len(t, pods, 2, "Expected 2 Pods to be returned")
+
+	// Validate Pods
+	assert.Equal(t, "Pod", pods[0].Kind, "Unexpected kind for the first Pod")
+	assert.Equal(t, "Pod", pods[1].Kind, "Unexpected kind for the second Pod")
+
+	// Query for Services
+	services, err := r.GetResources("v1", "Service")
+	require.NoError(t, err, "GetResources should not return an error for Services")
+	assert.Len(t, services, 1, "Expected 1 Service to be returned")
+}

--- a/smoke-test/Makefile
+++ b/smoke-test/Makefile
@@ -61,5 +61,9 @@ smoke-backup-restore: $(bootloose) id_rsa_k0s k0sctl
 smoke-controller-swap: $(bootloose) id_rsa_k0s k0sctl
 	BOOTLOOSE_TEMPLATE=bootloose-controller-swap.yaml.tpl K0SCTL_CONFIG=k0sctl-controller-swap.yaml ./smoke-controller-swap.sh
 
+smoke-multidoc: $(bootloose) id_rsa_k0s k0sctl
+	./smoke-multidoc.sh
+
+
 %.iid: Dockerfile.%
 	docker build --iidfile '$@' - < '$<'

--- a/smoke-test/multidoc/k0sctl-multidoc-1.yaml
+++ b/smoke-test/multidoc/k0sctl-multidoc-1.yaml
@@ -1,0 +1,25 @@
+apiVersion: k0sctl.k0sproject.io/v1beta1
+kind: cluster
+spec:
+  hosts:
+    - role: controller
+      uploadBinary: true
+      os: "$OS_OVERRIDE"
+      ssh:
+        address: "127.0.0.1"
+        port: 9022
+        keyPath: ./id_rsa_k0s
+    - role: worker
+      uploadBinary: true
+      os: "$OS_OVERRIDE"
+      ssh:
+        address: "127.0.0.1"
+        port: 9023
+        keyPath: ./id_rsa_k0s
+  k0s:
+    version: "${K0S_VERSION}"
+    config:
+      spec:
+        telemetry:
+          enabled: false
+

--- a/smoke-test/multidoc/k0sctl-multidoc-2.yaml
+++ b/smoke-test/multidoc/k0sctl-multidoc-2.yaml
@@ -1,0 +1,17 @@
+apiVersion: k0s.k0sproject.io/v1beta1
+kind: clusterconfig
+spec:
+  extensions:
+    helm:
+      concurrencyLevel: 5
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: hello
+spec:
+  containers:
+  - name: hello
+    image: nginx:alpine
+    ports:
+    - containerPort: 80

--- a/smoke-test/smoke-multidoc.sh
+++ b/smoke-test/smoke-multidoc.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env sh
+
+K0SCTL_CONFIG=${K0SCTL_CONFIG:-"k0sctl.yaml"}
+
+set -e
+
+
+. ./smoke.common.sh
+trap cleanup EXIT
+
+deleteCluster
+createCluster
+
+remoteCommand() {
+  local userhost="$1"
+  shift
+  bootloose ssh "${userhost}" -- "$@"
+}
+
+echo "* Starting apply"
+../k0sctl apply --config multidoc/ --kubeconfig-out applykubeconfig --debug
+echo "* Apply OK"
+
+remoteCommand root@manager0 "cat /etc/k0s/k0s.yaml" > k0syaml
+echo Resulting k0s.yaml:
+cat k0syaml
+echo "* Verifying config merging works"
+grep -q "concurrencyLevel: 5" k0syaml
+grep -q "enabled: false" k0syaml
+
+echo "* Done"
+


### PR DESCRIPTION
Fixes #812 

* Multiple `--config` statements, globs such as `config/**/*.yaml` or directories as in `--config configs/` are now allowed.
* `spec.k0s.config` can now be defined in a separate config in the standard k0s configuration format with `apiVersion: k0s.k0sproject.io/v1beta1` and `kind: ClusterConfig`.
* The separate k0s config can also be contained in the same multidoc YAML configuration file as the `k0sctl.yaml` when separated with the `---` document separator.

Multidoc configuration example:

```yaml
apiVersion: k0sctl.k0sproject.io/v1beta1
kind: cluster
spec:
  hosts:
    - role: single
      ssh:
        address: 10.0.0.1
  k0s:
    version: "v1.31.3+k0s.0"
---
apiVersion: k0s.k0sproject.io/v1beta1
kind: ClusterConfig
metadata:
  name: k0s
spec:
  api:
    address: 192.168.68.104
    k0sApiPort: 9443
    port: 6443
```

