### PR TITLE
Fix k0s version constraints for pre-release versions

### DIFF
--- a/phase/arm_prepare.go
+++ b/phase/arm_prepare.go
@@ -10,7 +10,7 @@ import (
 	"github.com/k0sproject/k0sctl/pkg/apis/k0sctl.k0sproject.io/v1beta1/cluster"
 )
 
-var etcdSupportedArchArm64Since = version.MustConstraint(">= v1.22.1-0+k0s.0")
+var etcdSupportedArchArm64Since = version.MustParse("v1.22.1+k0s.0")
 
 // PrepareArm implements a phase which fixes arm quirks
 type PrepareArm struct {
@@ -45,7 +45,7 @@ func (p *PrepareArm) Prepare(config *v1beta1.Cluster) error {
 
 		if strings.HasSuffix(arch, "64") {
 			// 64-bit arm is supported on etcd 3.5.0+ which is included in k0s v1.22.1+k0s.0 and newer
-			if etcdSupportedArchArm64Since.Check(p.Config.Spec.K0s.Version) {
+			if p.Config.Spec.K0s.Version.GreaterThanOrEqual(etcdSupportedArchArm64Since) {
 				return false
 			}
 		}

--- a/phase/arm_prepare.go
+++ b/phase/arm_prepare.go
@@ -10,7 +10,7 @@ import (
 	"github.com/k0sproject/k0sctl/pkg/apis/k0sctl.k0sproject.io/v1beta1/cluster"
 )
 
-var etcdSupportedArchArm64Since = version.MustConstraint(">= v1.22.1+k0s.0")
+var etcdSupportedArchArm64Since = version.MustConstraint(">= v1.22.1-0+k0s.0")
 
 // PrepareArm implements a phase which fixes arm quirks
 type PrepareArm struct {

--- a/phase/backup.go
+++ b/phase/backup.go
@@ -16,7 +16,7 @@ import (
 
 var _ Phase = &Backup{}
 
-var backupSinceVersion = version.MustConstraint(">= v1.21.0-rc.1+k0s.0")
+var backupSinceVersion = version.MustParse("v1.21.0-rc.1+k0s.0")
 
 // Backup connect to one of the controllers and takes a backup
 type Backup struct {
@@ -34,7 +34,7 @@ func (p *Backup) Title() string {
 func (p *Backup) Prepare(config *v1beta1.Cluster) error {
 	p.Config = config
 
-	if !backupSinceVersion.Check(p.Config.Spec.K0s.Version) {
+	if !p.Config.Spec.K0s.Version.GreaterThanOrEqual(backupSinceVersion) {
 		return fmt.Errorf("the version of k0s on the host does not support taking backups")
 	}
 

--- a/phase/backup.go
+++ b/phase/backup.go
@@ -116,7 +116,7 @@ func (p *Backup) Run() error {
 
 	if p.IsWet() {
 		// Download the file
-		f, err := os.OpenFile(localFile, os.O_RDWR|os.O_CREATE|os.O_SYNC, 0600)
+		f, err := os.OpenFile(localFile, os.O_RDWR|os.O_CREATE|os.O_SYNC, 0o600)
 		if err != nil {
 			return err
 		}

--- a/phase/configure_k0s.go
+++ b/phase/configure_k0s.go
@@ -21,7 +21,7 @@ import (
 )
 
 // "k0s default-config" was replaced with "k0s config create" in v1.23.1+k0s.0
-var configCreateSinceVersion = version.MustConstraint(">= v1.23.1+k0s.0")
+var configCreateSinceVersion = version.MustConstraint(">= v1.23.1-0+k0s.0")
 
 const (
 	configSourceExisting int = iota

--- a/phase/configure_k0s.go
+++ b/phase/configure_k0s.go
@@ -21,7 +21,7 @@ import (
 )
 
 // "k0s default-config" was replaced with "k0s config create" in v1.23.1+k0s.0
-var configCreateSinceVersion = version.MustConstraint(">= v1.23.1-0+k0s.0")
+var configCreateSince = version.MustParse("v1.23.1+k0s.0")
 
 const (
 	configSourceExisting int = iota
@@ -202,7 +202,7 @@ func (p *ConfigureK0s) ShouldRun() bool {
 func (p *ConfigureK0s) generateDefaultConfig() (string, error) {
 	log.Debugf("%s: generating default configuration", p.leader)
 	var cmd string
-	if configCreateSinceVersion.Check(p.leader.Metadata.K0sBinaryVersion) {
+	if p.leader.Metadata.K0sBinaryVersion.GreaterThanOrEqual(configCreateSince) {
 		cmd = p.leader.Configurer.K0sCmdf("config create --data-dir=%s", p.leader.K0sDataDir())
 	} else {
 		cmd = p.leader.Configurer.K0sCmdf("default-config")
@@ -228,7 +228,6 @@ func (p *ConfigureK0s) validateConfig(h *cluster.Host, configPath string) error 
 	log.Infof("%s: validating configuration", h)
 
 	var cmd string
-	log.Debugf("%s: comparing k0s version %s with %s", h, p.Config.Spec.K0s.Version, configCreateSinceVersion)
 
 	if h.Metadata.K0sBinaryTempFile != "" {
 		oldK0sBinaryPath := h.Configurer.K0sBinaryPath()
@@ -238,7 +237,8 @@ func (p *ConfigureK0s) validateConfig(h *cluster.Host, configPath string) error 
 		}()
 	}
 
-	if configCreateSinceVersion.Check(p.Config.Spec.K0s.Version) {
+	log.Debugf("%s: comparing k0s version %s with %s", h, p.Config.Spec.K0s.Version, configCreateSince)
+	if p.Config.Spec.K0s.Version.GreaterThanOrEqual(configCreateSince) {
 		log.Debugf("%s: comparison result true", h)
 		cmd = h.Configurer.K0sCmdf(`config validate --config "%s"`, configPath)
 	} else {

--- a/phase/gather_facts.go
+++ b/phase/gather_facts.go
@@ -17,7 +17,7 @@ type GatherFacts struct {
 }
 
 // K0s doesn't rely on unique machine IDs anymore since v1.30.
-var uniqueMachineIDVersion = version.MustConstraint("< v1.30-0")
+var uniqueMachineIDSince = version.MustParse("v1.30.0")
 
 // Title for the phase
 func (p *GatherFacts) Title() string {
@@ -36,7 +36,7 @@ func (p *GatherFacts) investigateHost(h *cluster.Host) error {
 	}
 	h.Metadata.Arch = output
 
-	if !p.SkipMachineIDs && uniqueMachineIDVersion.Check(p.Config.Spec.K0s.Version) {
+	if !p.SkipMachineIDs && p.Config.Spec.K0s.Version.LessThan(uniqueMachineIDSince) {
 		id, err := h.Configurer.MachineID(h)
 		if err != nil {
 			return err

--- a/phase/gather_facts.go
+++ b/phase/gather_facts.go
@@ -17,7 +17,7 @@ type GatherFacts struct {
 }
 
 // K0s doesn't rely on unique machine IDs anymore since v1.30.
-var uniqueMachineIDVersion = version.MustConstraint("< v1.30")
+var uniqueMachineIDVersion = version.MustConstraint("< v1.30-0")
 
 // Title for the phase
 func (p *GatherFacts) Title() string {

--- a/phase/prepare_hosts.go
+++ b/phase/prepare_hosts.go
@@ -15,7 +15,7 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
-var iptablesEmbeddedSince = version.MustConstraint(">= v1.22.1-0+k0s.0")
+var iptablesEmbeddedSince = version.MustParse("v1.22.1+k0s.0")
 
 // PrepareHosts installs required packages and so on on the hosts.
 type PrepareHosts struct {
@@ -85,7 +85,7 @@ func (p *PrepareHosts) prepareHost(h *cluster.Host) error {
 	}
 
 	// iptables is only required for very old versions of k0s
-	if p.Config.Spec.K0s.Version != nil && !iptablesEmbeddedSince.Check(p.Config.Spec.K0s.Version) && h.NeedIPTables() { //nolint:staticcheck
+	if p.Config.Spec.K0s.Version != nil && !p.Config.Spec.K0s.Version.GreaterThanOrEqual(iptablesEmbeddedSince) && h.NeedIPTables() { //nolint:staticcheck
 		pkgs = append(pkgs, "iptables")
 	}
 

--- a/phase/prepare_hosts.go
+++ b/phase/prepare_hosts.go
@@ -15,7 +15,7 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
-var iptablesEmbeddedSince = version.MustConstraint(">= v1.22.1+k0s.0")
+var iptablesEmbeddedSince = version.MustConstraint(">= v1.22.1-0+k0s.0")
 
 // PrepareHosts installs required packages and so on on the hosts.
 type PrepareHosts struct {

--- a/phase/reinstall.go
+++ b/phase/reinstall.go
@@ -36,12 +36,12 @@ func (p *Reinstall) Prepare(config *v1beta1.Cluster) error {
 
 // ShouldRun is true when there are hosts that needs to be reinstalled
 func (p *Reinstall) ShouldRun() bool {
-	return cluster.K0sForceFlagSince.Check(p.Config.Spec.K0s.Version) && len(p.hosts) > 0
+	return p.Config.Spec.K0s.Version.GreaterThanOrEqual(cluster.K0sForceFlagSince) && len(p.hosts) > 0
 }
 
 // Run the phase
 func (p *Reinstall) Run() error {
-	if !cluster.K0sForceFlagSince.Check(p.Config.Spec.K0s.Version) {
+	if p.Config.Spec.K0s.Version.LessThan(cluster.K0sForceFlagSince) {
 		log.Warnf("k0s version %s does not support install --force flag, installFlags won't be reconfigured", p.Config.Spec.K0s.Version)
 		return nil
 	}

--- a/phase/restore.go
+++ b/phase/restore.go
@@ -36,7 +36,7 @@ func (p *Restore) Prepare(config *v1beta1.Cluster) error {
 	}
 
 	// defined in backup.go
-	if !backupSinceVersion.Check(p.Config.Spec.K0s.Version) {
+	if p.Config.Spec.K0s.Version.LessThan(backupSinceVersion) {
 		return fmt.Errorf("the version of k0s on the host does not support restoring backups")
 	}
 

--- a/phase/validate_hosts.go
+++ b/phase/validate_hosts.go
@@ -23,7 +23,7 @@ func (p *ValidateHosts) Title() string {
 // Run the phase
 func (p *ValidateHosts) Run() error {
 	p.hncount = make(map[string]int, len(p.Config.Spec.Hosts))
-	if uniqueMachineIDVersion.Check(p.Config.Spec.K0s.Version) {
+	if p.Config.Spec.K0s.Version.LessThan(uniqueMachineIDSince) {
 		p.machineidcount = make(map[string]int, len(p.Config.Spec.Hosts))
 	}
 	p.privateaddrcount = make(map[string]int, len(p.Config.Spec.Hosts))

--- a/pkg/apis/k0sctl.k0sproject.io/v1beta1/cluster/host.go
+++ b/pkg/apis/k0sctl.k0sproject.io/v1beta1/cluster/host.go
@@ -21,7 +21,7 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
-var K0sForceFlagSince = version.MustConstraint(">= v1.27.4+k0s.0")
+var K0sForceFlagSince = version.MustConstraint(">= v1.27.4-0+k0s.0")
 
 // Host contains all the needed details to work with hosts
 type Host struct {
@@ -179,7 +179,7 @@ type HostMetadata struct {
 	K0sInstalled      bool
 	K0sExistingConfig string
 	K0sNewConfig      string
-	K0sTokenData  TokenData
+	K0sTokenData      TokenData
 	K0sStatusArgs     Flags
 	Arch              string
 	IsK0sLeader       bool

--- a/pkg/apis/k0sctl.k0sproject.io/v1beta1/cluster/host.go
+++ b/pkg/apis/k0sctl.k0sproject.io/v1beta1/cluster/host.go
@@ -21,7 +21,7 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
-var K0sForceFlagSince = version.MustConstraint(">= v1.27.4-0+k0s.0")
+var K0sForceFlagSince = version.MustParse("v1.27.4+k0s.0")
 
 // Host contains all the needed details to work with hosts
 type Host struct {
@@ -329,7 +329,7 @@ func (h *Host) K0sInstallFlags() (Flags, error) {
 		}
 	}
 
-	if flags.Include("--force") && h.Metadata.K0sBinaryVersion != nil && !K0sForceFlagSince.Check(h.Metadata.K0sBinaryVersion) {
+	if flags.Include("--force") && h.Metadata.K0sBinaryVersion != nil && h.Metadata.K0sBinaryVersion.LessThan(K0sForceFlagSince) {
 		log.Warnf("%s: k0s version %s does not support the --force flag, ignoring it", h, h.Metadata.K0sBinaryVersion)
 		flags.Delete("--force")
 	}

--- a/pkg/apis/k0sctl.k0sproject.io/v1beta1/cluster/k0s.go
+++ b/pkg/apis/k0sctl.k0sproject.io/v1beta1/cluster/k0s.go
@@ -24,9 +24,9 @@ import (
 const K0sMinVersion = "0.11.0-rc1"
 
 var (
-	k0sSupportedVersion           = version.MustConstraint(">= " + K0sMinVersion)
-	k0sDynamicConfigSince         = version.MustConstraint(">= 1.22.2-0+k0s.2")
-	k0sTokenCreateConfigFlagUntil = version.MustConstraint("< v1.23.4-rc.1+k0s.0")
+	k0sSupportedVersion           = version.MustParse(K0sMinVersion)
+	k0sDynamicConfigSince         = version.MustParse("1.22.2+k0s.2")
+	k0sTokenCreateConfigFlagUntil = version.MustParse("v1.23.4-rc.1+k0s.0")
 )
 
 // K0s holds configuration for bootstraping a k0s cluster
@@ -97,7 +97,7 @@ func validateVersion(value interface{}) error {
 		return nil
 	}
 
-	if !k0sSupportedVersion.Check(v) {
+	if v.LessThan(v) {
 		return fmt.Errorf("minimum supported k0s version is %s", k0sSupportedVersion)
 	}
 
@@ -122,7 +122,7 @@ func (k *K0s) validateMinDynamic() func(interface{}) error {
 			return nil
 		}
 
-		if k.Version != nil && !k.Version.IsZero() && !k0sDynamicConfigSince.Check(k.Version) {
+		if k.Version != nil && !k.Version.IsZero() && k.Version.LessThan(k0sDynamicConfigSince) {
 			return fmt.Errorf("dynamic config only available since k0s version %s", k0sDynamicConfigSince)
 		}
 
@@ -153,7 +153,7 @@ func (k *K0s) GenerateToken(h *Host, role string, expiry time.Duration) (string,
 
 	k0sFlags.AddOrReplace(fmt.Sprintf("--data-dir=%s", h.K0sDataDir()))
 
-	if k0sTokenCreateConfigFlagUntil.Check(k.Version) {
+	if k.Version.LessThanOrEqual(k0sTokenCreateConfigFlagUntil) {
 		k0sFlags.Add(fmt.Sprintf("--config %s", shellescape.Quote(h.K0sConfigPath())))
 	}
 

--- a/pkg/apis/k0sctl.k0sproject.io/v1beta1/cluster/k0s.go
+++ b/pkg/apis/k0sctl.k0sproject.io/v1beta1/cluster/k0s.go
@@ -25,7 +25,7 @@ const K0sMinVersion = "0.11.0-rc1"
 
 var (
 	k0sSupportedVersion           = version.MustConstraint(">= " + K0sMinVersion)
-	k0sDynamicConfigSince         = version.MustConstraint(">= 1.22.2+k0s.2")
+	k0sDynamicConfigSince         = version.MustConstraint(">= 1.22.2-0+k0s.2")
 	k0sTokenCreateConfigFlagUntil = version.MustConstraint("< v1.23.4-rc.1+k0s.0")
 )
 

--- a/pkg/apis/k0sctl.k0sproject.io/v1beta1/cluster/k0s.go
+++ b/pkg/apis/k0sctl.k0sproject.io/v1beta1/cluster/k0s.go
@@ -97,7 +97,7 @@ func validateVersion(value interface{}) error {
 		return nil
 	}
 
-	if v.LessThan(v) {
+	if v.LessThan(k0sSupportedVersion) {
 		return fmt.Errorf("minimum supported k0s version is %s", k0sSupportedVersion)
 	}
 


### PR DESCRIPTION
Fixes #826

Ref: https://github.com/k0sproject/version/pull/22

Stable version constraints like `>= v1.22.0` never match pre-release versions such as `v1.31.0-rc.1`. This is by design in the `k0sproject/version` package.

This PR simply adds `-0` to those constraints to make them match. This may not be 100% accurate if some feature was not in something like `v1.23.0-rc.1` but is in `v1.23.0` or `v1.23.0-rc.2`. 
