### PR TITLE
Fix multidoc smoke-test retry

### DIFF
--- a/smoke-test/smoke-multidoc.sh
+++ b/smoke-test/smoke-multidoc.sh
@@ -36,7 +36,6 @@ i=1
 
 while [ "$i" -le "$retries" ]; do
     echo "* Attempt $i: Checking if nginx is ready..."
-    ./kubectl exec pod/hello -- curl http://localhost/ | grep -q "Welcome to nginx!"
     if kubectl exec pod/hello -- curl -s http://localhost/ | grep -q "Welcome to nginx!"; then
         echo "nginx is ready!"
         nginx_ready=true


### PR DESCRIPTION
There was an extra line in the script causing it to not retry.
