### PR TITLE
Apply additional kube manifests from configs to cluster

### DIFF
--- a/action/apply.go
+++ b/action/apply.go
@@ -90,6 +90,7 @@ func NewApply(opts ApplyOptions) *Apply {
 			&phase.ResetWorkers{NoDrain: opts.NoDrain},
 			&phase.ResetControllers{NoDrain: opts.NoDrain},
 			&phase.RunHooks{Stage: "after", Action: "apply"},
+			&phase.ApplyManifests{},
 			unlockPhase,
 			&phase.Disconnect{},
 		},

--- a/phase/apply_manifests.go
+++ b/phase/apply_manifests.go
@@ -61,10 +61,9 @@ func (p *ApplyManifests) apply(name string, content []byte) error {
 		return fmt.Errorf("failed to run apply for manifest %s: %w", name, err)
 	}
 	if err := cmd.Wait(); err != nil {
-		log.Errorf("kubectl apply failed for manifest %s", name)
-		log.Errorf("kubectl apply stderr: %s", stderr.String())
-		return fmt.Errorf("failed to apply manifest %s: %w", name, err)
+		log.Errorf("%s: kubectl apply failed for manifest %s", p.leader, name)
+		log.Errorf("%s: kubectl apply stderr: %s", p.leader, stderr.String())
 	}
-	log.Infof("kubectl apply: %s", stdout.String())
+	log.Infof("%s: kubectl apply: %s", p.leader, stdout.String())
 	return nil
 }

--- a/phase/apply_manifests.go
+++ b/phase/apply_manifests.go
@@ -1,0 +1,70 @@
+package phase
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+
+	"github.com/k0sproject/k0sctl/pkg/apis/k0sctl.k0sproject.io/v1beta1"
+	"github.com/k0sproject/k0sctl/pkg/apis/k0sctl.k0sproject.io/v1beta1/cluster"
+	"github.com/k0sproject/rig/exec"
+	log "github.com/sirupsen/logrus"
+)
+
+// ApplyManifests is a phase that applies additional manifests to the cluster
+type ApplyManifests struct {
+	GenericPhase
+	leader *cluster.Host
+}
+
+// Title for the phase
+func (p *ApplyManifests) Title() string {
+	return "Apply additional manifests"
+}
+
+// Prepare the phase
+func (p *ApplyManifests) Prepare(config *v1beta1.Cluster) error {
+	p.Config = config
+	p.leader = p.Config.Spec.K0sLeader()
+
+	return nil
+}
+
+// ShouldRun is true when there are additional manifests to apply
+func (p *ApplyManifests) ShouldRun() bool {
+	return len(p.Config.Metadata.Manifests) > 0
+}
+
+// Run the phase
+func (p *ApplyManifests) Run() error {
+	for name, content := range p.Config.Metadata.Manifests {
+		if err := p.apply(name, content); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (p *ApplyManifests) apply(name string, content []byte) error {
+	if !p.IsWet() {
+		p.DryMsgf(p.leader, "apply manifest %s (%d bytes)", name, len(content))
+		return nil
+	}
+
+	log.Infof("%s: apply manifest %s (%d bytes)", p.leader, name, len(content))
+	kubectlCmd := p.leader.Configurer.KubectlCmdf(p.leader, p.leader.K0sDataDir(), "apply -f -")
+	var stdout, stderr bytes.Buffer
+
+	cmd, err := p.leader.ExecStreams(kubectlCmd, io.NopCloser(bytes.NewReader(content)), &stdout, &stderr, exec.Sudo(p.leader))
+	if err != nil {
+		return fmt.Errorf("failed to run apply for manifest %s: %w", name, err)
+	}
+	if err := cmd.Wait(); err != nil {
+		log.Errorf("kubectl apply failed for manifest %s", name)
+		log.Errorf("kubectl apply stderr: %s", stderr.String())
+		return fmt.Errorf("failed to apply manifest %s: %w", name, err)
+	}
+	log.Infof("kubectl apply: %s", stdout.String())
+	return nil
+}

--- a/pkg/apis/k0sctl.k0sproject.io/v1beta1/cluster.go
+++ b/pkg/apis/k0sctl.k0sproject.io/v1beta1/cluster.go
@@ -18,6 +18,7 @@ type ClusterMetadata struct {
 	User        string            `yaml:"user" default:"admin"`
 	Kubeconfig  string            `yaml:"-"`
 	EtcdMembers []string          `yaml:"-"`
+	Manifests   map[string][]byte `yaml:"-"`
 }
 
 // Cluster describes launchpad.yaml configuration

--- a/smoke-test/smoke-multidoc.sh
+++ b/smoke-test/smoke-multidoc.sh
@@ -21,6 +21,17 @@ echo "* Starting apply"
 ../k0sctl apply --config multidoc/ --kubeconfig-out applykubeconfig --debug
 echo "* Apply OK"
 
+echo "* Downloading kubectl for local test"
+downloadKubectl
+
+echo "*Waiting until the test pod is running"
+KUBECONFIG=applykubeconfig ./kubectl wait --for=condition=Ready pod/hello --timeout=120s
+
+sleep 2
+
+echo "* Using kubectl to verify the test pod works"
+KUBECONFIG=applykubeconfig ./kubectl exec -it pod/hello -- curl http://localhost/ | grep -q "Welcome to nginx!"
+
 remoteCommand root@manager0 "cat /etc/k0s/k0s.yaml" > k0syaml
 echo Resulting k0s.yaml:
 cat k0syaml


### PR DESCRIPTION
Additional feature for #812 

Any encountered configuration files that are in the "kubernetes resource" format (contains `apiVersion` and `kind` fields) will be applied to the cluster using `kubectl apply` as the last step before disconnect during a `k0sctl apply` action.

Example YAML:

```yaml
apiVersion: k0sctl.k0sproject.io/v1beta1
kind: cluster
spec:
  hosts:
    - role: single
      ssh:
        address: 10.0.0.1
---
apiVersion: v1
kind: Pod
metadata:
  name: hello
spec:
  containers:
  - name: hello
    image: nginx:alpine
    ports:
    - containerPort: 80
 ```
 