### PR TITLE
Delete DaemonSet pods after draining before upgrade or reset

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -38,6 +38,7 @@ require (
 	github.com/jellydator/validation v1.1.0
 	github.com/k0sproject/version v0.7.0
 	github.com/sergi/go-diff v1.3.1
+	k8s.io/api v0.32.3
 	k8s.io/client-go v0.32.3
 )
 

--- a/go.sum
+++ b/go.sum
@@ -121,8 +121,9 @@ github.com/kevinburke/ssh_config v1.2.0 h1:x584FjTGwHzMwvHx18PXxbBVzfnxogHaAReU4
 github.com/kevinburke/ssh_config v1.2.0/go.mod h1:CT57kijsi8u/K/BOFA39wgDQJ9CxiF4nAY/ojJ6r6mM=
 github.com/kisielk/errcheck v1.5.0/go.mod h1:pFxgyoBC7bSaBwPgfKdkLd5X25qrDl4LWUI2bnpBCr8=
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
-github.com/kr/pretty v0.1.0 h1:L/CwN0zerZDmRFUapSPitk6f+Q3+0za1rQkzVuMiMFI=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
+github.com/kr/pretty v0.3.1 h1:flRD4NNwYAUpkphVc1HcthR4KEIFJ65n8Mw5qdRn3LE=
+github.com/kr/pretty v0.3.1/go.mod h1:hoEshYVHaxMs3cyo3Yncou5ZscifuDolrwPKZanG3xk=
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
 github.com/kr/text v0.2.0 h1:5Nx0Ya0ZqY2ygV366QzturHI13Jq95ApcVaJBhpS+AY=
@@ -162,6 +163,8 @@ github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINE
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 h1:Jamvg5psRIccs7FGNTlIRMkT8wgtp5eCXdBlqhYGL6U=
 github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/rogpeppe/go-internal v1.12.0 h1:exVL4IDcn6na9z1rAb56Vxr+CgyK3nn3O+epU5NdKM8=
+github.com/rogpeppe/go-internal v1.12.0/go.mod h1:E+RYuTGaKKdloAfM02xzb0FW3Paa99yedzYV+kq4uf4=
 github.com/russross/blackfriday/v2 v2.1.0 h1:JIOH55/0cWyOuilr9/qlrm0BSXldqnqwMsf35Ld67mk=
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/sergi/go-diff v1.3.1 h1:xkr+Oxo4BOQKmkn/B9eMK0g5Kg/983T9DqqPHwYqD+8=
@@ -262,8 +265,9 @@ golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1/go.mod h1:I/5z698sn9Ka8T
 google.golang.org/protobuf v1.35.1 h1:m3LfL6/Ca+fqnjnlqQXNpFPABW1UD7mjh8KO2mKFytA=
 google.golang.org/protobuf v1.35.1/go.mod h1:9fA7Ob0pmnwhb644+1+CVWFRbNajQ6iRojtC/QF5bRE=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
-gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15 h1:YR8cESwS4TdDjEe65xsg0ogRM/Nc3DYOhEAlW+xobZo=
 gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c h1:Hei/4ADfdWqJk1ZMxUNpqntNwaWcugrBjAiHlqqRiVk=
+gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c/go.mod h1:JHkPIbrfpd72SG/EVd6muEfDQjcINNoR0C8j2r3qZ4Q=
 gopkg.in/evanphx/json-patch.v4 v4.12.0 h1:n6jtcsulIzXPJaxegRbvFNNrZDjbij7ny3gmSPG+6V4=
 gopkg.in/evanphx/json-patch.v4 v4.12.0/go.mod h1:p8EYWUEYMpynmqDbY58zCKCFZw8pRWMG4EsWvDvM72M=
 gopkg.in/inf.v0 v0.9.1 h1:73M5CoZyi3ZLMOyDlQh031Cx6N9NDJ2Vvfl76EDAgDc=

--- a/phase/reset_controllers.go
+++ b/phase/reset_controllers.go
@@ -62,6 +62,17 @@ func (p *ResetControllers) Run(ctx context.Context) error {
 			}); err != nil {
 				log.Warnf("%s: failed to drain node: %s", h, err.Error())
 			}
+			log.Debugf("%s: deleting any leftover daemonset pods", h)
+			if err := p.leader.KillDaemonSetPods(h, false); err != nil {
+				if Force {
+					log.Warnf("%s: failed to delete daemonset pods gracefully, will use force: %s", h, err.Error())
+					if err := p.leader.KillDaemonSetPods(h, true); err != nil {
+						log.Warnf("%s: failed to delete daemonset pods forcefully: %s", h, err.Error())
+					}
+				} else {
+					return fmt.Errorf("failed to delete daemonset pods: %w", err)
+				}
+			}
 		}
 		log.Debugf("%s: draining node completed", h)
 

--- a/phase/reset_workers.go
+++ b/phase/reset_workers.go
@@ -61,6 +61,16 @@ func (p *ResetWorkers) Run(ctx context.Context) error {
 			}); err != nil {
 				log.Warnf("%s: failed to drain node: %s", h, err.Error())
 			}
+			if err := p.leader.KillDaemonSetPods(h, false); err != nil {
+				if Force {
+					log.Warnf("%s: failed to delete daemonset pods gracefully, will use force: %s", h, err.Error())
+					if err := p.leader.KillDaemonSetPods(h, true); err != nil {
+						log.Warnf("%s: failed to delete daemonset pods forcefully: %s", h, err.Error())
+					}
+				} else {
+					return fmt.Errorf("failed to delete daemonset pods: %w", err)
+				}
+			}
 		}
 		log.Debugf("%s: draining node completed", h)
 

--- a/pkg/kube/pod.go
+++ b/pkg/kube/pod.go
@@ -1,0 +1,113 @@
+package kube
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+
+	"al.essio.dev/pkg/shellescape"
+	corev1 "k8s.io/api/core/v1"
+)
+
+// PodFilter is a search filter for listing pods.
+type PodFilter struct {
+	Namespace      string   // if empty, use --all-namespaces
+	NodeName       string   // for spec.nodeName
+	LabelSelectors []string // ["key=value", "key!=value"] etc.
+	FieldSelectors []string // ["status.phase=Running", "spec.nodeName=node1"]
+	OwnerKind      string   // e.g. "DaemonSet", "Deployment", etc.
+}
+
+func (f *PodFilter) ToKubectlArgs() string {
+	args := []string{"get", "pods", "-o", "json"}
+
+	if f.Namespace != "" {
+		args = append(args, "-n", shellescape.Quote(f.Namespace))
+	} else {
+		args = append(args, "--all-namespaces")
+	}
+
+	if len(f.LabelSelectors) > 0 {
+		labels := strings.Join(f.LabelSelectors, ",")
+		args = append(args, "-l", shellescape.Quote(labels))
+	}
+
+	fieldSelectors := append([]string{}, f.FieldSelectors...)
+	if f.NodeName != "" {
+		fieldSelectors = append(fieldSelectors, "spec.nodeName="+f.NodeName)
+	}
+	if len(fieldSelectors) > 0 {
+		fields := strings.Join(fieldSelectors, ",")
+		args = append(args, "--field-selector", shellescape.Quote(fields))
+	}
+
+	return strings.Join(args, " ")
+}
+
+// PodInfo contains information about a pod.
+type PodInfo struct {
+	Namespace string
+	Name      string
+	NodeName  string
+	OwnerKind string
+	OwnerName string
+	Status    string
+}
+
+// PodInfoParser is a io.WriteCloser that parses kubectl output on Close().
+type PodInfoParser struct {
+	buf    bytes.Buffer
+	closed bool
+	pods   []*PodInfo
+}
+
+// Write data to the buffer.
+func (p *PodInfoParser) Write(data []byte) (int, error) {
+	if p.closed {
+		return 0, errors.New("write after close")
+	}
+	return p.buf.Write(data)
+}
+
+// Close the buffer and parse the JSON data.
+func (p *PodInfoParser) Close() error {
+	if p.closed {
+		return nil
+	}
+	p.closed = true
+
+	var podList corev1.PodList
+	if err := json.Unmarshal(p.buf.Bytes(), &podList); err != nil {
+		return fmt.Errorf("failed to decode pod list: %w", err)
+	}
+
+	for _, item := range podList.Items {
+		pod := &PodInfo{
+			Name:      item.Name,
+			Namespace: item.Namespace,
+			NodeName:  item.Spec.NodeName,
+			Status:    string(item.Status.Phase),
+		}
+		if len(item.OwnerReferences) > 0 {
+			pod.OwnerKind = item.OwnerReferences[0].Kind
+			pod.OwnerName = item.OwnerReferences[0].Name
+		}
+		p.pods = append(p.pods, pod)
+	}
+
+	p.buf.Reset()
+
+	return nil
+}
+
+// Pods returns the parsed pod list.
+func (p *PodInfoParser) Pods() []*PodInfo {
+	return p.pods
+}
+
+// NewPodInfoParser creates a new PodInfoParser.
+func NewPodInfoParser() *PodInfoParser {
+	return &PodInfoParser{}
+}


### PR DESCRIPTION
Alternative to #863 

Before upgrading or resetting nodes k0sctl drains them. This PR deletes any remaining DaemonSet pods after that.

When `--force` is used, the pods will be terminated forcefully.
