### PR TITLE
Configurable drain timeout

### DIFF
--- a/README.md
+++ b/README.md
@@ -644,6 +644,14 @@ If set to `false`, k0sctl will not wait for k0s to become ready after restarting
 
 If set to `false`, k0sctl will skip draining nodes before performing disruptive operations like upgrade or reset. By default, nodes are drained to allow for graceful pod eviction. This is functionally the same as using `--no-drain` on the command line.
 
+##### `spec.options.drain.gracePeriod` &lt;duration&gt; (optional) (default: 2m)
+
+The duration to wait for pods to be evicted from the node before proceeding with the operation. 
+
+##### `spec.options.drain.timeout` &lt;duration&gt; (optional) (default: 5m)
+
+The duration to wait for the drain operation to complete before timing out. 
+
 ##### `spec.options.evictTaint.enabled` &lt;boolean&gt; (optional) (default: false)
 
 When enabled, k0sctl will apply a taint to nodes before service-affecting operations such as upgrade or reset. This is used to signal workloads to be evicted in advance of node disruption. You can also use the `--evict-taint=k0sctl.k0sproject.io/evic=true:NoExecute` command line option to enable this feature.

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -204,21 +204,19 @@ var initCommand = &cli.Command{
 			}
 		}
 
-		// Read addresses from args
-		addresses = append(addresses, ctx.Args().Slice()...)
-
-		cfg := v1beta1.Cluster{
-			APIVersion: v1beta1.APIVersion,
-			Kind:       "Cluster",
-			Metadata:   &v1beta1.ClusterMetadata{Name: ctx.String("cluster-name")},
-			Spec: &cluster.Spec{
-				Hosts: buildHosts(addresses, ctx.Int("controller-count"), ctx.String("user"), ctx.String("key-path")),
-				K0s:   &cluster.K0s{},
-			},
-		}
+		cfg := v1beta1.Cluster{}
 
 		if err := defaults.Set(&cfg); err != nil {
 			return err
+		}
+
+		cfg.Metadata.Name = ctx.String("cluster-name")
+
+		// Read addresses from args
+		addresses = append(addresses, ctx.Args().Slice()...)
+		cfg.Spec.Hosts = buildHosts(addresses, ctx.Int("controller-count"), ctx.String("user"), ctx.String("key-path"))
+		for _, h := range cfg.Spec.Hosts {
+			_ = defaults.Set(h)
 		}
 
 		if ctx.Bool("k0s") {

--- a/phase/reset_controllers.go
+++ b/phase/reset_controllers.go
@@ -73,7 +73,10 @@ func (p *ResetControllers) Run(ctx context.Context) error {
 				Metadata: cluster.HostMetadata{
 					Hostname: h.Metadata.Hostname,
 				},
-			}); err != nil {
+			},
+				p.Config.Spec.Options.Drain.GracePeriod,
+				p.Config.Spec.Options.Drain.Timeout,
+			); err != nil {
 				log.Warnf("%s: failed to drain node: %s", h, err.Error())
 			}
 		}

--- a/phase/reset_workers.go
+++ b/phase/reset_workers.go
@@ -72,7 +72,10 @@ func (p *ResetWorkers) Run(ctx context.Context) error {
 				Metadata: cluster.HostMetadata{
 					Hostname: h.Metadata.Hostname,
 				},
-			}); err != nil {
+			},
+				p.Config.Spec.Options.Drain.GracePeriod,
+				p.Config.Spec.Options.Drain.Timeout,
+			); err != nil {
 				log.Warnf("%s: failed to drain node: %s", h, err.Error())
 			}
 		}

--- a/phase/upgrade_workers.go
+++ b/phase/upgrade_workers.go
@@ -153,7 +153,7 @@ func (p *UpgradeWorkers) drainWorker(_ context.Context, h *cluster.Host) error {
 		return nil
 	}
 	log.Debugf("%s: drain", h)
-	if err := p.leader.DrainNode(h); err != nil {
+	if err := p.leader.DrainNode(h, p.Config.Spec.Options.Drain.GracePeriod, p.Config.Spec.Options.Drain.Timeout); err != nil {
 		return fmt.Errorf("drain node: %w", err)
 	}
 	return nil

--- a/pkg/apis/k0sctl.k0sproject.io/v1beta1/cluster.go
+++ b/pkg/apis/k0sctl.k0sproject.io/v1beta1/cluster.go
@@ -31,9 +31,7 @@ type Cluster struct {
 
 // UnmarshalYAML sets in some sane defaults when unmarshaling the data from yaml
 func (c *Cluster) UnmarshalYAML(unmarshal func(interface{}) error) error {
-	c.Metadata = &ClusterMetadata{
-		Name: "k0s-cluster",
-	}
+	c.Metadata = &ClusterMetadata{}
 	c.Spec = &cluster.Spec{}
 
 	type clusterConfig Cluster
@@ -48,6 +46,24 @@ func (c *Cluster) UnmarshalYAML(unmarshal func(interface{}) error) error {
 	}
 
 	return nil
+}
+
+// SetDefaults initializes default values
+func (c *Cluster) SetDefaults() {
+	if c.Metadata == nil {
+		c.Metadata = &ClusterMetadata{}
+	}
+	if c.Spec == nil {
+		c.Spec = &cluster.Spec{}
+	}
+	_ = defaults.Set(c.Metadata)
+	_ = defaults.Set(c.Spec)
+	if defaults.CanUpdate(c.APIVersion) {
+		c.APIVersion = APIVersion
+	}
+	if defaults.CanUpdate(c.Kind) {
+		c.Kind = "Cluster"
+	}
 }
 
 // Validate performs a configuration sanity check

--- a/pkg/apis/k0sctl.k0sproject.io/v1beta1/cluster/host.go
+++ b/pkg/apis/k0sctl.k0sproject.io/v1beta1/cluster/host.go
@@ -429,7 +429,7 @@ func (h *Host) K0sDataDir() string {
 }
 
 // DrainNode drains the given node
-func (h *Host) DrainNode(node *Host, gracePeriod string, timeout string) error {
+func (h *Host) DrainNode(node *Host, gracePeriod, timeout time.Duration) error {
 	return h.Exec(h.Configurer.KubectlCmdf(h, h.K0sDataDir(), "drain --grace-period=%s --force --timeout=%s --ignore-daemonsets --delete-emptydir-data %s", gracePeriod, timeout, node.Metadata.Hostname), exec.Sudo(h))
 }
 

--- a/pkg/apis/k0sctl.k0sproject.io/v1beta1/cluster/host.go
+++ b/pkg/apis/k0sctl.k0sproject.io/v1beta1/cluster/host.go
@@ -429,8 +429,8 @@ func (h *Host) K0sDataDir() string {
 }
 
 // DrainNode drains the given node
-func (h *Host) DrainNode(node *Host) error {
-	return h.Exec(h.Configurer.KubectlCmdf(h, h.K0sDataDir(), "drain --grace-period=120 --force --timeout=5m --ignore-daemonsets --delete-emptydir-data %s", node.Metadata.Hostname), exec.Sudo(h))
+func (h *Host) DrainNode(node *Host, gracePeriod string, timeout string) error {
+	return h.Exec(h.Configurer.KubectlCmdf(h, h.K0sDataDir(), "drain --grace-period=%s --force --timeout=%s --ignore-daemonsets --delete-emptydir-data %s", gracePeriod, timeout, node.Metadata.Hostname), exec.Sudo(h))
 }
 
 // CordonNode marks the node unschedulable

--- a/pkg/apis/k0sctl.k0sproject.io/v1beta1/cluster/options.go
+++ b/pkg/apis/k0sctl.k0sproject.io/v1beta1/cluster/options.go
@@ -3,6 +3,7 @@ package cluster
 import (
 	"fmt"
 	"strings"
+	"time"
 
 	"github.com/creasty/defaults"
 	"github.com/jellydator/validation"
@@ -10,10 +11,10 @@ import (
 
 // Options for cluster operations.
 type Options struct {
-	Wait        WaitOption        `yaml:"wait,omitempty"`
-	Drain       DrainOption       `yaml:"drain,omitempty"`
-	Concurrency ConcurrencyOption `yaml:"concurrency,omitempty"`
-	EvictTaint  EvictTaintOption  `yaml:"evictTaint,omitempty"`
+	Wait        WaitOption        `yaml:"wait"`
+	Drain       DrainOption       `yaml:"drain"`
+	Concurrency ConcurrencyOption `yaml:"concurrency"`
+	EvictTaint  EvictTaintOption  `yaml:"evictTaint"`
 }
 
 // WaitOption controls the wait behavior for cluster operations.
@@ -23,7 +24,9 @@ type WaitOption struct {
 
 // DrainOption controls the drain behavior for cluster operations.
 type DrainOption struct {
-	Enabled bool `yaml:"enabled" default:"true"`
+	Enabled     bool          `yaml:"enabled" default:"true"`
+	GracePeriod time.Duration `yaml:"gracePeriod" default:"120s"`
+	Timeout     time.Duration `yaml:"timeout" default:"300s"`
 }
 
 // ConcurrencyOption controls how many hosts are operated on at once.


### PR DESCRIPTION
Fixes #724
and
Closes #725

(finally)

Adds `spec.options.drain.gracePeriod` and `spec.options.drain.timeout` to control the timeout parameters tiven to `kubectl drain`.
