### PR TITLE
Ensure reset operation removes kubelet-root-dir

### DIFF
--- a/configurer/linux.go
+++ b/configurer/linux.go
@@ -38,6 +38,7 @@ func (l *Linux) initPaths() {
 		"K0sConfigPath":      "/etc/k0s/k0s.yaml",
 		"K0sJoinTokenPath":   "/etc/k0s/k0stoken",
 		"DataDirDefaultPath": "/var/lib/k0s",
+		"K0sKubeletRootDir":  "/var/lib/kubelet",
 	}
 }
 
@@ -75,6 +76,15 @@ func (l *Linux) DataDirDefaultPath() string {
 
 	l.initPaths()
 	return l.paths["DataDirDefaultPath"]
+}
+
+// K0sKubeletRootDir returns the path to the k0s kubelet root dir on the host
+func (l *Linux) K0sKubeletRootDir() string {
+	l.pathMu.Lock()
+	defer l.pathMu.Unlock()
+
+	l.initPaths()
+	return l.paths["K0sKubeletRootDir"]
 }
 
 // SetPath sets a path for a key

--- a/phase/reset_controllers.go
+++ b/phase/reset_controllers.go
@@ -116,7 +116,7 @@ func (p *ResetControllers) Run(ctx context.Context) error {
 
 		log.Debugf("%s: resetting k0s...", h)
 		var stdoutbuf, stderrbuf bytes.Buffer
-		cmd, err := h.ExecStreams(h.Configurer.K0sCmdf("reset --data-dir=%s", h.K0sDataDir()), nil, &stdoutbuf, &stderrbuf, exec.Sudo(h))
+		cmd, err := h.ExecStreams(h.Configurer.K0sCmdf("reset --data-dir=%s --kubelet-root-dir=%s", h.K0sDataDir(), h.K0sKubeletRootDir()), nil, &stdoutbuf, &stderrbuf, exec.Sudo(h))
 		if err != nil {
 			return fmt.Errorf("failed to run k0s reset: %w", err)
 		}

--- a/phase/reset_leader.go
+++ b/phase/reset_leader.go
@@ -58,7 +58,7 @@ func (p *ResetLeader) Run(ctx context.Context) error {
 	}
 
 	log.Debugf("%s: resetting k0s...", p.leader)
-	out, err := p.leader.ExecOutput(p.leader.Configurer.K0sCmdf("reset --data-dir=%s", p.leader.K0sDataDir()), exec.Sudo(p.leader))
+	out, err := p.leader.ExecOutput(p.leader.Configurer.K0sCmdf("reset --data-dir=%s --kubelet-root-dir=%s", p.leader.K0sDataDir(), p.leader.K0sKubeletRootDir), exec.Sudo(p.leader))
 	if err != nil {
 		log.Debugf("%s: k0s reset failed: %s", p.leader, out)
 		log.Warnf("%s: k0s reported failure: %v", p.leader, err)

--- a/phase/reset_workers.go
+++ b/phase/reset_workers.go
@@ -107,7 +107,7 @@ func (p *ResetWorkers) Run(ctx context.Context) error {
 
 		log.Debugf("%s: resetting k0s...", h)
 		var stdoutbuf, stderrbuf bytes.Buffer
-		cmd, err := h.ExecStreams(h.Configurer.K0sCmdf("reset --data-dir=%s", h.K0sDataDir()), nil, &stdoutbuf, &stderrbuf, exec.Sudo(h))
+		cmd, err := h.ExecStreams(h.Configurer.K0sCmdf("reset --data-dir=%s --kubelet-root-dir=%s", h.K0sDataDir(), h.K0sKubeletRootDir()), nil, &stdoutbuf, &stderrbuf, exec.Sudo(h))
 		if err != nil {
 			return fmt.Errorf("failed to run k0s reset: %w", err)
 		}

--- a/pkg/apis/k0sctl.k0sproject.io/v1beta1/cluster/host.go
+++ b/pkg/apis/k0sctl.k0sproject.io/v1beta1/cluster/host.go
@@ -134,6 +134,7 @@ type configurer interface {
 	K0sBinaryVersion(os.Host) (*version.Version, error)
 	K0sConfigPath() string
 	DataDirDefaultPath() string
+	K0sKubeletRootDir() string
 	K0sJoinTokenPath() string
 	WriteFile(os.Host, string, string, string) error
 	UpdateEnvironment(os.Host, map[string]string) error
@@ -249,6 +250,15 @@ func (h *Host) ResolveConfigurer() error {
 	}
 
 	return fmt.Errorf("unsupported OS")
+}
+
+// K0sKubeletRootDir returns the kubelet root directory from install flags or configurer
+func (h *Host) K0sKubeletRootDir() string {
+	if dir := h.InstallFlags.GetValue("--kubelet-root-dir"); dir != "" {
+		return dir
+	}
+
+	return h.Configurer.K0sKubeletRootDir()
 }
 
 // K0sJoinTokenPath returns the token file path from install flags or configurer

--- a/pkg/apis/k0sctl.k0sproject.io/v1beta1/cluster/host_test.go
+++ b/pkg/apis/k0sctl.k0sproject.io/v1beta1/cluster/host_test.go
@@ -50,6 +50,14 @@ func TestK0sJoinTokenPath(t *testing.T) {
 	require.Equal(t, "from-install-flags", h.K0sJoinTokenPath())
 }
 
+func TestK0sKubeletRootDir(t *testing.T) {
+	h := Host{}
+	h.Configurer = &mockconfigurer{}
+
+	h.InstallFlags.Add("--kubelet-root-dir from-install-flags")
+	require.Equal(t, "from-install-flags", h.K0sKubeletRootDir())
+}
+
 func TestK0sConfigPath(t *testing.T) {
 	h := Host{}
 	h.Configurer = &mockconfigurer{}


### PR DESCRIPTION
Fixes https://github.com/k0sproject/k0sctl/issues/892

Verified by checking that configured kubelet root directory gets removed with this fix when it would otherwise not have been removed due to  https://github.com/k0sproject/k0sctl/issues/892