### PR TITLE
Replace ubuntu-20.04 runners with 24.04

### DIFF
--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -13,7 +13,7 @@ on:
 jobs:
 
   build:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
 
     steps:
     - uses: actions/checkout@v4
@@ -46,7 +46,7 @@ jobs:
           - quay.io/k0sproject/bootloose-ubuntu20.04
     name: Basic 1+1 smoke
     needs: build
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
 
     steps:
       - uses: actions/checkout@v4
@@ -64,7 +64,7 @@ jobs:
           - quay.io/k0sproject/bootloose-ubuntu20.04
     name: Basic 1+1 smoke (regular user login)
     needs: build
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
 
     steps:
 
@@ -78,7 +78,7 @@ jobs:
   smoke-basic-idlike:
     name: Basic 1+1 smoke (ID_LIKE fallback)
     needs: build
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
 
     steps:
       - uses: actions/checkout@v4
@@ -99,7 +99,7 @@ jobs:
           - quay.io/k0sproject/bootloose-alpine3.18
     name: Basic 1+1 smoke using openssh client
     needs: build
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
 
     steps:
       - uses: actions/checkout@v4
@@ -116,7 +116,7 @@ jobs:
           - quay.io/k0sproject/bootloose-alpine3.18
     name: Basic 1+1 smoke using multidoc yamls
     needs: build
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
 
     steps:
       - uses: actions/checkout@v4
@@ -134,7 +134,7 @@ jobs:
           - quay.io/k0sproject/bootloose-alpine3.18
     name: Basic file upload smoke
     needs: build
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
 
     steps:
       - uses: actions/checkout@v4
@@ -149,7 +149,7 @@ jobs:
           - quay.io/k0sproject/bootloose-alpine3.18
     name: Basic dynamic config smoke
     needs: build
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
 
     steps:
       - uses: actions/checkout@v4
@@ -160,7 +160,7 @@ jobs:
   smoke-os-override:
     name: OS override smoke test
     needs: build
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
 
     steps:
       - uses: actions/checkout@v4
@@ -171,7 +171,7 @@ jobs:
   smoke-downloadurl:
     name: k0sDownloadURL smoke test
     needs: build
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
 
     steps:
       - uses: actions/checkout@v4
@@ -191,7 +191,7 @@ jobs:
           - v1.21.6+k0s.0
     name: Upgrade
     needs: build
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
 
     steps:
       - uses: actions/checkout@v4
@@ -212,7 +212,7 @@ jobs:
           - v1.21.6+k0s.0
     name: Dry run
     needs: build
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
 
     steps:
       - uses: actions/checkout@v4
@@ -232,7 +232,7 @@ jobs:
 
     name: Apply + reset
     needs: build
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
 
     steps:
       - uses: actions/checkout@v4
@@ -252,7 +252,7 @@ jobs:
 
     name: Apply + backup + reset + restore
     needs: build
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
 
     steps:
       - uses: actions/checkout@v4
@@ -265,7 +265,7 @@ jobs:
   smoke-backup-restore-out:
     name: Apply + backup + reset + restore (non-default output)
     needs: build
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
 
     steps:
       - uses: actions/checkout@v4
@@ -283,7 +283,7 @@ jobs:
 
     name: Controller swap
     needs: build
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
 
     steps:
       - uses: actions/checkout@v4
@@ -302,7 +302,7 @@ jobs:
 
     name: Reinstall (modify install flags)
     needs: build
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
 
     steps:
       - uses: actions/checkout@v4
@@ -315,7 +315,7 @@ jobs:
   smoke-init:
     name: Init sub-command smoke test
     needs: build
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
 
     steps:
       - uses: actions/checkout@v4

--- a/smoke-test/smoke-backup-restore.sh
+++ b/smoke-test/smoke-backup-restore.sh
@@ -11,7 +11,7 @@ trap runCleanup EXIT
 # custom exit trap to cleanup the backup archives
 runCleanup() {
     cleanup
-    rm k0s_backup*.tar.gz
+    rm -f k0s_backup*.tar.gz || true
 }
 
 deleteCluster


### PR DESCRIPTION
Github has retired ubuntu 20.04 runners. Replacing with 24.04.
