### PR TITLE
feat: create docker images for `k0sctl`

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,6 +9,9 @@ jobs:
   release:
     name: release
     runs-on: ubuntu-latest
+    permissions:
+      contents: write # needed to write releases
+      packages: write # needed for ghcr access
     steps:
       - name: Check out code into the Go module directory
         uses: actions/checkout@v4
@@ -16,6 +19,13 @@ jobs:
       - name: Tag name
         id: tag-name
         run: echo "tag=${GITHUB_REF#refs/tags/}" >> "$GITHUB_OUTPUT"
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Set up Go
         uses: actions/setup-go@v5
@@ -41,3 +51,14 @@ jobs:
           name: ${{ steps.tag-name.outputs.tag }}
           draft: true # So we can manually edit before publishing
           prerelease: ${{ contains(steps.tag-name.outputs.tag, '-') }} # v0.1.2-beta1, 1.2.3-rc1
+
+      - name: Build image and push to GitHub image registry
+        uses: docker/build-push-action@v6
+        if: startsWith(github.ref, 'refs/tags/')
+        with:
+          context: .
+          platforms: linux/amd64,linux/arm64,linux/arm/v7
+          tags: |
+            ghcr.io/k0sproject/k0sctl:latest
+            ghcr.io/k0sproject/k0sctl:${{ steps.tag-name.outputs.tag }}
+          push: true

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,37 @@
+FROM golang:1.24-alpine AS builder
+
+WORKDIR /src
+
+COPY go.mod go.sum ./
+
+RUN go mod download
+
+COPY . .
+
+ARG ENVIRONMENT
+ARG GIT_COMMIT
+ARG TAG_NAME
+
+ENV CGO_ENABLED=0
+
+RUN go build -trimpath -a \
+      -tags "netgo,osusergo,static_build" \
+      -installsuffix netgo \
+      -ldflags "-s -w \
+        -X github.com/k0sproject/k0sctl/version.Environment=${ENVIRONMENT} \
+        -X github.com/carlmjohnson/versioninfo.Revision=${GIT_COMMIT} \
+        -X github.com/carlmjohnson/versioninfo.Version=${TAG_NAME} \
+        -extldflags '-static'" \
+      -o /out/k0sctl .
+
+FROM docker.io/library/alpine:latest
+
+RUN apk add --no-cache tini openssh ca-certificates
+
+COPY --from=builder /out/k0sctl /k0sctl
+
+ENTRYPOINT ["/sbin/tini", "--"]
+
+USER 65534:65534
+
+CMD ["k0sctl"]

--- a/Makefile
+++ b/Makefile
@@ -17,11 +17,41 @@ k0sctl: $(GO_SRCS)
 bin/k0sctl-linux-amd64: $(GO_SRCS)
 	GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go build $(BUILD_FLAGS) -o bin/k0sctl-linux-amd64 main.go
 
+docker/build/linux-amd64:
+	docker buildx build \
+		--platform=linux/amd64 \
+		--build-arg ENVIRONMENT=$(ENVIRONMENT) \
+		--build-arg GIT_COMMIT=$(GIT_COMMIT) \
+		--build-arg TAG_NAME=$(TAG_NAME) \
+		-t ghcr.io/k0sproject/k0sctl:$(TAG_NAME)-amd64 \
+		--load \
+		.
+
 bin/k0sctl-linux-arm64: $(GO_SRCS)
 	GOOS=linux GOARCH=arm64 CGO_ENABLED=0 go build $(BUILD_FLAGS) -o bin/k0sctl-linux-arm64 main.go
 
+docker/build/linux-arm64:
+	docker buildx build \
+		--platform=linux/arm64 \
+		--build-arg ENVIRONMENT=$(ENVIRONMENT) \
+		--build-arg GIT_COMMIT=$(GIT_COMMIT) \
+		--build-arg TAG_NAME=$(TAG_NAME) \
+		-t ghcr.io/k0sproject/k0sctl:$(TAG_NAME)-arm64 \
+		--load \
+		.
+
 bin/k0sctl-linux-arm: $(GO_SRCS)
 	GOOS=linux GOARCH=arm CGO_ENABLED=0 go build $(BUILD_FLAGS) -o bin/k0sctl-linux-arm main.go
+
+docker/build/linux-arm:
+	docker buildx build \
+		--platform=linux/arm/v7 \
+		--build-arg ENVIRONMENT=$(ENVIRONMENT) \
+		--build-arg GIT_COMMIT=$(GIT_COMMIT) \
+		--build-arg TAG_NAME=$(TAG_NAME) \
+		-t ghcr.io/k0sproject/k0sctl:$(TAG_NAME)-arm \
+		--load \
+		.
 
 bin/k0sctl-win-amd64.exe: $(GO_SRCS)
 	GOOS=windows GOARCH=amd64 go build $(BUILD_FLAGS) -o bin/k0sctl-win-amd64.exe main.go
@@ -33,6 +63,8 @@ bin/k0sctl-darwin-arm64: $(GO_SRCS)
 	GOOS=darwin GOARCH=arm64 go build $(BUILD_FLAGS) -o bin/k0sctl-darwin-arm64 main.go
 
 bins := k0sctl-linux-amd64 k0sctl-linux-arm64 k0sctl-linux-arm k0sctl-win-amd64.exe k0sctl-darwin-amd64 k0sctl-darwin-arm64
+
+dockers := linux-amd64 linux-arm64 linux-arm
 
 bin/checksums.txt: $(addprefix bin/,$(bins))
 	sha256sum -b $(addprefix bin/,$(bins)) | sed 's/bin\///' > $@
@@ -50,6 +82,10 @@ build-all: $(addprefix bin/,$(bins)) bin/checksums.md
 .PHONY: clean
 clean:
 	rm -rf bin/ k0sctl
+
+.PHONY: clean-images
+clean-images:
+	docker rmi ghcr.io/k0sproject/k0sctl:$(TAG_NAME)-amd64 ghcr.io/k0sproject/k0sctl:$(TAG_NAME)-arm64 ghcr.io/k0sproject/k0sctl:$(TAG_NAME)-arm
 
 smoketests := smoke-basic smoke-basic-rootless smoke-files smoke-upgrade smoke-reset smoke-os-override smoke-init smoke-backup-restore smoke-dynamic smoke-basic-openssh smoke-dryrun smoke-downloadurl smoke-controller-swap smoke-reinstall smoke-multidoc
 .PHONY: $(smoketests)

--- a/README.md
+++ b/README.md
@@ -68,6 +68,21 @@ Note: The [chocolatey package](https://community.chocolatey.org/packages/k0sctl)
 choco install k0sctl
 ```
 
+### Container usage
+
+It is possible to use `k0sctl` as a docker/OCI container:
+
+```sh
+# pull the image
+docker pull ghcr.io/k0sprojects/k0sctl:latest
+
+# create a backup
+docker run -it --workdir /backup \
+  -v ./backup:/backup \
+  -v ./k0sctl.yaml:/etc/k0s/k0sctl.yaml \
+  ghcr.io/k0sprojects/k0sctl:latest k0sctl backup --config /etc/k0s/k0sctl.yaml
+```
+
 #### Shell auto-completions
 
 ##### Bash


### PR DESCRIPTION
This PR adds logic to create docker images from the `k0sctl` binary on release tags, in the same vain as in the `k0s` project:

https://github.com/k0sproject/k0s/pkgs/container/k0s

