### PR TITLE
Wait longer for controllers to become ready

### DIFF
--- a/phase/initialize_k0s.go
+++ b/phase/initialize_k0s.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"strings"
-	"time"
 
 	"github.com/k0sproject/k0sctl/pkg/apis/k0sctl.k0sproject.io/v1beta1"
 	"github.com/k0sproject/k0sctl/pkg/apis/k0sctl.k0sproject.io/v1beta1/cluster"
@@ -116,7 +115,7 @@ func (p *InitializeK0s) Run(ctx context.Context) error {
 		}
 
 		log.Infof("%s: wait for kubernetes to reach ready state", h)
-		err := retry.AdaptiveTimeout(ctx, 30*time.Second, func(_ context.Context) error {
+		err := retry.AdaptiveTimeout(ctx, retry.DefaultTimeout, func(_ context.Context) error {
 			out, err := h.ExecOutput(h.Configurer.KubectlCmdf(h, h.K0sDataDir(), "get --raw='/readyz'"), exec.Sudo(h))
 			if out != "ok" {
 				return fmt.Errorf("kubernetes api /readyz responded with %q", out)

--- a/phase/install_controllers.go
+++ b/phase/install_controllers.go
@@ -175,7 +175,7 @@ func (p *InstallControllers) Run(ctx context.Context) error {
 				return err
 			}
 
-			err := retry.AdaptiveTimeout(ctx, 30*time.Second, func(_ context.Context) error {
+			err := retry.AdaptiveTimeout(ctx, retry.DefaultTimeout, func(_ context.Context) error {
 				out, err := h.ExecOutput(h.Configurer.KubectlCmdf(h, h.K0sDataDir(), "get --raw='/readyz?verbose=true'"), exec.Sudo(h))
 				if err != nil {
 					return fmt.Errorf("readiness endpoint reports %q: %w", out, err)


### PR DESCRIPTION
Fixes #882 

The timeout when waiting for controllers to become ready was 30 seconds. This changes the wait to use the `retry.DefaultTimeout`.
