### PR TITLE
Allow defining backup filename

### DIFF
--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -262,6 +262,19 @@ jobs:
           LINUX_IMAGE: ${{ matrix.image }}
         run: make smoke-backup-restore
   
+  smoke-backup-restore-out:
+    name: Apply + backup + reset + restore (non-default output)
+    needs: build
+    runs-on: ubuntu-20.04
+
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ./.github/actions/smoke-test-cache
+      - name: Run smoke tests
+        env:
+          OUT: localfile
+        run: make smoke-backup-restore
+  
   smoke-controller-swap:
     strategy:
       matrix:

--- a/action/backup.go
+++ b/action/backup.go
@@ -3,6 +3,7 @@ package action
 import (
 	"context"
 	"fmt"
+	"io"
 	"time"
 
 	"github.com/k0sproject/k0sctl/phase"
@@ -12,6 +13,7 @@ import (
 type Backup struct {
 	// Manager is the phase manager
 	Manager *phase.Manager
+	Out  io.Writer
 }
 
 func (b Backup) Run(ctx context.Context) error {
@@ -27,7 +29,7 @@ func (b Backup) Run(ctx context.Context) error {
 		&phase.GatherFacts{SkipMachineIDs: true},
 		&phase.GatherK0sFacts{},
 		&phase.RunHooks{Stage: "before", Action: "backup"},
-		&phase.Backup{},
+		&phase.Backup{Out: b.Out},
 		&phase.RunHooks{Stage: "after", Action: "backup"},
 		&phase.Unlock{Cancel: lockPhase.Cancel},
 		&phase.Disconnect{},

--- a/cmd/backup.go
+++ b/cmd/backup.go
@@ -2,9 +2,14 @@ package cmd
 
 import (
 	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"time"
 
 	"github.com/k0sproject/k0sctl/action"
 	"github.com/k0sproject/k0sctl/phase"
+	log "github.com/sirupsen/logrus"
 	"github.com/urfave/cli/v2"
 )
 
@@ -12,6 +17,11 @@ var backupCommand = &cli.Command{
 	Name:  "backup",
 	Usage: "Take backup of existing clusters state",
 	Flags: []cli.Flag{
+		&cli.StringFlag{
+			Name:    "output",
+			Aliases: []string{"o"},
+			Usage:   "Output path for the backup. Default is k0s_backup_<timestamp>.tar.gz in current directory",
+		},
 		configFlag,
 		dryRunFlag,
 		concurrencyFlag,
@@ -25,14 +35,46 @@ var backupCommand = &cli.Command{
 	Before: actions(initLogging, initConfig, initManager, displayLogo, displayCopyright),
 	After:  actions(cancelTimeout),
 	Action: func(ctx *cli.Context) error {
+		var resultErr error
+		var out io.Writer
+		localFile := ctx.String("output")
+
+		if localFile == "" {
+			f, err := filepath.Abs(fmt.Sprintf("k0s_backup_%d.tar.gz", time.Now().Unix()))
+			if err != nil {
+				resultErr = fmt.Errorf("failed to generate local filename: %w", err)
+				return resultErr
+			}
+			localFile = f
+		}
+
+		defer func() {
+			if out != nil && resultErr != nil && localFile != "" {
+				if err := os.Remove(localFile); err != nil {
+					log.Warnf("failed to clean up incomplete backup file %s: %s", localFile, err)
+				}
+			}
+		}()
+
+		if out == nil {
+			f, err := os.OpenFile(localFile, os.O_RDWR|os.O_CREATE|os.O_SYNC, 0o600)
+			if err != nil {
+				resultErr = fmt.Errorf("open local file for writing: %w", err)
+				return resultErr
+			}
+			defer f.Close()
+			out = f
+		}
+
 		backupAction := action.Backup{
 			Manager: ctx.Context.Value(ctxManagerKey{}).(*phase.Manager),
+			Out:     out,
 		}
 
 		if err := backupAction.Run(ctx.Context); err != nil {
-			return fmt.Errorf("backup failed - log file saved to %s: %w", ctx.Context.Value(ctxLogFileKey{}).(string), err)
+			resultErr = fmt.Errorf("backup failed - log file saved to %s: %w", ctx.Context.Value(ctxLogFileKey{}).(string), err)
 		}
 
-		return nil
+		return resultErr
 	},
 }

--- a/cmd/completion.go
+++ b/cmd/completion.go
@@ -30,15 +30,15 @@ var completionCommand = &cli.Command{
 	Action: func(ctx *cli.Context) error {
 		switch path.Base(ctx.String("shell")) {
 		case "bash":
-			fmt.Print(bashTemplate())
+			fmt.Fprint(ctx.App.Writer, bashTemplate())
 		case "zsh":
-			fmt.Print(zshTemplate())
+			fmt.Fprint(ctx.App.Writer, zshTemplate())
 		case "fish":
 			t, err := ctx.App.ToFishCompletion()
 			if err != nil {
 				return err
 			}
-			fmt.Print(t)
+			fmt.Fprint(ctx.App.Writer, t)
 		default:
 			return fmt.Errorf("no completion script available for %s", ctx.String("shell"))
 		}

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -184,21 +184,23 @@ var initCommand = &cli.Command{
 		var addresses []string
 
 		// Read addresses from stdin
-		stat, err := os.Stdin.Stat()
-		if err == nil {
-			if (stat.Mode() & os.ModeCharDevice) == 0 {
-				rd := bufio.NewReader(os.Stdin)
-				for {
-					row, _, err := rd.ReadLine()
-					if err != nil {
-						break
+		if inF, ok := ctx.App.Reader.(*os.File); ok {
+			stat, err := inF.Stat()
+			if err == nil {
+				if (stat.Mode() & os.ModeCharDevice) == 0 {
+					rd := bufio.NewReader(os.Stdin)
+					for {
+						row, _, err := rd.ReadLine()
+						if err != nil {
+							break
+						}
+						addresses = append(addresses, string(row))
 					}
-					addresses = append(addresses, string(row))
-				}
-				if err != nil {
-					return err
-				}
+					if err != nil {
+						return err
+					}
 
+				}
 			}
 		}
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"context"
+	"io"
 	"os"
 	"os/signal"
 	"syscall"
@@ -22,43 +23,48 @@ func trapSignals(ctx context.Context, cancel context.CancelFunc) {
 	}
 }
 
-// App is the main urfave/cli.App for k0sctl
-var App = &cli.App{
-	Name:  "k0sctl",
-	Usage: "k0s cluster management tool",
-	Flags: []cli.Flag{
-		debugFlag,
-		traceFlag,
-		redactFlag,
-	},
-	Commands: []*cli.Command{
-		versionCommand,
-		applyCommand,
-		kubeconfigCommand,
-		initCommand,
-		resetCommand,
-		backupCommand,
-		{
-			Name:  "config",
-			Usage: "Configuration related sub-commands",
-			Subcommands: []*cli.Command{
-				configEditCommand,
-				configStatusCommand,
-			},
+// NewK0sctl returns the urfave/cli.App for k0sctl
+func NewK0sctl(in io.Reader, out, errOut io.Writer) *cli.App {
+	return &cli.App{
+		Name:  "k0sctl",
+		Usage: "k0s cluster management tool",
+		Flags: []cli.Flag{
+			debugFlag,
+			traceFlag,
+			redactFlag,
 		},
-		completionCommand,
-	},
-	EnableBashCompletion: true,
-	Before: func(ctx *cli.Context) error {
-		if globalCancel == nil {
-			cancelCtx, cancel := context.WithCancel(ctx.Context)
-			ctx.Context = cancelCtx
-			globalCancel = cancel
-		}
-		go trapSignals(ctx.Context, globalCancel)
-		return nil
-	},
-	After: func(ctx *cli.Context) error {
-		return cancelTimeout(ctx)
-	},
+		Commands: []*cli.Command{
+			versionCommand,
+			applyCommand,
+			kubeconfigCommand,
+			initCommand,
+			resetCommand,
+			backupCommand,
+			{
+				Name:  "config",
+				Usage: "Configuration related sub-commands",
+				Subcommands: []*cli.Command{
+					configEditCommand,
+					configStatusCommand,
+				},
+			},
+			completionCommand,
+		},
+		EnableBashCompletion: true,
+		Before: func(ctx *cli.Context) error {
+			if globalCancel == nil {
+				cancelCtx, cancel := context.WithCancel(ctx.Context)
+				ctx.Context = cancelCtx
+				globalCancel = cancel
+			}
+			go trapSignals(ctx.Context, globalCancel)
+			return nil
+		},
+		After: func(ctx *cli.Context) error {
+			return cancelTimeout(ctx)
+		},
+		Reader: in,
+		Writer:    out,
+		ErrWriter: errOut,
+	}
 }

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -32,7 +32,7 @@ var versionCommand = &cli.Command{
 			if err != nil {
 				return err
 			}
-			fmt.Println(v)
+			fmt.Fprintln(ctx.App.Writer, v)
 			os.Exit(0)
 		}
 
@@ -41,15 +41,15 @@ var versionCommand = &cli.Command{
 			if err != nil {
 				return err
 			}
-			fmt.Println(v.TagName)
+			fmt.Fprintln(ctx.App.Writer, v.TagName)
 			os.Exit(0)
 		}
 
 		return nil
 	},
 	Action: func(ctx *cli.Context) error {
-		fmt.Printf("version: %s\n", version.Version)
-		fmt.Printf("commit: %s\n", version.GitCommit)
+		fmt.Fprintf(ctx.App.Writer, "version: %s\n", version.Version)
+		fmt.Fprintf(ctx.App.Writer, "commit: %s\n", version.GitCommit)
 		return nil
 	},
 }

--- a/main.go
+++ b/main.go
@@ -13,8 +13,8 @@ import (
 )
 
 func main() {
-	err := cmd.App.Run(os.Args)
-	if err != nil {
+	k0sctl := cmd.NewK0sctl(os.Stdin, os.Stdout, os.Stderr)
+	if err := k0sctl.Run(os.Args); err != nil {
 		log.Fatal(err)
 	}
 }


### PR DESCRIPTION
Fixes #847

Adds `--output|-o` flag to the backup sub-command for writing the backup to the given filename.

Stdout / stdin piping is not yet implemented because it needs a larger refactoring of stream initialization.


