### PR TITLE
Add support for k0s v1.32.1 kubelet-root-dir

### DIFF
--- a/README.md
+++ b/README.md
@@ -310,6 +310,10 @@ Override host's hostname. When not set, the hostname reported by the operating s
 
 Set host's k0s data-dir.
 
+###### `spec.hosts[*].kubeletRootDir` &lt;string&gt; (optional) (default: `""`)
+
+Set host's k0s kubelet-root-dir.
+
 ###### `spec.hosts[*].installFlags` &lt;sequence&gt; (optional)
 
 Extra flags passed to the `k0s install` command on the target host. See `k0s install --help` for a list of options.

--- a/phase/gather_facts.go
+++ b/phase/gather_facts.go
@@ -17,8 +17,12 @@ type GatherFacts struct {
 	SkipMachineIDs bool
 }
 
-// K0s doesn't rely on unique machine IDs anymore since v1.30.
-var uniqueMachineIDSince = version.MustParse("v1.30.0")
+var (
+	// K0s doesn't rely on unique machine IDs anymore since v1.30.
+	uniqueMachineIDSince = version.MustParse("v1.30.0")
+	// --kubelet-root-dir was introduced in v1.32.1-rc.0
+	kubeletRootDirSince = version.MustParse("v1.32.1-rc.0")
+)
 
 // Title for the phase
 func (p *GatherFacts) Title() string {
@@ -81,6 +85,10 @@ func (p *GatherFacts) investigateHost(_ context.Context, h *cluster.Host) error 
 				log.Infof("%s: discovered %s as private address", h, addr)
 			}
 		}
+	}
+
+	if p.Config.Spec.K0s.Version.LessThan(kubeletRootDirSince) && h.KubeletRootDir != "" {
+		return fmt.Errorf("kubeletRootDir is not supported in k0s version %s, please remove it from the configuration", p.Config.Spec.K0s.Version)
 	}
 
 	return nil

--- a/phase/initialize_k0s.go
+++ b/phase/initialize_k0s.go
@@ -50,7 +50,7 @@ func (p *InitializeK0s) CleanUp() {
 		}
 	}
 	if h.Metadata.K0sInstalled {
-		if err := h.Exec(h.Configurer.K0sCmdf("reset --data-dir=%s", h.K0sDataDir()), exec.Sudo(h)); err != nil {
+		if err := h.Exec(h.K0sResetCommand(), exec.Sudo(h)); err != nil {
 			log.Warnf("%s: k0s reset failed", h)
 		}
 	}

--- a/phase/install_controllers.go
+++ b/phase/install_controllers.go
@@ -61,7 +61,7 @@ func (p *InstallControllers) CleanUp() {
 			}
 		}
 		if h.Metadata.K0sInstalled && p.IsWet() {
-			if err := h.Exec(h.Configurer.K0sCmdf("reset --data-dir=%s", h.K0sDataDir()), exec.Sudo(h)); err != nil {
+			if err := h.Exec(h.K0sResetCommand(), exec.Sudo(h)); err != nil {
 				log.Warnf("%s: k0s reset failed", h)
 			}
 		}

--- a/phase/install_workers.go
+++ b/phase/install_workers.go
@@ -55,7 +55,7 @@ func (p *InstallWorkers) CleanUp() {
 			}
 		}
 		if h.Metadata.K0sInstalled && p.IsWet() {
-			if err := h.Exec(h.Configurer.K0sCmdf("reset --data-dir=%s", h.K0sDataDir()), exec.Sudo(h)); err != nil {
+			if err := h.Exec(h.K0sResetCommand(), exec.Sudo(h)); err != nil {
 				log.Warnf("%s: k0s reset failed", h)
 			}
 		}

--- a/phase/reset_leader.go
+++ b/phase/reset_leader.go
@@ -58,7 +58,7 @@ func (p *ResetLeader) Run(ctx context.Context) error {
 	}
 
 	log.Debugf("%s: resetting k0s...", p.leader)
-	out, err := p.leader.ExecOutput(p.leader.Configurer.K0sCmdf("reset --data-dir=%s", p.leader.K0sDataDir()), exec.Sudo(p.leader))
+	out, err := p.leader.ExecOutput(p.leader.K0sResetCommand(), exec.Sudo(p.leader))
 	if err != nil {
 		log.Debugf("%s: k0s reset failed: %s", p.leader, out)
 		log.Warnf("%s: k0s reported failure: %v", p.leader, err)

--- a/phase/reset_workers.go
+++ b/phase/reset_workers.go
@@ -107,7 +107,7 @@ func (p *ResetWorkers) Run(ctx context.Context) error {
 
 		log.Debugf("%s: resetting k0s...", h)
 		var stdoutbuf, stderrbuf bytes.Buffer
-		cmd, err := h.ExecStreams(h.Configurer.K0sCmdf("reset --data-dir=%s", h.K0sDataDir()), nil, &stdoutbuf, &stderrbuf, exec.Sudo(h))
+		cmd, err := h.ExecStreams(h.K0sResetCommand(), nil, &stdoutbuf, &stderrbuf, exec.Sudo(h))
 		if err != nil {
 			return fmt.Errorf("failed to run k0s reset: %w", err)
 		}

--- a/smoke-test/smoke-reinstall.sh
+++ b/smoke-test/smoke-reinstall.sh
@@ -45,6 +45,8 @@ echo "Re-applying ${K0S_VERSION} with modified installFlags"
 echo "A re-apply should perform a re-install if there are changes"
 grep -iq "reinstalling" apply.log
 
+sleep 5
+
 echo "Install flags should change for controller"
 remoteCommand "root@manager0" "k0s status -o json | grep -q -- ${K0S_CONTROLLER_FLAG}"
 


### PR DESCRIPTION
Fixes #892
Closes #893 

Adds `spec.hosts[*].kubeletRootDir`. 

The value (unless empty) is passed to k0s just like `dataDir` when running `k0s install` or `k0s reset`.
