### PR TITLE
Add spec.options.evictTaint to allow setting a taint on nodes before stopping k0s

### DIFF
--- a/README.md
+++ b/README.md
@@ -213,6 +213,10 @@ spec:
       enabled: true
     drain:
       enabled: true
+    evictTaint:
+      enabled: false
+      taint: k0sctl.k0sproject.io/evict=true
+      effect: NoExecute
     concurrency:
       limit: 30
       uploads: 5
@@ -623,6 +627,10 @@ spec:
       enabled: true
     drain:
       enabled: true
+    evictTaint:
+      enabled: false
+      taint: k0sctl.k0sproject.io/evict=true
+      effect: NoExecute
     concurrency:
       limit: 30
       uploads: 5
@@ -635,6 +643,26 @@ If set to `false`, k0sctl will not wait for k0s to become ready after restarting
 ##### `spec.options.drain.enabled` &lt;boolean&gt; (optional) (default: true)
 
 If set to `false`, k0sctl will skip draining nodes before performing disruptive operations like upgrade or reset. By default, nodes are drained to allow for graceful pod eviction. This is functionally the same as using `--no-drain` on the command line.
+
+##### `spec.options.evictTaint.enabled` &lt;boolean&gt; (optional) (default: false)
+
+When enabled, k0sctl will apply a taint to nodes before service-affecting operations such as upgrade or reset. This is used to signal workloads to be evicted in advance of node disruption. You can also use the `--evict-taint=k0sctl.k0sproject.io/evic=true:NoExecute` command line option to enable this feature.
+
+##### `spec.options.evictTaint.taint` &lt;string&gt; (optional) (default: `k0sctl.k0sproject.io/evict=true`)
+
+The taint to apply when `evictTaint.enabled` is `true`. Must be in the format `key=value`.
+
+##### `spec.options.evictTaint.effect` &lt;string&gt; (optional) (default: `NoExecute`)
+
+The taint effect to apply. Must be one of:
+
+* `NoExecute`
+* `NoSchedule`
+* `PreferNoSchedule`
+
+##### `spec.options.evictTaint.controllerWorkers` &lt;boolean&gt; (optional) (default: false)
+
+Whether to also apply the taint to nodes with the controller+worker dual role. By default, taints are only applied to worker-only nodes.
 
 ##### `spec.options.concurrency.limit` &lt;integer&gt; (optional) (default: 30)
 

--- a/action/apply.go
+++ b/action/apply.go
@@ -38,8 +38,6 @@ type ApplyOptions struct {
 	KubeconfigCluster string
 	// ConfigPaths is the list of paths to the configuration files (used for kubeconfig command tip on success)
 	ConfigPaths []string
-	// DrainTaint is a taint to be added to worker nodes before draining during the upgrade, and removed after uncordoning
-	DrainTaint string
 }
 
 type Apply struct {
@@ -88,7 +86,7 @@ func NewApply(opts ApplyOptions) *Apply {
 			&phase.InstallControllers{},
 			&phase.InstallWorkers{},
 			&phase.UpgradeControllers{},
-			&phase.UpgradeWorkers{NoDrain: opts.NoDrain, DrainTaint: opts.DrainTaint},
+			&phase.UpgradeWorkers{NoDrain: opts.NoDrain},
 			&phase.Reinstall{},
 			&phase.ResetWorkers{NoDrain: opts.NoDrain},
 			&phase.ResetControllers{NoDrain: opts.NoDrain},

--- a/action/apply.go
+++ b/action/apply.go
@@ -38,6 +38,8 @@ type ApplyOptions struct {
 	KubeconfigCluster string
 	// ConfigPaths is the list of paths to the configuration files (used for kubeconfig command tip on success)
 	ConfigPaths []string
+	// DrainTaint is a taint to be added to worker nodes before draining during the upgrade, and removed after uncordoning
+	DrainTaint string
 }
 
 type Apply struct {
@@ -86,7 +88,7 @@ func NewApply(opts ApplyOptions) *Apply {
 			&phase.InstallControllers{},
 			&phase.InstallWorkers{},
 			&phase.UpgradeControllers{},
-			&phase.UpgradeWorkers{NoDrain: opts.NoDrain},
+			&phase.UpgradeWorkers{NoDrain: opts.NoDrain, DrainTaint: opts.DrainTaint},
 			&phase.Reinstall{},
 			&phase.ResetWorkers{NoDrain: opts.NoDrain},
 			&phase.ResetControllers{NoDrain: opts.NoDrain},

--- a/cmd/apply.go
+++ b/cmd/apply.go
@@ -60,6 +60,10 @@ var applyCommand = &cli.Command{
 			Name:  "force",
 			Usage: "Attempt a forced installation in case of certain failures",
 		},
+		&cli.StringFlag{
+			Name:  "drain-taint",
+			Usage: "Taint to be added to worker nodes before draining during the upgrade, and removed after uncordoning",
+		},
 		debugFlag,
 		traceFlag,
 		redactFlag,
@@ -98,6 +102,7 @@ var applyCommand = &cli.Command{
 			DisableDowngradeCheck: ctx.Bool("disable-downgrade-check"),
 			RestoreFrom:           ctx.String("restore-from"),
 			ConfigPaths:           ctx.StringSlice("config"),
+			DrainTaint:            ctx.String("drain-taint"),
 		}
 
 		applyAction := action.NewApply(applyOpts)

--- a/phase/reset_workers.go
+++ b/phase/reset_workers.go
@@ -60,6 +60,12 @@ func (p *ResetWorkers) DryRun() error {
 // Run the phase
 func (p *ResetWorkers) Run(ctx context.Context) error {
 	return p.parallelDo(ctx, p.hosts, func(_ context.Context, h *cluster.Host) error {
+		if t := p.Config.Spec.Options.EvictTaint; t.Enabled {
+			log.Debugf("%s: add taint: %s", h, t.String())
+			if err := p.leader.AddTaint(h, t.String()); err != nil {
+				return fmt.Errorf("add taint: %w", err)
+			}
+		}
 		if !p.NoDrain {
 			log.Debugf("%s: draining node", h)
 			if err := p.leader.DrainNode(&cluster.Host{

--- a/phase/upgrade_workers.go
+++ b/phase/upgrade_workers.go
@@ -17,8 +17,7 @@ import (
 type UpgradeWorkers struct {
 	GenericPhase
 
-	NoDrain    bool
-	DrainTaint string
+	NoDrain bool
 
 	hosts  cluster.Hosts
 	leader *cluster.Host
@@ -114,16 +113,19 @@ func (p *UpgradeWorkers) cordonWorker(_ context.Context, h *cluster.Host) error 
 func (p *UpgradeWorkers) uncordonWorker(_ context.Context, h *cluster.Host) error {
 	if !p.IsWet() {
 		p.DryMsg(h, "uncordon node")
+		if t := p.Config.Spec.Options.EvictTaint; t.Enabled {
+			p.DryMsgf(h, "remove taint %s", t.String())
+		}
 		return nil
 	}
 	log.Debugf("%s: uncordon", h)
 	if err := p.leader.UncordonNode(h); err != nil {
 		return fmt.Errorf("uncordon node: %w", err)
 	}
-	if t := p.DrainTaint; t != "" {
-		log.Debugf("%s: remove taint: %s", h, t)
-		if err := p.leader.RemoveTaint(h, t); err != nil {
-			return fmt.Errorf("remove taint node: %w", err)
+	if t := p.Config.Spec.Options.EvictTaint; t.Enabled {
+		log.Debugf("%s: remove taint: %s", h, t.String())
+		if err := p.leader.RemoveTaint(h, t.String()); err != nil {
+			return fmt.Errorf("remove taint: %w", err)
 		}
 	}
 	return nil
@@ -134,15 +136,21 @@ func (p *UpgradeWorkers) drainWorker(_ context.Context, h *cluster.Host) error {
 		log.Debugf("%s: not draining because --no-drain given", h)
 		return nil
 	}
+	if t := p.Config.Spec.Options.EvictTaint; t.Enabled {
+		log.Debugf("%s: add taint: %s", h, t.String())
+		err := p.Wet(h, "add taint "+t.String(), func() error {
+			if err := p.leader.AddTaint(h, t.String()); err != nil {
+				return fmt.Errorf("add taint: %w", err)
+			}
+			return nil
+		})
+		if err != nil {
+			return err
+		}
+	}
 	if !p.IsWet() {
 		p.DryMsg(h, "drain node")
 		return nil
-	}
-	if t := p.DrainTaint; t != "" {
-		log.Debugf("%s: add taint: %s", h, t)
-		if err := p.leader.AddTaint(h, t); err != nil {
-			return fmt.Errorf("add taint node: %w", err)
-		}
 	}
 	log.Debugf("%s: drain", h)
 	if err := p.leader.DrainNode(h); err != nil {

--- a/smoke-test/k0sctl.yaml
+++ b/smoke-test/k0sctl.yaml
@@ -22,6 +22,9 @@ spec:
         address: "127.0.0.1"
         port: 9023
         keyPath: ./id_rsa_k0s
+  options:
+    evictTaint:
+      enabled: true
   k0s:
     version: "${K0S_VERSION}"
     config:


### PR DESCRIPTION
Fixes the root issue in https://github.com/k0sproject/k0sctl/issues/861 but does not implement the requested hook feature, which may get implemented later.

Adds an `evictTaint` option that when enabled will make k0sctl apply a taint to nodes before their shutdown to allow DaemonSet pods without tolerations to shut down cleanly.

This can be set via `--evict-taint=<taint=value>:<effect>`, the default is `k0sctl.k0sproject.io/evict=true:NoExecute` and by default this feature is disabled.

This can be set via the new `options` config struct introduced in #870 like so:

```yaml
apiVersion: k0sctl.k0sproject.io/v1beta1
kind: cluster
spec:
  hosts:
    - ...
  options:
     evictTaint:
       enabled: true # default is false
       taint: k0sctl.k0sproject.io/evict=true
       effect: NoExecute
       controllerWorkers: false # setting this to true will make workload-running controllers also get the taint
```

