### PR TITLE
Configurable worker upgrade batch size

### DIFF
--- a/README.md
+++ b/README.md
@@ -637,6 +637,7 @@ spec:
       effect: NoExecute
     concurrency:
       limit: 30
+      workerDisruptionPercent: 10
       uploads: 5
 ```
 
@@ -699,6 +700,10 @@ Whether to also apply the taint to nodes with the controller+worker dual role. B
 ##### `spec.options.concurrency.limit` &lt;integer&gt; (optional) (default: 30)
 
 The maximum number of hosts to operate on concurrently during cluster operations. Same as the `--concurrency` command line option.
+
+##### `spec.options.concurrency.workerDisruptionPercent` &lt;integer&gt; (optional) (default: 10)
+
+The maximum percentage of worker nodes that can be disrupted at the same time during operations such as upgrade. This is used to ensure that a minimum number of worker nodes remain available during the operation. The value must be between 0 and 100.
 
 ##### `spec.options.concurrency.uploads` &lt;integer&gt; (optional) (default: 5)
 

--- a/phase/upgrade_workers.go
+++ b/phase/upgrade_workers.go
@@ -78,7 +78,7 @@ func (p *UpgradeWorkers) CleanUp() {
 // Run the phase
 func (p *UpgradeWorkers) Run(ctx context.Context) error {
 	// Upgrade worker hosts parallelly in 10% chunks
-	concurrentUpgrades := int(math.Floor(float64(len(p.hosts)) * 0.10))
+	concurrentUpgrades := int(math.Floor(float64(len(p.hosts)) * float64(p.Config.Spec.Options.Concurrency.WorkerDisruptionPercent/100)))
 	if concurrentUpgrades == 0 {
 		concurrentUpgrades = 1
 	}

--- a/pkg/apis/k0sctl.k0sproject.io/v1beta1/cluster/options.go
+++ b/pkg/apis/k0sctl.k0sproject.io/v1beta1/cluster/options.go
@@ -72,8 +72,9 @@ func (d *DrainOption) ToKubectlArgs() string {
 
 // ConcurrencyOption controls how many hosts are operated on at once.
 type ConcurrencyOption struct {
-	Limit   int `yaml:"limit" default:"30"`  // Max number of hosts to operate on at once
-	Uploads int `yaml:"uploads" default:"5"` // Max concurrent file uploads
+	Limit                   int `yaml:"limit" default:"30"`                   // Max number of hosts to operate on at once
+	WorkerDisruptionPercent int `yaml:"workerDisruptionPercent" default:"10"` // Max percentage of hosts to disrupt at once
+	Uploads                 int `yaml:"uploads" default:"5"`                  // Max concurrent file uploads
 }
 
 // UnmarshalYAML implements the yaml.Unmarshaler interface for ConcurrencyOption.


### PR DESCRIPTION
Fixes #895 

Makes the batch size of worker nodes to upgrade concurrently configurable via `spec.options.workerDisruptionPercent` (default: 10).
