### PR TITLE
Respect concurrency limit when upgrading workers

### DIFF
--- a/phase/upgrade_workers.go
+++ b/phase/upgrade_workers.go
@@ -82,6 +82,7 @@ func (p *UpgradeWorkers) Run(ctx context.Context) error {
 	if concurrentUpgrades == 0 {
 		concurrentUpgrades = 1
 	}
+	concurrentUpgrades = min(concurrentUpgrades, p.Config.Spec.Options.Concurrency.Limit)
 
 	log.Infof("Upgrading max %d workers in parallel", concurrentUpgrades)
 	return p.hosts.BatchedParallelEach(ctx, concurrentUpgrades,


### PR DESCRIPTION
As mentioned in #895, the concurrency limit was not respected in worker upgrade batching.
