### PR TITLE
Do not set etcd peerAddress when cluster storage type is kine

### DIFF
--- a/phase/configure_k0s.go
+++ b/phase/configure_k0s.go
@@ -336,8 +336,10 @@ func (p *ConfigureK0s) configFor(h *cluster.Host) (string, error) {
 		}
 	}
 
-	if cfg.Dig("spec", "storage", "etcd", "peerAddress") != nil && h.PrivateAddress != "" {
-		cfg.DigMapping("spec", "storage", "etcd")["peerAddress"] = addr
+	if h.Role != "single" {
+		if cfg.Dig("spec", "storage", "etcd", "peerAddress") != nil || h.PrivateAddress != "" {
+			cfg.DigMapping("spec", "storage", "etcd")["peerAddress"] = addr
+		}
 	}
 
 	if _, ok := cfg["apiVersion"]; !ok {

--- a/phase/configure_k0s.go
+++ b/phase/configure_k0s.go
@@ -336,7 +336,7 @@ func (p *ConfigureK0s) configFor(h *cluster.Host) (string, error) {
 		}
 	}
 
-	if h.Role != "single" {
+	if p.Config.StorageType() == "etcd" {
 		if cfg.Dig("spec", "storage", "etcd", "peerAddress") != nil || h.PrivateAddress != "" {
 			cfg.DigMapping("spec", "storage", "etcd")["peerAddress"] = addr
 		}

--- a/phase/configure_k0s.go
+++ b/phase/configure_k0s.go
@@ -336,7 +336,7 @@ func (p *ConfigureK0s) configFor(h *cluster.Host) (string, error) {
 		}
 	}
 
-	if cfg.Dig("spec", "storage", "etcd", "peerAddress") != nil || h.PrivateAddress != "" {
+	if cfg.Dig("spec", "storage", "etcd", "peerAddress") != nil && h.PrivateAddress != "" {
 		cfg.DigMapping("spec", "storage", "etcd")["peerAddress"] = addr
 	}
 

--- a/pkg/apis/k0sctl.k0sproject.io/v1beta1/cluster.go
+++ b/pkg/apis/k0sctl.k0sproject.io/v1beta1/cluster.go
@@ -58,3 +58,26 @@ func (c *Cluster) Validate() error {
 		validation.Field(&c.Spec),
 	)
 }
+
+// StorageType returns the k0s storage type.
+func (c *Cluster) StorageType() string {
+	if c.Spec == nil {
+		// default to etcd when there's no hosts or k0s spec, this should never happen.
+		return "etcd"
+	}
+
+	if c.Spec.K0s != nil {
+		if t := c.Spec.K0s.Config.DigString("spec", "storage", "type"); t != "" {
+			// if storage type is set in k0s spec, return it
+			return t
+		}
+	}
+
+	if h := c.Spec.K0sLeader(); h != nil && h.Role == "single" {
+		// default to "kine" on single node clusters
+		return "kine"
+	}
+
+	// default to etcd otherwise
+	return "etcd"
+}


### PR DESCRIPTION
Correcting a small bug outlined in #815 

Fixes #815 

I have tested locally and after applying this patch, the resulting configuration on `localhost` contains no reference to etcd as much when using `openSSH`

