### PR TITLE
Fix reset --force for v0.19

### DIFF
--- a/action/reset.go
+++ b/action/reset.go
@@ -36,6 +36,8 @@ func (r Reset) Run() error {
 		}
 	}
 
+	phase.Force = r.Force
+
 	start := time.Now()
 
 	for _, h := range r.Manager.Config.Spec.Hosts {


### PR DESCRIPTION
v0.19.x is used as a dependency in a bigger project, so backporting (or rather recreating) the `k0sctl reset --force` (or `Reset{Force: true}`) fix for it.
