### PR TITLE
Remove hardcoded retry timeouts

### DIFF
--- a/phase/configure_k0s.go
+++ b/phase/configure_k0s.go
@@ -301,7 +301,7 @@ func (p *ConfigureK0s) configureK0s(ctx context.Context, h *cluster.Host) error 
 		}
 
 		log.Infof("%s: waiting for k0s service to start", h)
-		return retry.AdaptiveTimeout(ctx, retry.DefaultTimeout, node.ServiceRunningFunc(h, h.K0sServiceName()))
+		return retry.WithDefaultTimeout(ctx, node.ServiceRunningFunc(h, h.K0sServiceName()))
 	}
 
 	return nil

--- a/phase/connect.go
+++ b/phase/connect.go
@@ -25,7 +25,7 @@ func (p *Connect) Title() string {
 // Run the phase
 func (p *Connect) Run(ctx context.Context) error {
 	return p.parallelDo(ctx, p.Config.Spec.Hosts, func(ctx context.Context, h *cluster.Host) error {
-		return retry.AdaptiveTimeout(ctx, 10*time.Minute, func(_ context.Context) error {
+		return retry.Timeout(ctx, 10*time.Minute, func(_ context.Context) error {
 			if err := h.Connect(); err != nil {
 				if errors.Is(err, rig.ErrCantConnect) || strings.Contains(err.Error(), "host key mismatch") {
 					return errors.Join(retry.ErrAbort, err)

--- a/phase/initialize_k0s.go
+++ b/phase/initialize_k0s.go
@@ -15,8 +15,8 @@ import (
 
 // InitializeK0s sets up the "initial" k0s controller
 type InitializeK0s struct {
-    GenericPhase
-    leader *cluster.Host
+	GenericPhase
+	leader *cluster.Host
 }
 
 // Title for the phase
@@ -36,18 +36,18 @@ func (p *InitializeK0s) Prepare(config *v1beta1.Cluster) error {
 
 // Before runs "before install" hooks for the leader controller
 func (p *InitializeK0s) Before() error {
-    if p.leader == nil || p.leader.Reset {
-        return nil
-    }
-    return p.runHooks(context.Background(), "install", "before", p.leader)
+	if p.leader == nil || p.leader.Reset {
+		return nil
+	}
+	return p.runHooks(context.Background(), "install", "before", p.leader)
 }
 
 // After runs "after install" hooks for the leader controller
 func (p *InitializeK0s) After() error {
-    if p.leader == nil || p.leader.Reset {
-        return nil
-    }
-    return p.runHooks(context.Background(), "install", "after", p.leader)
+	if p.leader == nil || p.leader.Reset {
+		return nil
+	}
+	return p.runHooks(context.Background(), "install", "after", p.leader)
 }
 
 // ShouldRun is true when there is a leader host
@@ -126,12 +126,12 @@ func (p *InitializeK0s) Run(ctx context.Context) error {
 		}
 
 		log.Infof("%s: waiting for the k0s service to start", h)
-		if err := retry.AdaptiveTimeout(ctx, retry.DefaultTimeout, node.ServiceRunningFunc(h, h.K0sServiceName())); err != nil {
+		if err := retry.WithDefaultTimeout(ctx, node.ServiceRunningFunc(h, h.K0sServiceName())); err != nil {
 			return err
 		}
 
 		log.Infof("%s: wait for kubernetes to reach ready state", h)
-		err := retry.AdaptiveTimeout(ctx, retry.DefaultTimeout, func(_ context.Context) error {
+		err := retry.WithDefaultTimeout(ctx, func(_ context.Context) error {
 			out, err := h.ExecOutput(h.Configurer.KubectlCmdf(h, h.K0sDataDir(), "get --raw='/readyz'"), exec.Sudo(h))
 			if out != "ok" {
 				return fmt.Errorf("kubernetes api /readyz responded with %q", out)
@@ -151,7 +151,7 @@ func (p *InitializeK0s) Run(ctx context.Context) error {
 	}
 
 	if p.IsWet() && p.Config.Spec.K0s.DynamicConfig {
-		if err := retry.AdaptiveTimeout(ctx, retry.DefaultTimeout, node.K0sDynamicConfigReadyFunc(h)); err != nil {
+		if err := retry.WithDefaultTimeout(ctx, node.K0sDynamicConfigReadyFunc(h)); err != nil {
 			return fmt.Errorf("dynamic config reconciliation failed: %w", err)
 		}
 	}

--- a/phase/install_controllers.go
+++ b/phase/install_controllers.go
@@ -50,10 +50,10 @@ func (p *InstallControllers) ShouldRun() bool {
 
 // Before runs "before install" hooks for controller hosts
 func (p *InstallControllers) Before() error {
-    if len(p.hosts) == 0 {
-        return nil
-    }
-    return p.runHooks(context.Background(), "install", "before", p.hosts...)
+	if len(p.hosts) == 0 {
+		return nil
+	}
+	return p.runHooks(context.Background(), "install", "before", p.hosts...)
 }
 
 // CleanUp cleans up the environment override files on hosts
@@ -78,10 +78,10 @@ func (p *InstallControllers) CleanUp() {
 
 // After runs "after install" hooks for controller hosts and cleans up tokens
 func (p *InstallControllers) After() error {
-    // Run "after install" hooks for controllers first
-    if err := p.runHooks(context.Background(), "install", "after", p.hosts...); err != nil {
-        return err
-    }
+	// Run "after install" hooks for controllers first
+	if err := p.runHooks(context.Background(), "install", "after", p.hosts...); err != nil {
+		return err
+	}
 	for i, h := range p.hosts {
 		if h.Metadata.K0sTokenData.Token == "" {
 			continue
@@ -132,7 +132,7 @@ func (p *InstallControllers) Run(ctx context.Context) error {
 	err := p.parallelDo(ctx, p.hosts, func(_ context.Context, h *cluster.Host) error {
 		if p.IsWet() || !p.leader.Metadata.DryRunFakeLeader {
 			log.Infof("%s: validating api connection to %s", h, h.Metadata.K0sTokenData.URL)
-			if err := retry.AdaptiveTimeout(ctx, 30*time.Second, node.HTTPStatusFunc(h, h.Metadata.K0sTokenData.URL, 200, 401, 404)); err != nil {
+			if err := retry.WithDefaultTimeout(ctx, node.HTTPStatusFunc(h, h.Metadata.K0sTokenData.URL, 200, 401, 404)); err != nil {
 				return fmt.Errorf("failed to connect from controller to kubernetes api - check networking: %w", err)
 			}
 		} else {
@@ -268,11 +268,11 @@ func (p *InstallControllers) installK0s(ctx context.Context, h *cluster.Host) er
 		}
 
 		log.Infof("%s: waiting for the k0s service to start", h)
-		if err := retry.AdaptiveTimeout(ctx, retry.DefaultTimeout, node.ServiceRunningFunc(h, h.K0sServiceName())); err != nil {
+		if err := retry.WithDefaultTimeout(ctx, node.ServiceRunningFunc(h, h.K0sServiceName())); err != nil {
 			return err
 		}
 
-		err := retry.AdaptiveTimeout(ctx, retry.DefaultTimeout, func(_ context.Context) error {
+		err := retry.WithDefaultTimeout(ctx, func(_ context.Context) error {
 			out, err := h.ExecOutput(h.Configurer.KubectlCmdf(h, h.K0sDataDir(), "get --raw='/readyz?verbose=true'"), exec.Sudo(h))
 			if err != nil {
 				return fmt.Errorf("readiness endpoint reports %q: %w", out, err)

--- a/phase/prepare_hosts.go
+++ b/phase/prepare_hosts.go
@@ -53,7 +53,7 @@ func (p *PrepareHosts) updateEnvironment(ctx context.Context, h *cluster.Host) e
 	// server configuration (sshd only accepts LC_* variables by default).
 	log.Infof("%s: reconnecting to apply new environment", h)
 	h.Disconnect()
-	return retry.AdaptiveTimeout(ctx, 10*time.Minute, func(_ context.Context) error {
+	return retry.Timeout(ctx, 10*time.Minute, func(_ context.Context) error {
 		if err := h.Connect(); err != nil {
 			if errors.Is(err, rig.ErrCantConnect) || strings.Contains(err.Error(), "host key mismatch") {
 				return errors.Join(retry.ErrAbort, err)

--- a/phase/reinstall.go
+++ b/phase/reinstall.go
@@ -98,7 +98,7 @@ func (p *Reinstall) reinstall(ctx context.Context, h *cluster.Host) error {
 			return fmt.Errorf("failed to restart k0s: %w", err)
 		}
 		log.Infof("%s: waiting for the k0s service to start", h)
-		if err := retry.AdaptiveTimeout(ctx, retry.DefaultTimeout, node.ServiceRunningFunc(h, h.K0sServiceName())); err != nil {
+		if err := retry.WithDefaultTimeout(ctx, node.ServiceRunningFunc(h, h.K0sServiceName())); err != nil {
 			return fmt.Errorf("k0s did not restart: %w", err)
 		}
 		return nil

--- a/phase/reset_controllers.go
+++ b/phase/reset_controllers.go
@@ -28,17 +28,17 @@ type ResetControllers struct {
 
 // Title for the phase
 func (p *ResetControllers) Title() string {
-    return "Reset controllers"
+	return "Reset controllers"
 }
 
 // Before runs "before reset" hooks
 func (p *ResetControllers) Before() error {
-    return p.runHooks(context.Background(), "reset", "before", p.hosts...)
+	return p.runHooks(context.Background(), "reset", "before", p.hosts...)
 }
 
 // After runs "after reset" hooks
 func (p *ResetControllers) After() error {
-    return p.runHooks(context.Background(), "reset", "after", p.hosts...)
+	return p.runHooks(context.Background(), "reset", "after", p.hosts...)
 }
 
 // Prepare the phase
@@ -109,7 +109,7 @@ func (p *ResetControllers) Run(ctx context.Context) error {
 				log.Warnf("%s: failed to stop k0s: %s", h, err.Error())
 			}
 			log.Debugf("%s: waiting for k0s to stop", h)
-			if err := retry.AdaptiveTimeout(ctx, retry.DefaultTimeout, node.ServiceStoppedFunc(h, h.K0sServiceName())); err != nil {
+			if err := retry.WithDefaultTimeout(ctx, node.ServiceStoppedFunc(h, h.K0sServiceName())); err != nil {
 				log.Warnf("%s: failed to wait for k0s to stop: %v", h, err)
 			}
 			log.Debugf("%s: stopping k0s completed", h)

--- a/phase/reset_leader.go
+++ b/phase/reset_leader.go
@@ -20,17 +20,17 @@ type ResetLeader struct {
 
 // Title for the phase
 func (p *ResetLeader) Title() string {
-    return "Reset leader"
+	return "Reset leader"
 }
 
 // Before runs "before reset" hooks
 func (p *ResetLeader) Before() error {
-    return p.runHooks(context.Background(), "reset", "before", p.leader)
+	return p.runHooks(context.Background(), "reset", "before", p.leader)
 }
 
 // After runs "after backup" hooks
 func (p *ResetLeader) After() error {
-    return p.runHooks(context.Background(), "reset", "after", p.leader)
+	return p.runHooks(context.Background(), "reset", "after", p.leader)
 }
 
 // Prepare the phase
@@ -61,7 +61,7 @@ func (p *ResetLeader) Run(ctx context.Context) error {
 			log.Warnf("%s: failed to stop k0s: %s", p.leader, err.Error())
 		}
 		log.Debugf("%s: waiting for k0s to stop", p.leader)
-		if err := retry.AdaptiveTimeout(ctx, retry.DefaultTimeout, node.ServiceStoppedFunc(p.leader, p.leader.K0sServiceName())); err != nil {
+		if err := retry.WithDefaultTimeout(ctx, node.ServiceStoppedFunc(p.leader, p.leader.K0sServiceName())); err != nil {
 			log.Warnf("%s: k0s service stop: %s", p.leader, err.Error())
 		}
 		log.Debugf("%s: stopping k0s completed", p.leader)

--- a/phase/reset_workers.go
+++ b/phase/reset_workers.go
@@ -27,7 +27,7 @@ type ResetWorkers struct {
 
 // Title for the phase
 func (p *ResetWorkers) Title() string {
-    return "Reset workers"
+	return "Reset workers"
 }
 
 // Prepare the phase
@@ -46,12 +46,12 @@ func (p *ResetWorkers) Prepare(config *v1beta1.Cluster) error {
 
 // Before runs "before reset" hooks
 func (p *ResetWorkers) Before() error {
-    return p.runHooks(context.Background(), "reset", "before", p.hosts...)
+	return p.runHooks(context.Background(), "reset", "before", p.hosts...)
 }
 
 // After runs "after reset" hooks
 func (p *ResetWorkers) After() error {
-    return p.runHooks(context.Background(), "reset", "after", p.hosts...)
+	return p.runHooks(context.Background(), "reset", "after", p.hosts...)
 }
 
 // ShouldRun is true when there are workers that needs to be reset
@@ -109,7 +109,7 @@ func (p *ResetWorkers) Run(ctx context.Context) error {
 				log.Warnf("%s: failed to stop k0s: %s", h, err.Error())
 			}
 			log.Debugf("%s: waiting for k0s to stop", h)
-			if err := retry.AdaptiveTimeout(ctx, retry.DefaultTimeout, node.ServiceStoppedFunc(h, h.K0sServiceName())); err != nil {
+			if err := retry.WithDefaultTimeout(ctx, node.ServiceStoppedFunc(h, h.K0sServiceName())); err != nil {
 				log.Warnf("%s: failed to wait for k0s to stop: %s", h, err.Error())
 			}
 			log.Debugf("%s: stopping k0s completed", h)

--- a/phase/upgrade_workers.go
+++ b/phase/upgrade_workers.go
@@ -56,23 +56,23 @@ func (p *UpgradeWorkers) Prepare(config *v1beta1.Cluster) error {
 
 // ShouldRun is true when there are workers that needs to be upgraded
 func (p *UpgradeWorkers) ShouldRun() bool {
-    return len(p.hosts) > 0
+	return len(p.hosts) > 0
 }
 
 // Before runs "before upgrade" hooks for worker hosts that need upgrade
 func (p *UpgradeWorkers) Before() error {
-    if len(p.hosts) == 0 {
-        return nil
-    }
-    return p.runHooks(context.Background(), "upgrade", "before", p.hosts...)
+	if len(p.hosts) == 0 {
+		return nil
+	}
+	return p.runHooks(context.Background(), "upgrade", "before", p.hosts...)
 }
 
 // After runs "after upgrade" hooks for worker hosts that were upgraded
 func (p *UpgradeWorkers) After() error {
-    if len(p.hosts) == 0 {
-        return nil
-    }
-    return p.runHooks(context.Background(), "upgrade", "after", p.hosts...)
+	if len(p.hosts) == 0 {
+		return nil
+	}
+	return p.runHooks(context.Background(), "upgrade", "after", p.hosts...)
 }
 
 // CleanUp cleans up the environment override files on hosts
@@ -193,7 +193,7 @@ func (p *UpgradeWorkers) upgradeWorker(ctx context.Context, h *cluster.Host) err
 			return err
 		}
 
-		if err := retry.AdaptiveTimeout(ctx, retry.DefaultTimeout, node.ServiceStoppedFunc(h, h.K0sServiceName())); err != nil {
+		if err := retry.WithDefaultTimeout(ctx, node.ServiceStoppedFunc(h, h.K0sServiceName())); err != nil {
 			return err
 		}
 
@@ -247,7 +247,7 @@ func (p *UpgradeWorkers) upgradeWorker(ctx context.Context, h *cluster.Host) err
 			log.Debugf("%s: not waiting because --no-wait given", h)
 		} else {
 			log.Infof("%s: waiting for node to become ready again", h)
-			if err := retry.AdaptiveTimeout(ctx, retry.DefaultTimeout, node.KubeNodeReadyFunc(h)); err != nil {
+			if err := retry.WithDefaultTimeout(ctx, node.KubeNodeReadyFunc(h)); err != nil {
 				return fmt.Errorf("node did not become ready: %w", err)
 			}
 		}

--- a/pkg/apis/k0sctl.k0sproject.io/v1beta1/cluster/k0s.go
+++ b/pkg/apis/k0sctl.k0sproject.io/v1beta1/cluster/k0s.go
@@ -158,7 +158,7 @@ func (k *K0s) GenerateToken(ctx context.Context, h *Host, role string, expiry ti
 	}
 
 	var token string
-	err := retry.AdaptiveTimeout(ctx, retry.DefaultTimeout, func(_ context.Context) error {
+	err := retry.WithDefaultTimeout(ctx, func(_ context.Context) error {
 		output, err := h.ExecOutput(h.Configurer.K0sCmdf("token create %s", k0sFlags.Join()), exec.HideOutput(), exec.Sudo(h))
 		if err != nil {
 			return fmt.Errorf("create token: %w", err)


### PR DESCRIPTION
Fixes #954 

- Remove `retry.AdaptiveTimeout` which was redundant, the `context` package already internally does what it was doing.
- Add a `retry.WithDefaultTimeout` that can be used as a shorthand for `retry.Timeout(ctx, retry.DefaultTimeout, func(..))`.
- Replace usages of `retry.AdaptiveTimeout` with `retry.Timeout` or `retry.WithDefaultTimeout`.
- Replace hardcoded `30*time.Second` durations at call sites with calls to`retry.WithDefaultTimeout` instead.
