### PR TITLE
Add spec.options for setting some flag values via config YAML

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,6 +208,14 @@ spec:
             cni:
               image: calico/cni
               version: v3.16.2
+  options:
+    wait:
+      enabled: true
+    drain:
+      enabled: true
+    concurrency:
+      limit: 30
+      uploads: 5
 ```
 
 ### Environment variable substitution
@@ -602,7 +610,41 @@ spec:
     externalAddress: 10.0.0.2
 ```
 
-#### Tokens
+### Options Fields
+
+The `spec.options` field contains options that can be used to modify the behavior of k0sctl.
+
+Example:
+
+```yaml
+spec:
+  options:
+    wait:
+      enabled: true
+    drain:
+      enabled: true
+    concurrency:
+      limit: 30
+      uploads: 5
+```
+
+##### `spec.options.wait.enabled` &lt;boolean&gt; (optional) (default: true)
+
+If set to `false`, k0sctl will not wait for k0s to become ready after restarting the service. By default, k0sctl waits for nodes to become ready before continuing to the next operation. This is functionally the same as using `--no-wait` on the command line.
+
+##### `spec.options.drain.enabled` &lt;boolean&gt; (optional) (default: true)
+
+If set to `false`, k0sctl will skip draining nodes before performing disruptive operations like upgrade or reset. By default, nodes are drained to allow for graceful pod eviction. This is functionally the same as using `--no-drain` on the command line.
+
+##### `spec.options.concurrency.limit` &lt;integer&gt; (optional) (default: 30)
+
+The maximum number of hosts to operate on concurrently during cluster operations. Same as the `--concurrency` command line option.
+
+##### `spec.options.concurrency.uploads` &lt;integer&gt; (optional) (default: 5)
+
+The maximum number of concurrent file uploads to perform. Same as the `--concurrent-uploads` command line option.
+
+### Tokens
 
 The following tokens can be used in the `k0sDownloadURL` and `files.[*].src` fields:
 

--- a/cmd/apply.go
+++ b/cmd/apply.go
@@ -81,15 +81,20 @@ var applyCommand = &cli.Command{
 			kubeconfigOut = out
 		}
 
+		manager, ok := ctx.Context.Value(ctxManagerKey{}).(*phase.Manager)
+		if !ok {
+			return fmt.Errorf("failed to retrieve manager from context")
+		}
+
 		applyOpts := action.ApplyOptions{
 			Force:                 ctx.Bool("force"),
-			Manager:               ctx.Context.Value(ctxManagerKey{}).(*phase.Manager),
+			Manager:               manager,
 			KubeconfigOut:         kubeconfigOut,
 			KubeconfigAPIAddress:  ctx.String("kubeconfig-api-address"),
 			KubeconfigUser:        ctx.String("kubeconfig-user"),
 			KubeconfigCluster:     ctx.String("kubeconfig-cluster"),
-			NoWait:                ctx.Bool("no-wait"),
-			NoDrain:               ctx.Bool("no-drain"),
+			NoWait:                ctx.Bool("no-wait") || !manager.Config.Spec.Options.Wait.Enabled,
+			NoDrain:               ctx.Bool("no-drain") || !manager.Config.Spec.Options.Drain.Enabled,
 			DisableDowngradeCheck: ctx.Bool("disable-downgrade-check"),
 			RestoreFrom:           ctx.String("restore-from"),
 			ConfigPaths:           ctx.StringSlice("config"),

--- a/cmd/flags.go
+++ b/cmd/flags.go
@@ -148,7 +148,6 @@ func actions(funcs ...func(*cli.Context) error) func(*cli.Context) error {
 
 // initConfig takes the config flag, does some magic and replaces the value with the file contents
 func initConfig(ctx *cli.Context) error {
-	println("initconfig")
 	f := ctx.StringSlice("config")
 	if len(f) == 0 || f[0] == "" {
 		return nil
@@ -306,8 +305,16 @@ func initManager(ctx *cli.Context) error {
 		return fmt.Errorf("failed to initialize phase manager: %w", err)
 	}
 
-	manager.Concurrency = ctx.Int("concurrency")
-	manager.ConcurrentUploads = ctx.Int("concurrent-uploads")
+	if ctx.IsSet("concurrency") {
+		manager.Concurrency = ctx.Int("concurrency")
+	} else {
+		manager.Concurrency = cfg.Spec.Options.Concurrency.Limit
+	}
+	if ctx.IsSet("concurrent-uploads") {
+		manager.ConcurrentUploads = ctx.Int("concurrent-uploads")
+	} else {
+		manager.ConcurrentUploads = cfg.Spec.Options.Concurrency.Uploads
+	}
 	manager.DryRun = ctx.Bool("dry-run")
 	manager.Writer = ctx.App.Writer
 

--- a/cmd/flags.go
+++ b/cmd/flags.go
@@ -325,7 +325,6 @@ func initManager(ctx *cli.Context) error {
 
 // initLogging initializes the logger
 func initLogging(ctx *cli.Context) error {
-	println("initlogging")
 	log.SetLevel(log.TraceLevel)
 	log.SetOutput(io.Discard)
 	initScreenLogger(ctx, logLevelFromCtx(ctx, log.InfoLevel))

--- a/phase/reset_controllers.go
+++ b/phase/reset_controllers.go
@@ -53,8 +53,8 @@ func (p *ResetControllers) ShouldRun() bool {
 // Run the phase
 func (p *ResetControllers) Run(ctx context.Context) error {
 	for _, h := range p.hosts {
-		log.Debugf("%s: draining node", h)
 		if !p.NoDrain && h.Role != "controller" {
+			log.Debugf("%s: draining node", h)
 			if err := p.leader.DrainNode(&cluster.Host{
 				Metadata: cluster.HostMetadata{
 					Hostname: h.Metadata.Hostname,

--- a/phase/reset_workers.go
+++ b/phase/reset_workers.go
@@ -49,11 +49,19 @@ func (p *ResetWorkers) ShouldRun() bool {
 	return len(p.hosts) > 0
 }
 
+// DryRun reports the nodes will be reset
+func (p *ResetWorkers) DryRun() error {
+	for _, h := range p.hosts {
+		p.DryMsg(h, "node would be reset")
+	}
+	return nil
+}
+
 // Run the phase
 func (p *ResetWorkers) Run(ctx context.Context) error {
 	return p.parallelDo(ctx, p.hosts, func(_ context.Context, h *cluster.Host) error {
-		log.Debugf("%s: draining node", h)
 		if !p.NoDrain {
+			log.Debugf("%s: draining node", h)
 			if err := p.leader.DrainNode(&cluster.Host{
 				Metadata: cluster.HostMetadata{
 					Hostname: h.Metadata.Hostname,

--- a/pkg/apis/k0sctl.k0sproject.io/v1beta1/cluster/options.go
+++ b/pkg/apis/k0sctl.k0sproject.io/v1beta1/cluster/options.go
@@ -1,0 +1,47 @@
+package cluster
+
+import (
+	"fmt"
+
+	"github.com/creasty/defaults"
+)
+
+// Options for cluster operations.
+type Options struct {
+	Wait        WaitOption        `yaml:"wait,omitempty"`
+	Drain       DrainOption       `yaml:"drain,omitempty"`
+	Concurrency ConcurrencyOption `yaml:"concurrency,omitempty"`
+}
+
+// WaitOption controls the wait behavior for cluster operations.
+type WaitOption struct {
+	Enabled bool `yaml:"enabled" default:"true"`
+}
+
+// DrainOption controls the drain behavior for cluster operations.
+type DrainOption struct {
+	Enabled bool `yaml:"enabled" default:"true"`
+}
+
+// ConcurrencyOption controls how many hosts are operated on at once.
+type ConcurrencyOption struct {
+	Limit   int `yaml:"limit" default:"30"`  // Max number of hosts to operate on at once
+	Uploads int `yaml:"uploads" default:"5"` // Max concurrent file uploads
+}
+
+// UnmarshalYAML implements the yaml.Unmarshaler interface for ConcurrencyOption.
+func (c *ConcurrencyOption) UnmarshalYAML(unmarshal func(interface{}) error) error {
+	type concurrencyOption ConcurrencyOption
+	var tmp concurrencyOption
+
+	if err := unmarshal(&tmp); err != nil {
+		return err
+	}
+
+	if err := defaults.Set(&tmp); err != nil {
+		return fmt.Errorf("failed to set defaults for concurrency option: %w", err)
+	}
+
+	*c = ConcurrencyOption(tmp)
+	return nil
+}

--- a/pkg/apis/k0sctl.k0sproject.io/v1beta1/cluster/spec.go
+++ b/pkg/apis/k0sctl.k0sproject.io/v1beta1/cluster/spec.go
@@ -11,8 +11,9 @@ import (
 
 // Spec defines cluster config spec section
 type Spec struct {
-	Hosts Hosts `yaml:"hosts,omitempty"`
-	K0s   *K0s  `yaml:"k0s,omitempty"`
+	Hosts   Hosts   `yaml:"hosts,omitempty"`
+	K0s     *K0s    `yaml:"k0s,omitempty"`
+	Options Options `yaml:"options,omitempty"`
 
 	k0sLeader *Host
 }
@@ -49,6 +50,7 @@ func (s *Spec) SetDefaults() {
 		s.K0s = &K0s{}
 		_ = defaults.Set(s.K0s)
 	}
+	_ = defaults.Set(s.Options)
 }
 
 // K0sLeader returns a controller host that is selected to be a "leader",


### PR DESCRIPTION
Split from #863 

Adds `spec.options` to config that can be used to give some k0sctl parameters via config in addition to command line flags.

Example:

```yaml
spec:
  options:
    wait:
      enabled: true # Setting this to false is the same as using --no-wait
    drain:
      enabled: true # Setting this to false is the same as using --no-drain
    concurrency:
      limit: 30 # Same as --concurrency
      uploads: 5 # Same as --concurrent-uploads
```

