### PR TITLE
Clean up uploaded k0s binary temp files 

### DIFF
--- a/phase/download_k0s.go
+++ b/phase/download_k0s.go
@@ -82,3 +82,13 @@ func (p *DownloadK0s) downloadK0s(_ context.Context, h *cluster.Host) error {
 
 	return nil
 }
+
+// Cleanup removes the binary temp file if it wasn't used
+func (p *DownloadK0s) CleanUp() {
+	_ = p.parallelDo(context.Background(), p.hosts, func(_ context.Context, h *cluster.Host) error {
+		if h.Metadata.K0sBinaryTempFile != "" {
+			_ = h.Configurer.DeleteFile(h, h.Metadata.K0sBinaryTempFile)
+		}
+		return nil
+	})
+}

--- a/phase/install_binaries.go
+++ b/phase/install_binaries.go
@@ -70,6 +70,7 @@ func (p *InstallBinaries) installBinary(_ context.Context, h *cluster.Host) erro
 	if err := h.UpdateK0sBinary(h.Metadata.K0sBinaryTempFile, p.Config.Spec.K0s.Version); err != nil {
 		return fmt.Errorf("failed to install k0s binary: %w", err)
 	}
+	h.Metadata.K0sBinaryTempFile = ""
 
 	return nil
 }
@@ -80,9 +81,7 @@ func (p *InstallBinaries) CleanUp() {
 			return nil
 		}
 		logrus.Infof("%s: cleaning up k0s binary tempfile", h)
-		if err := h.Configurer.DeleteFile(h, h.Metadata.K0sBinaryTempFile); err != nil {
-			return fmt.Errorf("clean up tempfile: %w", err)
-		}
+		_ = h.Configurer.DeleteFile(h, h.Metadata.K0sBinaryTempFile)
 		return nil
 	})
 	if err != nil {

--- a/phase/upload_k0s.go
+++ b/phase/upload_k0s.go
@@ -83,3 +83,13 @@ func (p *UploadK0s) uploadBinary(_ context.Context, h *cluster.Host) error {
 
 	return nil
 }
+
+// Cleanup removes the binary temp file if it wasn't used
+func (p *UploadK0s) CleanUp() {
+	_ = p.parallelDo(context.Background(), p.hosts, func(_ context.Context, h *cluster.Host) error {
+		if h.Metadata.K0sBinaryTempFile != "" {
+			_ = h.Configurer.DeleteFile(h, h.Metadata.K0sBinaryTempFile)
+		}
+		return nil
+	})
+}

--- a/pkg/apis/k0sctl.k0sproject.io/v1beta1/cluster/host.go
+++ b/pkg/apis/k0sctl.k0sproject.io/v1beta1/cluster/host.go
@@ -391,6 +391,10 @@ func (h *Host) InstallK0sBinary(path string) error {
 		return fmt.Errorf("install k0s binary: %w", err)
 	}
 
+	if err := h.Configurer.DeleteFile(h, path); err != nil {
+		log.Warnf("%s: failed to delete k0s binary tempfile: %s", h, err)
+	}
+
 	return nil
 }
 


### PR DESCRIPTION
Fixes #849 

The `/usr/local/bin/k0s.tmp.<timestamp>` files were being left behind.
