### PR TITLE
Add host.K0sInstallPath for changing k0s install location on target

### DIFF
--- a/README.md
+++ b/README.md
@@ -315,6 +315,10 @@ When `false`, the k0s binary downloading is performed on the target host itself
 
 A path to a file on the local host that contains a k0s binary to be uploaded to the host. Can be used to test drive a custom development build of k0s.
 
+###### `spec.hosts[*].k0sInstallPath` &lt;string&gt; (optional) (default: depends on OS)
+
+A path on the node where to install the k0s binary.
+
 ###### `spec.hosts[*].k0sDownloadURL` &lt;string&gt; (optional)
 
 A URL to download the k0s binary from. The default is to download from the [k0s repository](https://github.com/k0sproject/k0s). The URL can contain '%'-prefixed tokens that will be replaced with the host's information, see [tokens](#tokens).

--- a/phase/configure_k0s.go
+++ b/phase/configure_k0s.go
@@ -230,7 +230,7 @@ func (p *ConfigureK0s) validateConfig(h *cluster.Host, configPath string) error 
 	var cmd string
 
 	if h.Metadata.K0sBinaryTempFile != "" {
-		oldK0sBinaryPath := h.Configurer.K0sBinaryPath()
+		oldK0sBinaryPath := h.K0sInstallLocation()
 		h.Configurer.SetPath("K0sBinaryPath", h.Metadata.K0sBinaryTempFile)
 		defer func() {
 			h.Configurer.SetPath("K0sBinaryPath", oldK0sBinaryPath)

--- a/phase/download_k0s.go
+++ b/phase/download_k0s.go
@@ -61,7 +61,7 @@ func (p *DownloadK0s) Run(ctx context.Context) error {
 }
 
 func (p *DownloadK0s) downloadK0s(_ context.Context, h *cluster.Host) error {
-	tmp := h.Configurer.K0sBinaryPath() + ".tmp." + strconv.Itoa(int(time.Now().UnixNano()))
+	tmp := h.K0sInstallLocation() + ".tmp." + strconv.Itoa(int(time.Now().UnixNano()))
 
 	log.Infof("%s: downloading k0s %s", h, p.Config.Spec.K0s.Version)
 	if h.K0sDownloadURL != "" {

--- a/phase/initialize_k0s.go
+++ b/phase/initialize_k0s.go
@@ -77,7 +77,7 @@ func (p *InitializeK0s) Run(ctx context.Context) error {
 		return err
 	}
 
-	err = p.Wet(p.leader, fmt.Sprintf("install first k0s controller using `%s`", strings.ReplaceAll(cmd, p.leader.Configurer.K0sBinaryPath(), "k0s")), func() error {
+	err = p.Wet(p.leader, fmt.Sprintf("install first k0s controller using `%s`", strings.ReplaceAll(cmd, p.leader.K0sInstallLocation(), "k0s")), func() error {
 		return h.Exec(cmd, exec.Sudo(h))
 	}, func() error {
 		p.leader.Metadata.DryRunFakeLeader = true

--- a/phase/install_binaries.go
+++ b/phase/install_binaries.go
@@ -50,7 +50,7 @@ func (p *InstallBinaries) DryRun() error {
 		context.Background(),
 		p.Config.Spec.Hosts.Filter(func(h *cluster.Host) bool { return h.Metadata.K0sBinaryTempFile != "" }),
 		func(_ context.Context, h *cluster.Host) error {
-			p.DryMsgf(h, "install k0s %s binary from %s to %s", p.Config.Spec.K0s.Version, h.Metadata.K0sBinaryTempFile, h.Configurer.K0sBinaryPath())
+			p.DryMsgf(h, "install k0s %s binary from %s to %s", p.Config.Spec.K0s.Version, h.Metadata.K0sBinaryTempFile, h.K0sInstallLocation())
 			if err := h.Execf(`chmod +x "%s"`, h.Metadata.K0sBinaryTempFile, exec.Sudo(h)); err != nil {
 				logrus.Warnf("%s: failed to chmod k0s temp binary for dry-run: %s", h, err.Error())
 			}

--- a/phase/install_controllers.go
+++ b/phase/install_controllers.go
@@ -222,7 +222,7 @@ func (p *InstallControllers) installK0s(ctx context.Context, h *cluster.Host) er
 		return err
 	}
 	log.Infof("%s: installing k0s controller", h)
-	err = p.Wet(h, fmt.Sprintf("install k0s controller using `%s", strings.ReplaceAll(cmd, h.Configurer.K0sBinaryPath(), "k0s")), func() error {
+	err = p.Wet(h, fmt.Sprintf("install k0s controller using `%s", strings.ReplaceAll(cmd, h.K0sInstallLocation(), "k0s")), func() error {
 		var stdout, stderr bytes.Buffer
 		runner, err := h.ExecStreams(cmd, nil, &stdout, &stderr, exec.Sudo(h))
 		if err != nil {

--- a/phase/install_workers.go
+++ b/phase/install_workers.go
@@ -190,7 +190,7 @@ func (p *InstallWorkers) Run(ctx context.Context) error {
 		if err != nil {
 			return err
 		}
-		err = p.Wet(h, fmt.Sprintf("install k0s worker with `%s`", strings.ReplaceAll(cmd, h.Configurer.K0sBinaryPath(), "k0s")), func() error {
+		err = p.Wet(h, fmt.Sprintf("install k0s worker with `%s`", strings.ReplaceAll(cmd, h.K0sInstallLocation(), "k0s")), func() error {
 			return h.Exec(cmd, exec.Sudo(h))
 		})
 		if err != nil {

--- a/phase/prepare_hosts.go
+++ b/phase/prepare_hosts.go
@@ -110,5 +110,8 @@ func (p *PrepareHosts) prepareHost(ctx context.Context, h *cluster.Host) error {
 		}
 	}
 
+	// Needed to make configurer.K0sBinaryPath() to work inside the configurer itself as it can't call host.K0sInstallLocation().
+	h.Configurer.SetPath("K0sBinaryPath", h.K0sInstallLocation())
+
 	return nil
 }

--- a/phase/reinstall.go
+++ b/phase/reinstall.go
@@ -83,7 +83,7 @@ func (p *Reinstall) reinstall(ctx context.Context, h *cluster.Host) error {
 		return err
 	}
 	log.Infof("%s: reinstalling k0s", h)
-	err = p.Wet(h, fmt.Sprintf("reinstall k0s using `%s", strings.ReplaceAll(cmd, h.Configurer.K0sBinaryPath(), "k0s")), func() error {
+	err = p.Wet(h, fmt.Sprintf("reinstall k0s using `%s", strings.ReplaceAll(cmd, h.K0sInstallLocation(), "k0s")), func() error {
 		if err := h.Exec(cmd, exec.Sudo(h)); err != nil {
 			return fmt.Errorf("failed to reinstall k0s: %w", err)
 		}

--- a/phase/upload_k0s.go
+++ b/phase/upload_k0s.go
@@ -44,7 +44,7 @@ func (p *UploadK0s) Prepare(config *v1beta1.Cluster) error {
 		}
 
 		// If the file has been changed compared to local, re-upload and replace
-		return h.FileChanged(h.UploadBinaryPath, h.Configurer.K0sBinaryPath())
+		return h.FileChanged(h.UploadBinaryPath, h.K0sInstallLocation())
 	})
 	return nil
 }
@@ -60,7 +60,7 @@ func (p *UploadK0s) Run(ctx context.Context) error {
 }
 
 func (p *UploadK0s) uploadBinary(_ context.Context, h *cluster.Host) error {
-	tmp := h.Configurer.K0sBinaryPath() + ".tmp." + strconv.Itoa(int(time.Now().UnixNano()))
+	tmp := h.K0sInstallLocation() + ".tmp." + strconv.Itoa(int(time.Now().UnixNano()))
 
 	stat, err := os.Stat(h.UploadBinaryPath)
 	if err != nil {

--- a/phase/validate_hosts.go
+++ b/phase/validate_hosts.go
@@ -113,9 +113,9 @@ const cleanUpOlderThan = 30 * time.Minute
 
 // clean up any k0s.tmp.* files from K0sBinaryPath that are older than 30 minutes and warn if there are any that are newer than that
 func (p *ValidateHosts) cleanUpOldK0sTmpFiles(_ context.Context, h *cluster.Host) error {
-	err := fs.WalkDir(h.SudoFsys(), filepath.Join(filepath.Dir(h.Configurer.K0sBinaryPath()), "k0s.tmp.*"), func(path string, d fs.DirEntry, err error) error {
+	err := fs.WalkDir(h.SudoFsys(), filepath.Join(filepath.Dir(h.K0sInstallLocation()), "k0s.tmp.*"), func(path string, d fs.DirEntry, err error) error {
 		if err != nil {
-			log.Warnf("failed to walk k0s.tmp.* files in %s: %v", h.Configurer.K0sBinaryPath(), err)
+			log.Warnf("failed to walk k0s.tmp.* files in %s: %v", h.K0sInstallLocation(), err)
 			return nil
 		}
 		log.Debugf("%s: found k0s binary upload temporary file %s", h, path)
@@ -135,7 +135,7 @@ func (p *ValidateHosts) cleanUpOldK0sTmpFiles(_ context.Context, h *cluster.Host
 		return nil
 	})
 	if err != nil {
-		log.Warnf("failed to walk k0s.tmp.* files in %s: %v", h.Configurer.K0sBinaryPath(), err)
+		log.Warnf("failed to walk k0s.tmp.* files in %s: %v", h.K0sInstallPath(), err)
 	}
 	return nil
 }

--- a/pkg/apis/k0sctl.k0sproject.io/v1beta1/cluster/host.go
+++ b/pkg/apis/k0sctl.k0sproject.io/v1beta1/cluster/host.go
@@ -37,6 +37,7 @@ type Host struct {
 	Environment      map[string]string `yaml:"environment,flow,omitempty"`
 	UploadBinary     bool              `yaml:"uploadBinary,omitempty"`
 	K0sBinaryPath    string            `yaml:"k0sBinaryPath,omitempty"`
+	K0sInstallPath   string            `yaml:"k0sInstallPath,omitempty"`
 	K0sDownloadURL   string            `yaml:"k0sDownloadURL,omitempty"`
 	InstallFlags     Flags             `yaml:"installFlags,omitempty"`
 	Files            []*UploadFile     `yaml:"files,omitempty"`
@@ -260,6 +261,15 @@ func (h *Host) ResolveConfigurer() error {
 	return fmt.Errorf("unsupported OS")
 }
 
+// K0sInstallPath returns the k0s binary path from the K0sInstallPath field or configurer.K0sBinaryPath()
+func (h *Host) K0sInstallLocation() string {
+	if h.K0sInstallPath != "" {
+		return h.K0sInstallPath
+	}
+
+	return h.Configurer.K0sBinaryPath()
+}
+
 // K0sJoinTokenPath returns the token file path from install flags or configurer
 func (h *Host) K0sJoinTokenPath() string {
 	if path := h.InstallFlags.GetValue("--token-file"); path != "" {
@@ -399,7 +409,7 @@ func (h *Host) K0sServiceName() string {
 }
 
 func (h *Host) k0sBinaryPathDir() string {
-	return gopath.Dir(h.Configurer.K0sBinaryPath())
+	return gopath.Dir(h.K0sInstallLocation())
 }
 
 // InstallK0sBinary installs the k0s binary from the provided file path to K0sBinaryPath
@@ -413,7 +423,7 @@ func (h *Host) InstallK0sBinary(path string) error {
 		return fmt.Errorf("create k0s binary dir: %w", err)
 	}
 
-	if err := h.Execf(`install -m 0750 -o root -g root "%s" "%s"`, path, h.Configurer.K0sBinaryPath(), exec.Sudo(h)); err != nil {
+	if err := h.Execf(`install -m 0750 -o root -g root "%s" "%s"`, path, h.K0sInstallLocation(), exec.Sudo(h)); err != nil {
 		return fmt.Errorf("install k0s binary: %w", err)
 	}
 

--- a/smoke-test/Makefile
+++ b/smoke-test/Makefile
@@ -50,7 +50,7 @@ smoke-reset: $(bootloose) id_rsa_k0s k0sctl
 	./smoke-reset.sh
 
 smoke-os-override: $(bootloose) id_rsa_k0s k0sctl
-	BOOTLOOSE_TEMPLATE=bootloose.yaml.osoverride.tpl K0SCTL_CONFIG=k0sctl-single.yaml OS_RELEASE_PATH=$(realpath os-release) OS_OVERRIDE="ubuntu" ./smoke-basic.sh
+	BOOTLOOSE_TEMPLATE=bootloose.yaml.osoverride.tpl K0SCTL_CONFIG=k0sctl-single.yaml OS_RELEASE_PATH=$(realpath os-release) OS_OVERRIDE="ubuntu" INSTALL_PATH="/usr/local/bin/custom-k0s" ./smoke-basic.sh
 
 smoke-downloadurl: $(bootloose) id_rsa_k0s k0sctl
 	BOOTLOOSE_TEMPLATE=bootloose.yaml.single.tpl K0SCTL_CONFIG=k0sctl-downloadurl.yaml ./smoke-basic.sh

--- a/smoke-test/smoke-basic.sh
+++ b/smoke-test/smoke-basic.sh
@@ -15,6 +15,11 @@ echo "* Starting apply"
 ../k0sctl apply --config "${K0SCTL_CONFIG}" --kubeconfig-out applykubeconfig --debug
 echo "* Apply OK"
 
+if [ "${INSTALL_PATH}" != "" ]; then
+    echo "* Checking k0s binary is at the custom install path"
+    bootloose ssh root@manager0 -- test -x "${INSTALL_PATH}"
+fi
+
 echo "* Verify hooks were executed on the host"
 bootloose ssh root@manager0 -- grep -q hello apply.hook
 


### PR DESCRIPTION
Fixes #437 

Adds `k0sInstallPath` to host fields to allow overriding the install path on target.

Example:

```yaml
spec:
  hosts:
    - role: controller
      k0sInstallPath: /opt/k0s/bin/k0s
```

