### PR TITLE
Add a --timeout flag to allow retrying operations for a longer time

### DIFF
--- a/action/apply.go
+++ b/action/apply.go
@@ -1,6 +1,7 @@
 package action
 
 import (
+	"context"
 	"fmt"
 	"io"
 	"os"
@@ -103,7 +104,7 @@ func NewApply(opts ApplyOptions) *Apply {
 }
 
 // Run the Apply action
-func (a Apply) Run() error {
+func (a Apply) Run(ctx context.Context) error {
 	if len(a.Phases) == 0 {
 		// for backwards compatibility with the old Apply struct without NewApply(..)
 		tmpApply := NewApply(a.ApplyOptions)
@@ -118,7 +119,7 @@ func (a Apply) Run() error {
 
 	var result error
 
-	if result = a.Manager.Run(); result != nil {
+	if result = a.Manager.Run(ctx); result != nil {
 		log.Info(phase.Colorize.Red("==> Apply failed").String())
 		return result
 	}

--- a/action/backup.go
+++ b/action/backup.go
@@ -1,6 +1,7 @@
 package action
 
 import (
+	"context"
 	"fmt"
 	"time"
 
@@ -13,7 +14,7 @@ type Backup struct {
 	Manager *phase.Manager
 }
 
-func (b Backup) Run() error {
+func (b Backup) Run(ctx context.Context) error {
 	start := time.Now()
 
 	lockPhase := &phase.Lock{}
@@ -32,7 +33,7 @@ func (b Backup) Run() error {
 		&phase.Disconnect{},
 	)
 
-	if err := b.Manager.Run(); err != nil {
+	if err := b.Manager.Run(ctx); err != nil {
 		return err
 	}
 

--- a/action/config_edit.go
+++ b/action/config_edit.go
@@ -1,6 +1,7 @@
 package action
 
 import (
+	"context"
 	"fmt"
 	"io"
 	"os"
@@ -20,7 +21,7 @@ type ConfigEdit struct {
 	Stdin  io.Reader
 }
 
-func (c ConfigEdit) Run() error {
+func (c ConfigEdit) Run(_ context.Context) error {
 	stdoutFile, ok := c.Stdout.(*os.File)
 
 	if !ok || !isatty.IsTerminal(stdoutFile.Fd()) {

--- a/action/config_status.go
+++ b/action/config_status.go
@@ -1,6 +1,7 @@
 package action
 
 import (
+	"context"
 	"fmt"
 	"io"
 
@@ -15,7 +16,7 @@ type ConfigStatus struct {
 	Writer      io.Writer
 }
 
-func (c ConfigStatus) Run() error {
+func (c ConfigStatus) Run(_ context.Context) error {
 	h := c.Config.Spec.K0sLeader()
 
 	if err := h.Connect(); err != nil {

--- a/action/kubeconfig.go
+++ b/action/kubeconfig.go
@@ -1,6 +1,8 @@
 package action
 
 import (
+	"context"
+
 	"github.com/k0sproject/k0sctl/phase"
 	"github.com/k0sproject/k0sctl/pkg/apis/k0sctl.k0sproject.io/v1beta1/cluster"
 )
@@ -15,7 +17,7 @@ type Kubeconfig struct {
 	Kubeconfig string
 }
 
-func (k *Kubeconfig) Run() error {
+func (k *Kubeconfig) Run(ctx context.Context) error {
 	// Change so that the internal config has only single controller host as we
 	// do not need to connect to all nodes
 	k.Manager.Config.Spec.Hosts = cluster.Hosts{k.Manager.Config.Spec.K0sLeader()}
@@ -27,5 +29,5 @@ func (k *Kubeconfig) Run() error {
 		&phase.Disconnect{},
 	)
 
-	return k.Manager.Run()
+	return k.Manager.Run(ctx)
 }

--- a/action/reset.go
+++ b/action/reset.go
@@ -1,6 +1,7 @@
 package action
 
 import (
+	"context"
 	"fmt"
 	"io"
 	"os"
@@ -20,7 +21,7 @@ type Reset struct {
 	Force   bool
 }
 
-func (r Reset) Run() error {
+func (r Reset) Run(ctx context.Context) error {
 	if !r.Force {
 		if stdoutFile, ok := r.Stdout.(*os.File); ok && !isatty.IsTerminal(stdoutFile.Fd()) {
 			return fmt.Errorf("reset requires --force")
@@ -66,7 +67,7 @@ func (r Reset) Run() error {
 		&phase.Disconnect{},
 	)
 
-	if err := r.Manager.Run(); err != nil {
+	if err := r.Manager.Run(ctx); err != nil {
 		return err
 	}
 

--- a/cmd/apply.go
+++ b/cmd/apply.go
@@ -65,8 +65,10 @@ var applyCommand = &cli.Command{
 		redactFlag,
 		retryIntervalFlag,
 		retryTimeoutFlag,
+		timeoutFlag,
 	},
 	Before: actions(initLogging, initConfig, initManager, displayLogo, displayCopyright, warnOldCache),
+	After:  actions(cancelTimeout),
 	Action: func(ctx *cli.Context) error {
 		var kubeconfigOut io.Writer
 
@@ -95,7 +97,7 @@ var applyCommand = &cli.Command{
 
 		applyAction := action.NewApply(applyOpts)
 
-		if err := applyAction.Run(); err != nil {
+		if err := applyAction.Run(ctx.Context); err != nil {
 			return fmt.Errorf("apply failed - log file saved to %s: %w", ctx.Context.Value(ctxLogFileKey{}).(string), err)
 		}
 

--- a/cmd/backup.go
+++ b/cmd/backup.go
@@ -18,16 +18,18 @@ var backupCommand = &cli.Command{
 		debugFlag,
 		traceFlag,
 		redactFlag,
+		timeoutFlag,
 		retryIntervalFlag,
 		retryTimeoutFlag,
 	},
 	Before: actions(initLogging, initConfig, initManager, displayLogo, displayCopyright),
+	After:  actions(cancelTimeout),
 	Action: func(ctx *cli.Context) error {
 		backupAction := action.Backup{
 			Manager: ctx.Context.Value(ctxManagerKey{}).(*phase.Manager),
 		}
 
-		if err := backupAction.Run(); err != nil {
+		if err := backupAction.Run(ctx.Context); err != nil {
 			return fmt.Errorf("backup failed - log file saved to %s: %w", ctx.Context.Value(ctxLogFileKey{}).(string), err)
 		}
 

--- a/cmd/config_edit.go
+++ b/cmd/config_edit.go
@@ -15,8 +15,10 @@ var configEditCommand = &cli.Command{
 		debugFlag,
 		traceFlag,
 		redactFlag,
+		timeoutFlag,
 	},
 	Before: actions(initLogging, initConfig),
+	After:  actions(cancelTimeout),
 	Action: func(ctx *cli.Context) error {
 		configEditAction := action.ConfigEdit{
 			Config: ctx.Context.Value(ctxConfigsKey{}).(*v1beta1.Cluster),
@@ -25,6 +27,6 @@ var configEditCommand = &cli.Command{
 			Stdin:  ctx.App.Reader,
 		}
 
-		return configEditAction.Run()
+		return configEditAction.Run(ctx.Context)
 	},
 }

--- a/cmd/config_status.go
+++ b/cmd/config_status.go
@@ -14,6 +14,7 @@ var configStatusCommand = &cli.Command{
 		debugFlag,
 		traceFlag,
 		redactFlag,
+		timeoutFlag,
 		&cli.StringFlag{
 			Name:    "output",
 			Usage:   "kubectl output formatting",
@@ -21,6 +22,7 @@ var configStatusCommand = &cli.Command{
 		},
 	},
 	Before: actions(initLogging, initConfig),
+	After:  actions(cancelTimeout),
 	Action: func(ctx *cli.Context) error {
 		cfg, err := readConfig(ctx)
 		if err != nil {
@@ -33,6 +35,6 @@ var configStatusCommand = &cli.Command{
 			Writer: ctx.App.Writer,
 		}
 
-		return configStatusAction.Run()
+		return configStatusAction.Run(ctx.Context)
 	},
 }

--- a/cmd/kubeconfig.go
+++ b/cmd/kubeconfig.go
@@ -34,10 +34,12 @@ var kubeconfigCommand = &cli.Command{
 		debugFlag,
 		traceFlag,
 		redactFlag,
+		timeoutFlag,
 		retryIntervalFlag,
 		retryTimeoutFlag,
 	},
 	Before: actions(initSilentLogging, initConfig, initManager),
+	After:  actions(cancelTimeout),
 	Action: func(ctx *cli.Context) error {
 		kubeconfigAction := action.Kubeconfig{
 			Manager:              ctx.Context.Value(ctxManagerKey{}).(*phase.Manager),
@@ -46,7 +48,7 @@ var kubeconfigCommand = &cli.Command{
 			KubeconfigCluster:    ctx.String("cluster"),
 		}
 
-		if err := kubeconfigAction.Run(); err != nil {
+		if err := kubeconfigAction.Run(ctx.Context); err != nil {
 			return fmt.Errorf("getting kubeconfig failed - log file saved to %s: %w", ctx.Context.Value(ctxLogFileKey{}).(string), err)
 		}
 

--- a/cmd/reset.go
+++ b/cmd/reset.go
@@ -19,6 +19,7 @@ var resetCommand = &cli.Command{
 		debugFlag,
 		traceFlag,
 		redactFlag,
+		timeoutFlag,
 		retryIntervalFlag,
 		retryTimeoutFlag,
 		&cli.BoolFlag{
@@ -28,6 +29,7 @@ var resetCommand = &cli.Command{
 		},
 	},
 	Before: actions(initLogging, initConfig, initManager, displayCopyright),
+	After:  actions(cancelTimeout),
 	Action: func(ctx *cli.Context) error {
 		resetAction := action.Reset{
 			Manager: ctx.Context.Value(ctxManagerKey{}).(*phase.Manager),
@@ -35,7 +37,7 @@ var resetCommand = &cli.Command{
 			Stdout:  ctx.App.Writer,
 		}
 
-		if err := resetAction.Run(); err != nil {
+		if err := resetAction.Run(ctx.Context); err != nil {
 			return fmt.Errorf("reset failed - log file saved to %s: %w", ctx.Context.Value(ctxLogFileKey{}).(string), err)
 		}
 

--- a/phase/apply_manifests.go
+++ b/phase/apply_manifests.go
@@ -2,6 +2,7 @@ package phase
 
 import (
 	"bytes"
+	"context"
 	"fmt"
 	"io"
 
@@ -36,7 +37,7 @@ func (p *ApplyManifests) ShouldRun() bool {
 }
 
 // Run the phase
-func (p *ApplyManifests) Run() error {
+func (p *ApplyManifests) Run(_ context.Context) error {
 	for name, content := range p.Config.Metadata.Manifests {
 		if err := p.apply(name, content); err != nil {
 			return err

--- a/phase/arm_prepare.go
+++ b/phase/arm_prepare.go
@@ -63,11 +63,11 @@ func (p *PrepareArm) ShouldRun() bool {
 }
 
 // Run the phase
-func (p *PrepareArm) Run(_ context.Context) error {
-	return p.parallelDo(p.hosts, p.etcdUnsupportedArch)
+func (p *PrepareArm) Run(ctx context.Context) error {
+	return p.parallelDo(ctx, p.hosts, p.etcdUnsupportedArch)
 }
 
-func (p *PrepareArm) etcdUnsupportedArch(h *cluster.Host) error {
+func (p *PrepareArm) etcdUnsupportedArch(_ context.Context, h *cluster.Host) error {
 	log.Warnf("%s: enabling ETCD_UNSUPPORTED_ARCH=%s override - you may encounter problems with etcd", h, h.Metadata.Arch)
 	h.Environment["ETCD_UNSUPPORTED_ARCH"] = h.Metadata.Arch
 

--- a/phase/arm_prepare.go
+++ b/phase/arm_prepare.go
@@ -1,6 +1,7 @@
 package phase
 
 import (
+	"context"
 	"strings"
 
 	"github.com/k0sproject/version"
@@ -62,7 +63,7 @@ func (p *PrepareArm) ShouldRun() bool {
 }
 
 // Run the phase
-func (p *PrepareArm) Run() error {
+func (p *PrepareArm) Run(_ context.Context) error {
 	return p.parallelDo(p.hosts, p.etcdUnsupportedArch)
 }
 

--- a/phase/backup.go
+++ b/phase/backup.go
@@ -1,6 +1,7 @@
 package phase
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"path"
@@ -54,7 +55,7 @@ func (p *Backup) ShouldRun() bool {
 }
 
 // Run the phase
-func (p *Backup) Run() error {
+func (p *Backup) Run(_ context.Context) error {
 	h := p.leader
 
 	log.Infof("%s: backing up", h)

--- a/phase/configure_k0s.go
+++ b/phase/configure_k0s.go
@@ -258,7 +258,7 @@ func (p *ConfigureK0s) validateConfig(h *cluster.Host, configPath string) error 
 	return nil
 }
 
-func (p *ConfigureK0s) configureK0s(_ context.Context, h *cluster.Host) error {
+func (p *ConfigureK0s) configureK0s(ctx context.Context, h *cluster.Host) error {
 	path := h.K0sConfigPath()
 	if h.Configurer.FileExist(h, path) {
 		if !h.Configurer.FileContains(h, path, " generated-by-k0sctl") {
@@ -301,7 +301,7 @@ func (p *ConfigureK0s) configureK0s(_ context.Context, h *cluster.Host) error {
 		}
 
 		log.Infof("%s: waiting for k0s service to start", h)
-		return retry.Timeout(context.TODO(), retry.DefaultTimeout, node.ServiceRunningFunc(h, h.K0sServiceName()))
+		return retry.AdaptiveTimeout(ctx, retry.DefaultTimeout, node.ServiceRunningFunc(h, h.K0sServiceName()))
 	}
 
 	return nil

--- a/phase/configure_k0s.go
+++ b/phase/configure_k0s.go
@@ -217,7 +217,7 @@ func (p *ConfigureK0s) generateDefaultConfig() (string, error) {
 }
 
 // Run the phase
-func (p *ConfigureK0s) Run() error {
+func (p *ConfigureK0s) Run(_ context.Context) error {
 	controllers := p.Config.Spec.Hosts.Controllers().Filter(func(h *cluster.Host) bool {
 		return !h.Reset && len(h.Metadata.K0sNewConfig) > 0
 	})

--- a/phase/configure_k0s.go
+++ b/phase/configure_k0s.go
@@ -217,11 +217,11 @@ func (p *ConfigureK0s) generateDefaultConfig() (string, error) {
 }
 
 // Run the phase
-func (p *ConfigureK0s) Run(_ context.Context) error {
+func (p *ConfigureK0s) Run(ctx context.Context) error {
 	controllers := p.Config.Spec.Hosts.Controllers().Filter(func(h *cluster.Host) bool {
 		return !h.Reset && len(h.Metadata.K0sNewConfig) > 0
 	})
-	return p.parallelDo(controllers, p.configureK0s)
+	return p.parallelDo(ctx, controllers, p.configureK0s)
 }
 
 func (p *ConfigureK0s) validateConfig(h *cluster.Host, configPath string) error {
@@ -258,7 +258,7 @@ func (p *ConfigureK0s) validateConfig(h *cluster.Host, configPath string) error 
 	return nil
 }
 
-func (p *ConfigureK0s) configureK0s(h *cluster.Host) error {
+func (p *ConfigureK0s) configureK0s(_ context.Context, h *cluster.Host) error {
 	path := h.K0sConfigPath()
 	if h.Configurer.FileExist(h, path) {
 		if !h.Configurer.FileContains(h, path, " generated-by-k0sctl") {

--- a/phase/connect.go
+++ b/phase/connect.go
@@ -23,7 +23,7 @@ func (p *Connect) Title() string {
 }
 
 // Run the phase
-func (p *Connect) Run() error {
+func (p *Connect) Run(_ context.Context) error {
 	return p.parallelDo(p.Config.Spec.Hosts, func(h *cluster.Host) error {
 		return retry.Timeout(context.TODO(), 10*time.Minute, func(_ context.Context) error {
 			if err := h.Connect(); err != nil {

--- a/phase/connect.go
+++ b/phase/connect.go
@@ -25,7 +25,7 @@ func (p *Connect) Title() string {
 // Run the phase
 func (p *Connect) Run(ctx context.Context) error {
 	return p.parallelDo(ctx, p.Config.Spec.Hosts, func(ctx context.Context, h *cluster.Host) error {
-		return retry.Timeout(ctx, 10*time.Minute, func(_ context.Context) error {
+		return retry.AdaptiveTimeout(ctx, 10*time.Minute, func(_ context.Context) error {
 			if err := h.Connect(); err != nil {
 				if errors.Is(err, rig.ErrCantConnect) || strings.Contains(err.Error(), "host key mismatch") {
 					return errors.Join(retry.ErrAbort, err)

--- a/phase/connect.go
+++ b/phase/connect.go
@@ -23,9 +23,9 @@ func (p *Connect) Title() string {
 }
 
 // Run the phase
-func (p *Connect) Run(_ context.Context) error {
-	return p.parallelDo(p.Config.Spec.Hosts, func(h *cluster.Host) error {
-		return retry.Timeout(context.TODO(), 10*time.Minute, func(_ context.Context) error {
+func (p *Connect) Run(ctx context.Context) error {
+	return p.parallelDo(ctx, p.Config.Spec.Hosts, func(ctx context.Context, h *cluster.Host) error {
+		return retry.Timeout(ctx, 10*time.Minute, func(_ context.Context) error {
 			if err := h.Connect(); err != nil {
 				if errors.Is(err, rig.ErrCantConnect) || strings.Contains(err.Error(), "host key mismatch") {
 					return errors.Join(retry.ErrAbort, err)

--- a/phase/daemon_reload.go
+++ b/phase/daemon_reload.go
@@ -1,6 +1,8 @@
 package phase
 
 import (
+	"context"
+
 	"github.com/k0sproject/k0sctl/pkg/apis/k0sctl.k0sproject.io/v1beta1/cluster"
 	log "github.com/sirupsen/logrus"
 )
@@ -21,7 +23,7 @@ func (p *DaemonReload) ShouldRun() bool {
 }
 
 // Run the phase
-func (p *DaemonReload) Run() error {
+func (p *DaemonReload) Run(_ context.Context) error {
 	return p.parallelDo(p.Config.Spec.Hosts, func(h *cluster.Host) error {
 		log.Infof("%s: reloading service manager", h)
 		if err := h.Configurer.DaemonReload(h); err != nil {

--- a/phase/daemon_reload.go
+++ b/phase/daemon_reload.go
@@ -23,8 +23,8 @@ func (p *DaemonReload) ShouldRun() bool {
 }
 
 // Run the phase
-func (p *DaemonReload) Run(_ context.Context) error {
-	return p.parallelDo(p.Config.Spec.Hosts, func(h *cluster.Host) error {
+func (p *DaemonReload) Run(ctx context.Context) error {
+	return p.parallelDo(ctx, p.Config.Spec.Hosts, func(_ context.Context, h *cluster.Host) error {
 		log.Infof("%s: reloading service manager", h)
 		if err := h.Configurer.DaemonReload(h); err != nil {
 			log.Warnf("%s: failed to reload service manager: %s", h, err.Error())

--- a/phase/default_k0s_version.go
+++ b/phase/default_k0s_version.go
@@ -1,6 +1,7 @@
 package phase
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/k0sproject/version"
@@ -20,7 +21,7 @@ func (p *DefaultK0sVersion) Title() string {
 	return "Set k0s version"
 }
 
-func (p *DefaultK0sVersion) Run() error {
+func (p *DefaultK0sVersion) Run(_ context.Context) error {
 	isStable := p.Config.Spec.K0s.VersionChannel == "" || p.Config.Spec.K0s.VersionChannel == "stable"
 
 	var msg string

--- a/phase/detect_os.go
+++ b/phase/detect_os.go
@@ -27,8 +27,8 @@ func (p *DetectOS) Title() string {
 }
 
 // Run the phase
-func (p *DetectOS) Run(_ context.Context) error {
-	return p.parallelDo(p.Config.Spec.Hosts, func(h *cluster.Host) error {
+func (p *DetectOS) Run(ctx context.Context) error {
+	return p.parallelDo(ctx, p.Config.Spec.Hosts, func(_ context.Context, h *cluster.Host) error {
 		if h.OSIDOverride != "" {
 			log.Infof("%s: OS ID has been manually set to %s", h, h.OSIDOverride)
 		}

--- a/phase/detect_os.go
+++ b/phase/detect_os.go
@@ -1,6 +1,7 @@
 package phase
 
 import (
+	"context"
 	"strings"
 
 	"github.com/k0sproject/k0sctl/pkg/apis/k0sctl.k0sproject.io/v1beta1/cluster"
@@ -26,7 +27,7 @@ func (p *DetectOS) Title() string {
 }
 
 // Run the phase
-func (p *DetectOS) Run() error {
+func (p *DetectOS) Run(_ context.Context) error {
 	return p.parallelDo(p.Config.Spec.Hosts, func(h *cluster.Host) error {
 		if h.OSIDOverride != "" {
 			log.Infof("%s: OS ID has been manually set to %s", h, h.OSIDOverride)

--- a/phase/disconnect.go
+++ b/phase/disconnect.go
@@ -1,6 +1,8 @@
 package phase
 
 import (
+	"context"
+
 	"github.com/k0sproject/k0sctl/pkg/apis/k0sctl.k0sproject.io/v1beta1/cluster"
 )
 
@@ -23,11 +25,11 @@ func (p *Disconnect) DryRun() error {
 		return nil
 	})
 
-	return p.Run()
+	return p.Run(context.TODO())
 }
 
 // Run the phase
-func (p *Disconnect) Run() error {
+func (p *Disconnect) Run(_ context.Context) error {
 	return p.Config.Spec.Hosts.ParallelEach(func(h *cluster.Host) error {
 		h.Disconnect()
 		return nil

--- a/phase/disconnect.go
+++ b/phase/disconnect.go
@@ -18,7 +18,7 @@ func (p *Disconnect) Title() string {
 
 // DryRun cleans up the temporary k0s binary from the hosts
 func (p *Disconnect) DryRun() error {
-	_ = p.Config.Spec.Hosts.ParallelEach(func(h *cluster.Host) error {
+	_ = p.Config.Spec.Hosts.ParallelEach(context.Background(), func(_ context.Context, h *cluster.Host) error {
 		if h.Metadata.K0sBinaryTempFile != "" && h.Configurer.FileExist(h, h.Metadata.K0sBinaryTempFile) {
 			_ = h.Configurer.DeleteFile(h, h.Metadata.K0sBinaryTempFile)
 		}
@@ -29,8 +29,8 @@ func (p *Disconnect) DryRun() error {
 }
 
 // Run the phase
-func (p *Disconnect) Run(_ context.Context) error {
-	return p.Config.Spec.Hosts.ParallelEach(func(h *cluster.Host) error {
+func (p *Disconnect) Run(ctx context.Context) error {
+	return p.Config.Spec.Hosts.ParallelEach(ctx, func(_ context.Context, h *cluster.Host) error {
 		h.Disconnect()
 		return nil
 	})

--- a/phase/download_binaries.go
+++ b/phase/download_binaries.go
@@ -1,6 +1,7 @@
 package phase
 
 import (
+	"context"
 	"fmt"
 	"io"
 	"net/http"
@@ -41,7 +42,7 @@ func (p *DownloadBinaries) ShouldRun() bool {
 }
 
 // Run the phase
-func (p *DownloadBinaries) Run() error {
+func (p *DownloadBinaries) Run(_ context.Context) error {
 	var bins binaries
 
 	for _, h := range p.hosts {

--- a/phase/download_k0s.go
+++ b/phase/download_k0s.go
@@ -1,6 +1,7 @@
 package phase
 
 import (
+	"context"
 	"fmt"
 	"strconv"
 	"time"
@@ -55,7 +56,7 @@ func (p *DownloadK0s) ShouldRun() bool {
 }
 
 // Run the phase
-func (p *DownloadK0s) Run() error {
+func (p *DownloadK0s) Run(_ context.Context) error {
 	return p.parallelDo(p.hosts, p.downloadK0s)
 }
 

--- a/phase/download_k0s.go
+++ b/phase/download_k0s.go
@@ -56,11 +56,11 @@ func (p *DownloadK0s) ShouldRun() bool {
 }
 
 // Run the phase
-func (p *DownloadK0s) Run(_ context.Context) error {
-	return p.parallelDo(p.hosts, p.downloadK0s)
+func (p *DownloadK0s) Run(ctx context.Context) error {
+	return p.parallelDo(ctx, p.hosts, p.downloadK0s)
 }
 
-func (p *DownloadK0s) downloadK0s(h *cluster.Host) error {
+func (p *DownloadK0s) downloadK0s(_ context.Context, h *cluster.Host) error {
 	tmp := h.Configurer.K0sBinaryPath() + ".tmp." + strconv.Itoa(int(time.Now().UnixNano()))
 
 	log.Infof("%s: downloading k0s %s", h, p.Config.Spec.K0s.Version)

--- a/phase/gather_facts.go
+++ b/phase/gather_facts.go
@@ -1,6 +1,7 @@
 package phase
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/k0sproject/k0sctl/pkg/apis/k0sctl.k0sproject.io/v1beta1/cluster"
@@ -25,7 +26,7 @@ func (p *GatherFacts) Title() string {
 }
 
 // Run the phase
-func (p *GatherFacts) Run() error {
+func (p *GatherFacts) Run(_ context.Context) error {
 	return p.parallelDo(p.Config.Spec.Hosts, p.investigateHost)
 }
 

--- a/phase/gather_facts.go
+++ b/phase/gather_facts.go
@@ -26,11 +26,11 @@ func (p *GatherFacts) Title() string {
 }
 
 // Run the phase
-func (p *GatherFacts) Run(_ context.Context) error {
-	return p.parallelDo(p.Config.Spec.Hosts, p.investigateHost)
+func (p *GatherFacts) Run(ctx context.Context) error {
+	return p.parallelDo(ctx, p.Config.Spec.Hosts, p.investigateHost)
 }
 
-func (p *GatherFacts) investigateHost(h *cluster.Host) error {
+func (p *GatherFacts) investigateHost(_ context.Context, h *cluster.Host) error {
 	output, err := h.Configurer.Arch(h)
 	if err != nil {
 		return err

--- a/phase/gather_k0s_facts.go
+++ b/phase/gather_k0s_facts.go
@@ -68,7 +68,7 @@ func (p *GatherK0sFacts) ShouldRun() bool {
 }
 
 // Run the phase
-func (p *GatherK0sFacts) Run() error {
+func (p *GatherK0sFacts) Run(_ context.Context) error {
 	var controllers cluster.Hosts = p.hosts.Controllers()
 	if err := p.parallelDo(controllers, p.investigateK0s); err != nil {
 		return err

--- a/phase/gather_k0s_facts.go
+++ b/phase/gather_k0s_facts.go
@@ -181,7 +181,7 @@ func (p *GatherK0sFacts) listEtcdMembers(h *cluster.Host) error {
 	return nil
 }
 
-func (p *GatherK0sFacts) investigateK0s(_ context.Context, h *cluster.Host) error {
+func (p *GatherK0sFacts) investigateK0s(ctx context.Context, h *cluster.Host) error {
 	output, err := h.ExecOutput(h.Configurer.K0sCmdf("version"), exec.Sudo(h))
 	if err != nil {
 		log.Debugf("%s: no 'k0s' binary in PATH", h)
@@ -314,7 +314,7 @@ func (p *GatherK0sFacts) investigateK0s(_ context.Context, h *cluster.Host) erro
 
 	if !h.IsController() {
 		log.Infof("%s: checking if worker %s has joined", p.leader, h.Metadata.Hostname)
-		if err := node.KubeNodeReadyFunc(h)(context.Background()); err != nil {
+		if err := node.KubeNodeReadyFunc(h)(ctx); err != nil {
 			log.Debugf("%s: failed to get ready status: %s", h, err.Error())
 		} else {
 			h.Metadata.Ready = true

--- a/phase/gather_k0s_facts.go
+++ b/phase/gather_k0s_facts.go
@@ -68,9 +68,9 @@ func (p *GatherK0sFacts) ShouldRun() bool {
 }
 
 // Run the phase
-func (p *GatherK0sFacts) Run(_ context.Context) error {
+func (p *GatherK0sFacts) Run(ctx context.Context) error {
 	var controllers cluster.Hosts = p.hosts.Controllers()
-	if err := p.parallelDo(controllers, p.investigateK0s); err != nil {
+	if err := p.parallelDo(ctx, controllers, p.investigateK0s); err != nil {
 		return err
 	}
 	p.leader = p.Config.Spec.K0sLeader()
@@ -85,7 +85,7 @@ func (p *GatherK0sFacts) Run(_ context.Context) error {
 	}
 
 	var workers cluster.Hosts = p.hosts.Workers()
-	if err := p.parallelDo(workers, p.investigateK0s); err != nil {
+	if err := p.parallelDo(ctx, workers, p.investigateK0s); err != nil {
 		return err
 	}
 
@@ -181,7 +181,7 @@ func (p *GatherK0sFacts) listEtcdMembers(h *cluster.Host) error {
 	return nil
 }
 
-func (p *GatherK0sFacts) investigateK0s(h *cluster.Host) error {
+func (p *GatherK0sFacts) investigateK0s(_ context.Context, h *cluster.Host) error {
 	output, err := h.ExecOutput(h.Configurer.K0sCmdf("version"), exec.Sudo(h))
 	if err != nil {
 		log.Debugf("%s: no 'k0s' binary in PATH", h)

--- a/phase/generic_phase.go
+++ b/phase/generic_phase.go
@@ -1,6 +1,7 @@
 package phase
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/k0sproject/k0sctl/pkg/apis/k0sctl.k0sproject.io/v1beta1"
@@ -50,16 +51,16 @@ func (p *GenericPhase) SetManager(m *Manager) {
 	p.manager = m
 }
 
-func (p *GenericPhase) parallelDo(hosts cluster.Hosts, funcs ...func(h *cluster.Host) error) error {
+func (p *GenericPhase) parallelDo(ctx context.Context, hosts cluster.Hosts, funcs ...func(context.Context, *cluster.Host) error) error {
 	if p.manager.Concurrency == 0 {
-		return hosts.ParallelEach(funcs...)
+		return hosts.ParallelEach(ctx, funcs...)
 	}
-	return hosts.BatchedParallelEach(p.manager.Concurrency, funcs...)
+	return hosts.BatchedParallelEach(ctx, p.manager.Concurrency, funcs...)
 }
 
-func (p *GenericPhase) parallelDoUpload(hosts cluster.Hosts, funcs ...func(h *cluster.Host) error) error {
+func (p *GenericPhase) parallelDoUpload(ctx context.Context, hosts cluster.Hosts, funcs ...func(context.Context, *cluster.Host) error) error {
 	if p.manager.Concurrency == 0 {
-		return hosts.ParallelEach(funcs...)
+		return hosts.ParallelEach(ctx, funcs...)
 	}
-	return hosts.BatchedParallelEach(p.manager.ConcurrentUploads, funcs...)
+	return hosts.BatchedParallelEach(ctx, p.manager.ConcurrentUploads, funcs...)
 }

--- a/phase/get_kubeconfig.go
+++ b/phase/get_kubeconfig.go
@@ -1,6 +1,7 @@
 package phase
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/alessio/shellescape"
@@ -36,7 +37,7 @@ func (p *GetKubeconfig) DryRun() error {
 }
 
 // Run the phase
-func (p *GetKubeconfig) Run() error {
+func (p *GetKubeconfig) Run(_ context.Context) error {
 	h := p.Config.Spec.Hosts.Controllers()[0]
 
 	output, err := readKubeconfig(h)

--- a/phase/get_kubeconfig_test.go
+++ b/phase/get_kubeconfig_test.go
@@ -1,6 +1,7 @@
 package phase
 
 import (
+	"context"
 	"strings"
 	"testing"
 
@@ -50,14 +51,14 @@ func TestGetKubeconfig(t *testing.T) {
 	readKubeconfig = fakeReader
 
 	p := GetKubeconfig{GenericPhase: GenericPhase{Config: cfg}}
-	require.NoError(t, p.Run())
+	require.NoError(t, p.Run(context.Background()))
 	conf, err := clientcmd.Load([]byte(cfg.Metadata.Kubeconfig))
 	require.NoError(t, err)
 	require.Equal(t, "https://10.0.0.1:6443", conf.Clusters["k0s"].Server)
 
 	cfg.Spec.Hosts[0].Connection.SSH.Address = "abcd:efgh:ijkl:mnop"
 	p.APIAddress = ""
-	require.NoError(t, p.Run())
+	require.NoError(t, p.Run(context.Background()))
 	conf, err = clientcmd.Load([]byte(cfg.Metadata.Kubeconfig))
 	require.NoError(t, err)
 	require.Equal(t, "https://[abcd:efgh:ijkl:mnop]:6443", conf.Clusters["k0s"].Server)

--- a/phase/initialize_k0s.go
+++ b/phase/initialize_k0s.go
@@ -58,7 +58,7 @@ func (p *InitializeK0s) CleanUp() {
 }
 
 // Run the phase
-func (p *InitializeK0s) Run() error {
+func (p *InitializeK0s) Run(_ context.Context) error {
 	h := p.leader
 	h.Metadata.IsK0sLeader = true
 

--- a/phase/install_binaries.go
+++ b/phase/install_binaries.go
@@ -1,6 +1,7 @@
 package phase
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/k0sproject/k0sctl/pkg/apis/k0sctl.k0sproject.io/v1beta1"
@@ -24,7 +25,6 @@ func (p *InstallBinaries) Title() string {
 func (p *InstallBinaries) Prepare(config *v1beta1.Cluster) error {
 	p.Config = config
 	p.hosts = p.Config.Spec.Hosts.Filter(func(h *cluster.Host) bool {
-
 		if h.Reset && h.Metadata.K0sBinaryVersion != nil {
 			return false
 		}
@@ -61,7 +61,7 @@ func (p *InstallBinaries) DryRun() error {
 }
 
 // Run the phase
-func (p *InstallBinaries) Run() error {
+func (p *InstallBinaries) Run(_ context.Context) error {
 	return p.parallelDo(p.hosts, p.installBinary)
 }
 
@@ -84,7 +84,6 @@ func (p *InstallBinaries) CleanUp() {
 		}
 		return nil
 	})
-
 	if err != nil {
 		logrus.Debugf("failed to clean up tempfiles: %v", err)
 	}

--- a/phase/install_binaries.go
+++ b/phase/install_binaries.go
@@ -47,8 +47,9 @@ func (p *InstallBinaries) ShouldRun() bool {
 // DryRun reports what would happen if Run is called.
 func (p *InstallBinaries) DryRun() error {
 	return p.parallelDo(
+		context.Background(),
 		p.Config.Spec.Hosts.Filter(func(h *cluster.Host) bool { return h.Metadata.K0sBinaryTempFile != "" }),
-		func(h *cluster.Host) error {
+		func(_ context.Context, h *cluster.Host) error {
 			p.DryMsgf(h, "install k0s %s binary from %s to %s", p.Config.Spec.K0s.Version, h.Metadata.K0sBinaryTempFile, h.Configurer.K0sBinaryPath())
 			if err := h.Execf(`chmod +x "%s"`, h.Metadata.K0sBinaryTempFile, exec.Sudo(h)); err != nil {
 				logrus.Warnf("%s: failed to chmod k0s temp binary for dry-run: %s", h, err.Error())
@@ -61,11 +62,11 @@ func (p *InstallBinaries) DryRun() error {
 }
 
 // Run the phase
-func (p *InstallBinaries) Run(_ context.Context) error {
-	return p.parallelDo(p.hosts, p.installBinary)
+func (p *InstallBinaries) Run(ctx context.Context) error {
+	return p.parallelDo(ctx, p.hosts, p.installBinary)
 }
 
-func (p *InstallBinaries) installBinary(h *cluster.Host) error {
+func (p *InstallBinaries) installBinary(_ context.Context, h *cluster.Host) error {
 	if err := h.UpdateK0sBinary(h.Metadata.K0sBinaryTempFile, p.Config.Spec.K0s.Version); err != nil {
 		return fmt.Errorf("failed to install k0s binary: %w", err)
 	}
@@ -74,7 +75,7 @@ func (p *InstallBinaries) installBinary(h *cluster.Host) error {
 }
 
 func (p *InstallBinaries) CleanUp() {
-	err := p.parallelDo(p.hosts, func(h *cluster.Host) error {
+	err := p.parallelDo(context.Background(), p.hosts, func(_ context.Context, h *cluster.Host) error {
 		if h.Metadata.K0sBinaryTempFile == "" {
 			return nil
 		}

--- a/phase/install_controllers.go
+++ b/phase/install_controllers.go
@@ -86,7 +86,7 @@ func (p *InstallControllers) After() error {
 }
 
 // Run the phase
-func (p *InstallControllers) Run() error {
+func (p *InstallControllers) Run(_ context.Context) error {
 	for _, h := range p.hosts {
 		if p.IsWet() {
 			log.Infof("%s: generate join token for %s", p.leader, h)

--- a/phase/install_workers.go
+++ b/phase/install_workers.go
@@ -96,7 +96,7 @@ func (p *InstallWorkers) After() error {
 }
 
 // Run the phase
-func (p *InstallWorkers) Run() error {
+func (p *InstallWorkers) Run(_ context.Context) error {
 	for i, h := range p.hosts {
 		log.Infof("%s: generating a join token for worker %d", p.leader, i+1)
 		err := p.Wet(p.leader, fmt.Sprintf("generate a k0s join token for worker %s", h), func() error {

--- a/phase/lock.go
+++ b/phase/lock.go
@@ -61,7 +61,7 @@ func (p *Lock) UnlockPhase() Phase {
 }
 
 // Run the phase
-func (p *Lock) Run() error {
+func (p *Lock) Run(_ context.Context) error {
 	if err := p.parallelDo(p.Config.Spec.Hosts, p.startLock); err != nil {
 		return err
 	}

--- a/phase/manager.go
+++ b/phase/manager.go
@@ -1,6 +1,7 @@
 package phase
 
 import (
+	"context"
 	"fmt"
 	"sync"
 
@@ -20,7 +21,7 @@ var Colorize = aurora.NewAurora(false)
 
 // Phase represents a runnable phase which can be added to Manager.
 type Phase interface {
-	Run() error
+	Run(context.Context) error
 	Title() string
 }
 
@@ -173,7 +174,7 @@ func (m *Manager) Wet(host fmt.Stringer, msg string, funcs ...errorfunc) error {
 }
 
 // Run executes all the added Phases in order
-func (m *Manager) Run() error {
+func (m *Manager) Run(ctx context.Context) error {
 	var ran []Phase
 	var result error
 
@@ -240,7 +241,7 @@ func (m *Manager) Run() error {
 			continue
 		}
 
-		result = p.Run()
+		result = p.Run(ctx)
 		ran = append(ran, p)
 
 		if p, ok := p.(afterhook); ok {

--- a/phase/manager.go
+++ b/phase/manager.go
@@ -208,7 +208,8 @@ func (m *Manager) Run(ctx context.Context) error {
 		title := p.Title()
 
 		if err := ctx.Err(); err != nil {
-			return fmt.Errorf("context cancelled before entering phase %q: %w", title, err)
+			result = fmt.Errorf("context canceled before entering phase %q: %w", title, err)
+			return result
 		}
 
 		if p, ok := p.(withmanager); ok {

--- a/phase/manager.go
+++ b/phase/manager.go
@@ -207,6 +207,10 @@ func (m *Manager) Run(ctx context.Context) error {
 	for _, p := range m.phases {
 		title := p.Title()
 
+		if err := ctx.Err(); err != nil {
+			return fmt.Errorf("context cancelled before entering phase %q: %w", title, err)
+		}
+
 		if p, ok := p.(withmanager); ok {
 			p.SetManager(m)
 		}

--- a/phase/manager_test.go
+++ b/phase/manager_test.go
@@ -1,6 +1,7 @@
 package phase
 
 import (
+	"context"
 	"fmt"
 	"testing"
 
@@ -23,7 +24,7 @@ func (p *conditionalPhase) ShouldRun() bool {
 	return false
 }
 
-func (p *conditionalPhase) Run() error {
+func (p *conditionalPhase) Run(_ context.Context) error {
 	p.runCalled = true
 	return nil
 }
@@ -32,7 +33,7 @@ func TestConditionalPhase(t *testing.T) {
 	m := Manager{Config: &v1beta1.Cluster{Spec: &cluster.Spec{}}}
 	p := &conditionalPhase{}
 	m.AddPhase(p)
-	require.NoError(t, m.Run())
+	require.NoError(t, m.Run(context.Background()))
 	require.False(t, p.runCalled, "run was not called")
 	require.True(t, p.shouldrunCalled, "shouldrun was not called")
 }
@@ -50,7 +51,7 @@ func (p *configPhase) Prepare(c *v1beta1.Cluster) error {
 	return nil
 }
 
-func (p *configPhase) Run() error {
+func (p *configPhase) Run(_ context.Context) error {
 	return nil
 }
 
@@ -58,7 +59,7 @@ func TestConfigPhase(t *testing.T) {
 	m := Manager{Config: &v1beta1.Cluster{Spec: &cluster.Spec{}}}
 	p := &configPhase{}
 	m.AddPhase(p)
-	require.NoError(t, m.Run())
+	require.NoError(t, m.Run(context.Background()))
 	require.True(t, p.receivedConfig, "config was not received")
 }
 
@@ -83,7 +84,7 @@ func (p *hookedPhase) After(err error) error {
 	return nil
 }
 
-func (p *hookedPhase) Run() error {
+func (p *hookedPhase) Run(_ context.Context) error {
 	return fmt.Errorf("run failed")
 }
 
@@ -91,7 +92,7 @@ func TestHookedPhase(t *testing.T) {
 	m := Manager{Config: &v1beta1.Cluster{Spec: &cluster.Spec{}}}
 	p := &hookedPhase{}
 	m.AddPhase(p)
-	require.Error(t, m.Run())
+	require.Error(t, m.Run(context.Background()))
 	require.True(t, p.beforeCalled, "before hook was not called")
 	require.True(t, p.afterCalled, "after hook was not called")
 	require.EqualError(t, p.err, "run failed")

--- a/phase/prepare_hosts.go
+++ b/phase/prepare_hosts.go
@@ -28,8 +28,8 @@ func (p *PrepareHosts) Title() string {
 }
 
 // Run the phase
-func (p *PrepareHosts) Run(_ context.Context) error {
-	return p.parallelDo(p.Config.Spec.Hosts, p.prepareHost)
+func (p *PrepareHosts) Run(ctx context.Context) error {
+	return p.parallelDo(ctx, p.Config.Spec.Hosts, p.prepareHost)
 }
 
 type prepare interface {
@@ -64,7 +64,7 @@ func (p *PrepareHosts) updateEnvironment(h *cluster.Host) error {
 	})
 }
 
-func (p *PrepareHosts) prepareHost(h *cluster.Host) error {
+func (p *PrepareHosts) prepareHost(_ context.Context, h *cluster.Host) error {
 	if c, ok := h.Configurer.(prepare); ok {
 		if err := c.Prepare(h); err != nil {
 			return err

--- a/phase/prepare_hosts.go
+++ b/phase/prepare_hosts.go
@@ -28,7 +28,7 @@ func (p *PrepareHosts) Title() string {
 }
 
 // Run the phase
-func (p *PrepareHosts) Run() error {
+func (p *PrepareHosts) Run(_ context.Context) error {
 	return p.parallelDo(p.Config.Spec.Hosts, p.prepareHost)
 }
 

--- a/phase/reinstall.go
+++ b/phase/reinstall.go
@@ -40,7 +40,7 @@ func (p *Reinstall) ShouldRun() bool {
 }
 
 // Run the phase
-func (p *Reinstall) Run() error {
+func (p *Reinstall) Run(ctx context.Context) error {
 	if p.Config.Spec.K0s.Version.LessThan(cluster.K0sForceFlagSince) {
 		log.Warnf("k0s version %s does not support install --force flag, installFlags won't be reconfigured", p.Config.Spec.K0s.Version)
 		return nil

--- a/phase/reinstall.go
+++ b/phase/reinstall.go
@@ -98,7 +98,7 @@ func (p *Reinstall) reinstall(ctx context.Context, h *cluster.Host) error {
 			return fmt.Errorf("failed to restart k0s: %w", err)
 		}
 		log.Infof("%s: waiting for the k0s service to start", h)
-		if err := retry.Timeout(ctx, retry.DefaultTimeout, node.ServiceRunningFunc(h, h.K0sServiceName())); err != nil {
+		if err := retry.AdaptiveTimeout(ctx, retry.DefaultTimeout, node.ServiceRunningFunc(h, h.K0sServiceName())); err != nil {
 			return fmt.Errorf("k0s did not restart: %w", err)
 		}
 		return nil

--- a/phase/reinstall.go
+++ b/phase/reinstall.go
@@ -48,8 +48,8 @@ func (p *Reinstall) Run(ctx context.Context) error {
 	controllers := p.hosts.Controllers()
 	if len(controllers) > 0 {
 		log.Infof("Reinstalling %d controllers sequentially", len(controllers))
-		err := controllers.Each(func(h *cluster.Host) error {
-			return p.reinstall(h)
+		err := controllers.Each(ctx, func(ctx context.Context, h *cluster.Host) error {
+			return p.reinstall(ctx, h)
 		})
 		if err != nil {
 			return err
@@ -68,10 +68,10 @@ func (p *Reinstall) Run(ctx context.Context) error {
 
 	log.Infof("Reinstalling max %d workers in parallel", concurrentReinstalls)
 
-	return p.hosts.BatchedParallelEach(concurrentReinstalls, p.reinstall)
+	return p.hosts.BatchedParallelEach(ctx, concurrentReinstalls, p.reinstall)
 }
 
-func (p *Reinstall) reinstall(h *cluster.Host) error {
+func (p *Reinstall) reinstall(ctx context.Context, h *cluster.Host) error {
 	if p.Config.Spec.K0s.DynamicConfig && h.Role != "worker" {
 		h.InstallFlags.AddOrReplace("--enable-dynamic-config")
 	}
@@ -98,7 +98,7 @@ func (p *Reinstall) reinstall(h *cluster.Host) error {
 			return fmt.Errorf("failed to restart k0s: %w", err)
 		}
 		log.Infof("%s: waiting for the k0s service to start", h)
-		if err := retry.Timeout(context.TODO(), retry.DefaultTimeout, node.ServiceRunningFunc(h, h.K0sServiceName())); err != nil {
+		if err := retry.Timeout(ctx, retry.DefaultTimeout, node.ServiceRunningFunc(h, h.K0sServiceName())); err != nil {
 			return fmt.Errorf("k0s did not restart: %w", err)
 		}
 		return nil

--- a/phase/reset_controllers.go
+++ b/phase/reset_controllers.go
@@ -51,7 +51,7 @@ func (p *ResetControllers) ShouldRun() bool {
 }
 
 // Run the phase
-func (p *ResetControllers) Run(_ context.Context) error {
+func (p *ResetControllers) Run(ctx context.Context) error {
 	for _, h := range p.hosts {
 		log.Debugf("%s: draining node", h)
 		if !p.NoDrain && h.Role != "controller" {
@@ -83,7 +83,7 @@ func (p *ResetControllers) Run(_ context.Context) error {
 				log.Warnf("%s: failed to stop k0s: %s", h, err.Error())
 			}
 			log.Debugf("%s: waiting for k0s to stop", h)
-			if err := retry.Timeout(context.TODO(), retry.DefaultTimeout, node.ServiceStoppedFunc(h, h.K0sServiceName())); err != nil {
+			if err := retry.AdaptiveTimeout(ctx, retry.DefaultTimeout, node.ServiceStoppedFunc(h, h.K0sServiceName())); err != nil {
 				log.Warnf("%s: failed to wait for k0s to stop: %v", h, err)
 			}
 			log.Debugf("%s: stopping k0s completed", h)

--- a/phase/reset_controllers.go
+++ b/phase/reset_controllers.go
@@ -51,7 +51,7 @@ func (p *ResetControllers) ShouldRun() bool {
 }
 
 // Run the phase
-func (p *ResetControllers) Run() error {
+func (p *ResetControllers) Run(_ context.Context) error {
 	for _, h := range p.hosts {
 		log.Debugf("%s: draining node", h)
 		if !p.NoDrain && h.Role != "controller" {

--- a/phase/reset_leader.go
+++ b/phase/reset_leader.go
@@ -30,7 +30,7 @@ func (p *ResetLeader) Prepare(config *v1beta1.Cluster) error {
 }
 
 // Run the phase
-func (p *ResetLeader) Run() error {
+func (p *ResetLeader) Run(_ context.Context) error {
 	if p.leader.Configurer.ServiceIsRunning(p.leader, p.leader.K0sServiceName()) {
 		log.Debugf("%s: stopping k0s...", p.leader)
 		if err := p.leader.Configurer.StopService(p.leader, p.leader.K0sServiceName()); err != nil {

--- a/phase/reset_leader.go
+++ b/phase/reset_leader.go
@@ -30,14 +30,14 @@ func (p *ResetLeader) Prepare(config *v1beta1.Cluster) error {
 }
 
 // Run the phase
-func (p *ResetLeader) Run(_ context.Context) error {
+func (p *ResetLeader) Run(ctx context.Context) error {
 	if p.leader.Configurer.ServiceIsRunning(p.leader, p.leader.K0sServiceName()) {
 		log.Debugf("%s: stopping k0s...", p.leader)
 		if err := p.leader.Configurer.StopService(p.leader, p.leader.K0sServiceName()); err != nil {
 			log.Warnf("%s: failed to stop k0s: %s", p.leader, err.Error())
 		}
 		log.Debugf("%s: waiting for k0s to stop", p.leader)
-		if err := retry.Timeout(context.TODO(), retry.DefaultTimeout, node.ServiceStoppedFunc(p.leader, p.leader.K0sServiceName())); err != nil {
+		if err := retry.AdaptiveTimeout(ctx, retry.DefaultTimeout, node.ServiceStoppedFunc(p.leader, p.leader.K0sServiceName())); err != nil {
 			log.Warnf("%s: k0s service stop: %s", p.leader, err.Error())
 		}
 		log.Debugf("%s: stopping k0s completed", p.leader)

--- a/phase/reset_workers.go
+++ b/phase/reset_workers.go
@@ -50,8 +50,8 @@ func (p *ResetWorkers) ShouldRun() bool {
 }
 
 // Run the phase
-func (p *ResetWorkers) Run(_ context.Context) error {
-	return p.parallelDo(p.hosts, func(h *cluster.Host) error {
+func (p *ResetWorkers) Run(ctx context.Context) error {
+	return p.parallelDo(ctx, p.hosts, func(_ context.Context, h *cluster.Host) error {
 		log.Debugf("%s: draining node", h)
 		if !p.NoDrain {
 			if err := p.leader.DrainNode(&cluster.Host{

--- a/phase/reset_workers.go
+++ b/phase/reset_workers.go
@@ -82,7 +82,7 @@ func (p *ResetWorkers) Run(ctx context.Context) error {
 				log.Warnf("%s: failed to stop k0s: %s", h, err.Error())
 			}
 			log.Debugf("%s: waiting for k0s to stop", h)
-			if err := retry.Timeout(context.TODO(), retry.DefaultTimeout, node.ServiceStoppedFunc(h, h.K0sServiceName())); err != nil {
+			if err := retry.AdaptiveTimeout(ctx, retry.DefaultTimeout, node.ServiceStoppedFunc(h, h.K0sServiceName())); err != nil {
 				log.Warnf("%s: failed to wait for k0s to stop: %s", h, err.Error())
 			}
 			log.Debugf("%s: stopping k0s completed", h)

--- a/phase/reset_workers.go
+++ b/phase/reset_workers.go
@@ -50,7 +50,7 @@ func (p *ResetWorkers) ShouldRun() bool {
 }
 
 // Run the phase
-func (p *ResetWorkers) Run() error {
+func (p *ResetWorkers) Run(_ context.Context) error {
 	return p.parallelDo(p.hosts, func(h *cluster.Host) error {
 		log.Debugf("%s: draining node", h)
 		if !p.NoDrain {

--- a/phase/restore.go
+++ b/phase/restore.go
@@ -1,6 +1,7 @@
 package phase
 
 import (
+	"context"
 	"fmt"
 	"path"
 
@@ -48,7 +49,7 @@ func (p *Restore) Prepare(config *v1beta1.Cluster) error {
 }
 
 // Run the phase
-func (p *Restore) Run() error {
+func (p *Restore) Run(_ context.Context) error {
 	// Push the backup file to controller
 	h := p.leader
 	tmpDir, err := h.Configurer.TempDir(h)

--- a/phase/runhooks.go
+++ b/phase/runhooks.go
@@ -1,6 +1,7 @@
 package phase
 
 import (
+	"context"
 	"fmt"
 
 	"golang.org/x/text/cases"
@@ -41,7 +42,7 @@ func (p *RunHooks) ShouldRun() bool {
 }
 
 // Run does all the prep work on the hosts in parallel
-func (p *RunHooks) Run() error {
+func (p *RunHooks) Run(_ context.Context) error {
 	return p.hosts.ParallelEach(p.runHooksForHost)
 }
 

--- a/phase/runhooks.go
+++ b/phase/runhooks.go
@@ -42,11 +42,11 @@ func (p *RunHooks) ShouldRun() bool {
 }
 
 // Run does all the prep work on the hosts in parallel
-func (p *RunHooks) Run(_ context.Context) error {
-	return p.hosts.ParallelEach(p.runHooksForHost)
+func (p *RunHooks) Run(ctx context.Context) error {
+	return p.hosts.ParallelEach(ctx, p.runHooksForHost)
 }
 
-func (p *RunHooks) runHooksForHost(h *cluster.Host) error {
+func (p *RunHooks) runHooksForHost(_ context.Context, h *cluster.Host) error {
 	steps := h.Hooks.ForActionAndStage(p.Action, p.Stage)
 	for _, s := range steps {
 		err := p.Wet(h, fmt.Sprintf("run hook: `%s`", s), func() error {

--- a/phase/unlock.go
+++ b/phase/unlock.go
@@ -1,6 +1,8 @@
 package phase
 
 import (
+	"context"
+
 	"github.com/k0sproject/k0sctl/pkg/apis/k0sctl.k0sproject.io/v1beta1"
 	log "github.com/sirupsen/logrus"
 )
@@ -28,7 +30,7 @@ func (p *Unlock) Title() string {
 }
 
 // Run the phase
-func (p *Unlock) Run() error {
+func (p *Unlock) Run(_ context.Context) error {
 	p.Cancel()
 	return nil
 }

--- a/phase/upgrade_controllers.go
+++ b/phase/upgrade_controllers.go
@@ -58,7 +58,7 @@ func (p *UpgradeControllers) CleanUp() {
 }
 
 // Run the phase
-func (p *UpgradeControllers) Run() error {
+func (p *UpgradeControllers) Run(_ context.Context) error {
 	for _, h := range p.hosts {
 		if !h.Configurer.FileExist(h, h.Metadata.K0sBinaryTempFile) {
 			return fmt.Errorf("k0s binary tempfile not found on host")

--- a/phase/upgrade_workers.go
+++ b/phase/upgrade_workers.go
@@ -155,7 +155,7 @@ func (p *UpgradeWorkers) upgradeWorker(ctx context.Context, h *cluster.Host) err
 			return err
 		}
 
-		if err := retry.Timeout(ctx, retry.DefaultTimeout, node.ServiceStoppedFunc(h, h.K0sServiceName())); err != nil {
+		if err := retry.AdaptiveTimeout(ctx, retry.DefaultTimeout, node.ServiceStoppedFunc(h, h.K0sServiceName())); err != nil {
 			return err
 		}
 
@@ -209,7 +209,7 @@ func (p *UpgradeWorkers) upgradeWorker(ctx context.Context, h *cluster.Host) err
 			log.Debugf("%s: not waiting because --no-wait given", h)
 		} else {
 			log.Infof("%s: waiting for node to become ready again", h)
-			if err := retry.Timeout(context.TODO(), retry.DefaultTimeout, node.KubeNodeReadyFunc(h)); err != nil {
+			if err := retry.AdaptiveTimeout(ctx, retry.DefaultTimeout, node.KubeNodeReadyFunc(h)); err != nil {
 				return fmt.Errorf("node did not become ready: %w", err)
 			}
 		}

--- a/phase/upgrade_workers.go
+++ b/phase/upgrade_workers.go
@@ -76,7 +76,7 @@ func (p *UpgradeWorkers) CleanUp() {
 }
 
 // Run the phase
-func (p *UpgradeWorkers) Run() error {
+func (p *UpgradeWorkers) Run(_ context.Context) error {
 	// Upgrade worker hosts parallelly in 10% chunks
 	concurrentUpgrades := int(math.Floor(float64(len(p.hosts)) * 0.10))
 	if concurrentUpgrades == 0 {

--- a/phase/upgrade_workers.go
+++ b/phase/upgrade_workers.go
@@ -40,7 +40,7 @@ func (p *UpgradeWorkers) Prepare(config *v1beta1.Cluster) error {
 		}
 		return !h.Reset && h.Metadata.NeedsUpgrade
 	})
-	err := p.parallelDo(p.hosts, func(h *cluster.Host) error {
+	err := p.parallelDo(context.Background(), p.hosts, func(_ context.Context, h *cluster.Host) error {
 		if !h.Configurer.FileExist(h, h.Metadata.K0sBinaryTempFile) {
 			return fmt.Errorf("k0s binary tempfile not found on host")
 		}
@@ -64,7 +64,7 @@ func (p *UpgradeWorkers) CleanUp() {
 	if !p.IsWet() {
 		return
 	}
-	_ = p.parallelDo(p.hosts, func(h *cluster.Host) error {
+	_ = p.parallelDo(context.Background(), p.hosts, func(_ context.Context, h *cluster.Host) error {
 		if len(h.Environment) > 0 {
 			if err := h.Configurer.CleanupServiceEnvironment(h, h.K0sServiceName()); err != nil {
 				log.Warnf("%s: failed to clean up service environment: %s", h, err.Error())
@@ -76,7 +76,7 @@ func (p *UpgradeWorkers) CleanUp() {
 }
 
 // Run the phase
-func (p *UpgradeWorkers) Run(_ context.Context) error {
+func (p *UpgradeWorkers) Run(ctx context.Context) error {
 	// Upgrade worker hosts parallelly in 10% chunks
 	concurrentUpgrades := int(math.Floor(float64(len(p.hosts)) * 0.10))
 	if concurrentUpgrades == 0 {
@@ -84,7 +84,7 @@ func (p *UpgradeWorkers) Run(_ context.Context) error {
 	}
 
 	log.Infof("Upgrading max %d workers in parallel", concurrentUpgrades)
-	return p.hosts.BatchedParallelEach(concurrentUpgrades,
+	return p.hosts.BatchedParallelEach(ctx, concurrentUpgrades,
 		p.start,
 		p.cordonWorker,
 		p.drainWorker,
@@ -94,7 +94,7 @@ func (p *UpgradeWorkers) Run(_ context.Context) error {
 	)
 }
 
-func (p *UpgradeWorkers) cordonWorker(h *cluster.Host) error {
+func (p *UpgradeWorkers) cordonWorker(_ context.Context, h *cluster.Host) error {
 	if p.NoDrain {
 		log.Debugf("%s: not cordoning because --no-drain given", h)
 		return nil
@@ -110,7 +110,7 @@ func (p *UpgradeWorkers) cordonWorker(h *cluster.Host) error {
 	return nil
 }
 
-func (p *UpgradeWorkers) uncordonWorker(h *cluster.Host) error {
+func (p *UpgradeWorkers) uncordonWorker(_ context.Context, h *cluster.Host) error {
 	if !p.IsWet() {
 		p.DryMsg(h, "uncordon node")
 		return nil
@@ -122,7 +122,7 @@ func (p *UpgradeWorkers) uncordonWorker(h *cluster.Host) error {
 	return nil
 }
 
-func (p *UpgradeWorkers) drainWorker(h *cluster.Host) error {
+func (p *UpgradeWorkers) drainWorker(_ context.Context, h *cluster.Host) error {
 	if p.NoDrain {
 		log.Debugf("%s: not draining because --no-drain given", h)
 		return nil
@@ -138,24 +138,24 @@ func (p *UpgradeWorkers) drainWorker(h *cluster.Host) error {
 	return nil
 }
 
-func (p *UpgradeWorkers) start(h *cluster.Host) error {
+func (p *UpgradeWorkers) start(_ context.Context, h *cluster.Host) error {
 	log.Infof("%s: starting upgrade", h)
 	return nil
 }
 
-func (p *UpgradeWorkers) finish(h *cluster.Host) error {
+func (p *UpgradeWorkers) finish(_ context.Context, h *cluster.Host) error {
 	log.Infof("%s: upgrade finished", h)
 	return nil
 }
 
-func (p *UpgradeWorkers) upgradeWorker(h *cluster.Host) error {
+func (p *UpgradeWorkers) upgradeWorker(ctx context.Context, h *cluster.Host) error {
 	log.Debugf("%s: stop service", h)
 	err := p.Wet(h, "stop k0s service", func() error {
 		if err := h.Configurer.StopService(h, h.K0sServiceName()); err != nil {
 			return err
 		}
 
-		if err := retry.Timeout(context.TODO(), retry.DefaultTimeout, node.ServiceStoppedFunc(h, h.K0sServiceName())); err != nil {
+		if err := retry.Timeout(ctx, retry.DefaultTimeout, node.ServiceStoppedFunc(h, h.K0sServiceName())); err != nil {
 			return err
 		}
 

--- a/phase/upload_k0s.go
+++ b/phase/upload_k0s.go
@@ -55,11 +55,11 @@ func (p *UploadK0s) ShouldRun() bool {
 }
 
 // Run the phase
-func (p *UploadK0s) Run(_ context.Context) error {
-	return p.parallelDoUpload(p.hosts, p.uploadBinary)
+func (p *UploadK0s) Run(ctx context.Context) error {
+	return p.parallelDoUpload(ctx, p.hosts, p.uploadBinary)
 }
 
-func (p *UploadK0s) uploadBinary(h *cluster.Host) error {
+func (p *UploadK0s) uploadBinary(_ context.Context, h *cluster.Host) error {
 	tmp := h.Configurer.K0sBinaryPath() + ".tmp." + strconv.Itoa(int(time.Now().UnixNano()))
 
 	stat, err := os.Stat(h.UploadBinaryPath)

--- a/phase/upload_k0s.go
+++ b/phase/upload_k0s.go
@@ -1,6 +1,7 @@
 package phase
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"strconv"
@@ -54,7 +55,7 @@ func (p *UploadK0s) ShouldRun() bool {
 }
 
 // Run the phase
-func (p *UploadK0s) Run() error {
+func (p *UploadK0s) Run(_ context.Context) error {
 	return p.parallelDoUpload(p.hosts, p.uploadBinary)
 }
 

--- a/phase/uploadfiles.go
+++ b/phase/uploadfiles.go
@@ -42,11 +42,11 @@ func (p *UploadFiles) ShouldRun() bool {
 }
 
 // Run the phase
-func (p *UploadFiles) Run(_ context.Context) error {
-	return p.parallelDoUpload(p.Config.Spec.Hosts, p.uploadFiles)
+func (p *UploadFiles) Run(ctx context.Context) error {
+	return p.parallelDoUpload(ctx, p.Config.Spec.Hosts, p.uploadFiles)
 }
 
-func (p *UploadFiles) uploadFiles(h *cluster.Host) error {
+func (p *UploadFiles) uploadFiles(_ context.Context, h *cluster.Host) error {
 	for _, f := range h.Files {
 		var err error
 		if f.IsURL() {

--- a/phase/uploadfiles.go
+++ b/phase/uploadfiles.go
@@ -1,6 +1,7 @@
 package phase
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"path"
@@ -41,7 +42,7 @@ func (p *UploadFiles) ShouldRun() bool {
 }
 
 // Run the phase
-func (p *UploadFiles) Run() error {
+func (p *UploadFiles) Run(_ context.Context) error {
 	return p.parallelDoUpload(p.Config.Spec.Hosts, p.uploadFiles)
 }
 

--- a/phase/validate_etcd_members.go
+++ b/phase/validate_etcd_members.go
@@ -1,6 +1,7 @@
 package phase
 
 import (
+	"context"
 	"fmt"
 	"slices"
 
@@ -50,7 +51,7 @@ func (p *ValidateEtcdMembers) ShouldRun() bool {
 }
 
 // Run the phase
-func (p *ValidateEtcdMembers) Run() error {
+func (p *ValidateEtcdMembers) Run(_ context.Context) error {
 	if err := p.validateControllerSwap(); err != nil {
 		return err
 	}

--- a/phase/validate_facts.go
+++ b/phase/validate_facts.go
@@ -1,6 +1,7 @@
 package phase
 
 import (
+	"context"
 	"fmt"
 
 	log "github.com/sirupsen/logrus"
@@ -18,7 +19,7 @@ func (p *ValidateFacts) Title() string {
 }
 
 // Run the phase
-func (p *ValidateFacts) Run() error {
+func (p *ValidateFacts) Run(_ context.Context) error {
 	if err := p.validateDowngrade(); err != nil {
 		return err
 	}

--- a/phase/validate_hosts.go
+++ b/phase/validate_hosts.go
@@ -1,6 +1,7 @@
 package phase
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/k0sproject/k0sctl/pkg/apis/k0sctl.k0sproject.io/v1beta1/cluster"
@@ -21,7 +22,7 @@ func (p *ValidateHosts) Title() string {
 }
 
 // Run the phase
-func (p *ValidateHosts) Run() error {
+func (p *ValidateHosts) Run(_ context.Context) error {
 	p.hncount = make(map[string]int, len(p.Config.Spec.Hosts))
 	if p.Config.Spec.K0s.Version.LessThan(uniqueMachineIDSince) {
 		p.machineidcount = make(map[string]int, len(p.Config.Spec.Hosts))

--- a/phase/validate_hosts.go
+++ b/phase/validate_hosts.go
@@ -22,7 +22,7 @@ func (p *ValidateHosts) Title() string {
 }
 
 // Run the phase
-func (p *ValidateHosts) Run(_ context.Context) error {
+func (p *ValidateHosts) Run(ctx context.Context) error {
 	p.hncount = make(map[string]int, len(p.Config.Spec.Hosts))
 	if p.Config.Spec.K0s.Version.LessThan(uniqueMachineIDSince) {
 		p.machineidcount = make(map[string]int, len(p.Config.Spec.Hosts))
@@ -49,6 +49,7 @@ func (p *ValidateHosts) Run(_ context.Context) error {
 	}
 
 	return p.parallelDo(
+		ctx,
 		p.Config.Spec.Hosts,
 		p.warnK0sBinaryPath,
 		p.validateUniqueHostname,
@@ -58,7 +59,7 @@ func (p *ValidateHosts) Run(_ context.Context) error {
 	)
 }
 
-func (p *ValidateHosts) warnK0sBinaryPath(h *cluster.Host) error {
+func (p *ValidateHosts) warnK0sBinaryPath(_ context.Context, h *cluster.Host) error {
 	if h.K0sBinaryPath != "" {
 		log.Warnf("%s: k0s binary path is set to %q, version checking for the host is disabled. The k0s version for other hosts is %s.", h, h.K0sBinaryPath, p.Config.Spec.K0s.Version)
 	}
@@ -66,7 +67,7 @@ func (p *ValidateHosts) warnK0sBinaryPath(h *cluster.Host) error {
 	return nil
 }
 
-func (p *ValidateHosts) validateUniqueHostname(h *cluster.Host) error {
+func (p *ValidateHosts) validateUniqueHostname(_ context.Context, h *cluster.Host) error {
 	if p.hncount[h.Metadata.Hostname] > 1 {
 		return fmt.Errorf("hostname is not unique: %s", h.Metadata.Hostname)
 	}
@@ -74,7 +75,7 @@ func (p *ValidateHosts) validateUniqueHostname(h *cluster.Host) error {
 	return nil
 }
 
-func (p *ValidateHosts) validateUniquePrivateAddress(h *cluster.Host) error {
+func (p *ValidateHosts) validateUniquePrivateAddress(_ context.Context, h *cluster.Host) error {
 	if p.privateaddrcount[h.PrivateAddress] > 1 {
 		return fmt.Errorf("privateAddress %q is not unique: %s", h.PrivateAddress, h.Metadata.Hostname)
 	}
@@ -82,7 +83,7 @@ func (p *ValidateHosts) validateUniquePrivateAddress(h *cluster.Host) error {
 	return nil
 }
 
-func (p *ValidateHosts) validateUniqueMachineID(h *cluster.Host) error {
+func (p *ValidateHosts) validateUniqueMachineID(_ context.Context, h *cluster.Host) error {
 	if p.machineidcount[h.Metadata.MachineID] > 1 {
 		return fmt.Errorf("machine id %s is not unique: %s", h.Metadata.MachineID, h.Metadata.Hostname)
 	}
@@ -90,7 +91,7 @@ func (p *ValidateHosts) validateUniqueMachineID(h *cluster.Host) error {
 	return nil
 }
 
-func (p *ValidateHosts) validateSudo(h *cluster.Host) error {
+func (p *ValidateHosts) validateSudo(_ context.Context, h *cluster.Host) error {
 	if err := h.Configurer.CheckPrivilege(h); err != nil {
 		return err
 	}

--- a/pkg/apis/k0sctl.k0sproject.io/v1beta1/cluster/hosts.go
+++ b/pkg/apis/k0sctl.k0sproject.io/v1beta1/cluster/hosts.go
@@ -1,6 +1,7 @@
 package cluster
 
 import (
+	"context"
 	"fmt"
 	"strings"
 	"sync"
@@ -97,10 +98,10 @@ func (hosts Hosts) Workers() Hosts {
 }
 
 // Each runs a function (or multiple functions chained) on every Host.
-func (hosts Hosts) Each(filters ...func(h *Host) error) error {
+func (hosts Hosts) Each(ctx context.Context, filters ...func(context.Context, *Host) error) error {
 	for _, filter := range filters {
 		for _, h := range hosts {
-			if err := filter(h); err != nil {
+			if err := filter(ctx, h); err != nil {
 				return err
 			}
 		}
@@ -111,7 +112,7 @@ func (hosts Hosts) Each(filters ...func(h *Host) error) error {
 
 // ParallelEach runs a function (or multiple functions chained) on every Host parallelly.
 // Any errors will be concatenated and returned.
-func (hosts Hosts) ParallelEach(filters ...func(h *Host) error) error {
+func (hosts Hosts) ParallelEach(ctx context.Context, filters ...func(context.Context, *Host) error) error {
 	var wg sync.WaitGroup
 	var mu sync.Mutex
 	var errors []string
@@ -121,7 +122,7 @@ func (hosts Hosts) ParallelEach(filters ...func(h *Host) error) error {
 			wg.Add(1)
 			go func(h *Host) {
 				defer wg.Done()
-				if err := filter(h); err != nil {
+				if err := filter(ctx, h); err != nil {
 					mu.Lock()
 					errors = append(errors, fmt.Sprintf("%s: %s", h.String(), err.Error()))
 					mu.Unlock()
@@ -139,13 +140,13 @@ func (hosts Hosts) ParallelEach(filters ...func(h *Host) error) error {
 }
 
 // BatchedParallelEach runs a function (or multiple functions chained) on every Host parallelly in groups of batchSize hosts.
-func (hosts Hosts) BatchedParallelEach(batchSize int, filter ...func(h *Host) error) error {
+func (hosts Hosts) BatchedParallelEach(ctx context.Context, batchSize int, filter ...func(context.Context, *Host) error) error {
 	for i := 0; i < len(hosts); i += batchSize {
 		end := i + batchSize
 		if end > len(hosts) {
 			end = len(hosts)
 		}
-		if err := hosts[i:end].ParallelEach(filter...); err != nil {
+		if err := hosts[i:end].ParallelEach(ctx, filter...); err != nil {
 			return err
 		}
 	}

--- a/pkg/apis/k0sctl.k0sproject.io/v1beta1/cluster/k0s.go
+++ b/pkg/apis/k0sctl.k0sproject.io/v1beta1/cluster/k0s.go
@@ -146,7 +146,7 @@ func (k *K0s) NodeConfig() dig.Mapping {
 }
 
 // GenerateToken runs the k0s token create command
-func (k *K0s) GenerateToken(h *Host, role string, expiry time.Duration) (string, error) {
+func (k *K0s) GenerateToken(ctx context.Context, h *Host, role string, expiry time.Duration) (string, error) {
 	var k0sFlags Flags
 	k0sFlags.Add(fmt.Sprintf("--role %s", role))
 	k0sFlags.Add(fmt.Sprintf("--expiry %s", expiry))
@@ -158,7 +158,7 @@ func (k *K0s) GenerateToken(h *Host, role string, expiry time.Duration) (string,
 	}
 
 	var token string
-	err := retry.Timeout(context.TODO(), retry.DefaultTimeout, func(_ context.Context) error {
+	err := retry.AdaptiveTimeout(ctx, retry.DefaultTimeout, func(_ context.Context) error {
 		output, err := h.ExecOutput(h.Configurer.K0sCmdf("token create %s", k0sFlags.Join()), exec.HideOutput(), exec.Sudo(h))
 		if err != nil {
 			return fmt.Errorf("create token: %w", err)

--- a/pkg/retry/retry.go
+++ b/pkg/retry/retry.go
@@ -73,6 +73,18 @@ func Timeout(ctx context.Context, timeout time.Duration, f func(ctx context.Cont
 	return Context(ctx, f)
 }
 
+// AdaptiveTimeout is like Timeout but uses the given timeout only if the given context does not have a deadline or has a deadline that only occurs after the given timeout.
+func AdaptiveTimeout(ctx context.Context, timeout time.Duration, f func(ctx context.Context) error) error {
+	parentDeadline, hasDeadline := ctx.Deadline()
+	newDeadline := time.Now().Add(timeout)
+
+	if hasDeadline && parentDeadline.Before(newDeadline) {
+		return Context(ctx, f)
+	}
+
+	return Timeout(ctx, timeout, f)
+}
+
 // Times is a retry wrapper that will retry the given function until it succeeds or the given number of
 // attempts have been made
 func Times(ctx context.Context, times int, f func(context.Context) error) error {


### PR DESCRIPTION
Adds a `--timeout=<duration>` flag for most subcommands.

Usage:

```
k0sctl apply --timeout=120m
```

The timeout is not absolutely effective for all operations as the current version of [rig](https://github.com/k0sproject/rig) does not support command timeouts (v2 does but migration #755 is still unfinished) and if a remote command hangs forever or past the timeout, it won't bite and abort the command, but instead keep waiting for it to finish.

If a timeout is not given, the pre-existing per step predefined (seems to always be either 30 seconds or 2 minutes) timeouts are be used and the functionality should remain the same.

If a timeout is given, each of those operations will be retried until the global timeout expires.

I'm not completely sure about naming it `--timeout` as it usually would imply that a long-running operation would be cut short when the time is exceeded, but in this case the use-case should more often seem to be to make it run longer than usual.

While making this I realized there was already the `--retry-timeout ("Default timeout when waiting for node state changes")` flag that could have been used for some operations. It should probably be deprecated with the addition of `--timeout`.
