### PR TITLE
Fix ineffective boolean options

### DIFF
--- a/cmd/apply.go
+++ b/cmd/apply.go
@@ -113,7 +113,7 @@ var applyCommand = &cli.Command{
 			KubeconfigAPIAddress:  ctx.String("kubeconfig-api-address"),
 			KubeconfigUser:        ctx.String("kubeconfig-user"),
 			KubeconfigCluster:     ctx.String("kubeconfig-cluster"),
-			NoWait:                ctx.Bool("no-wait") || !manager.Config.Spec.Options.Wait.Enabled,
+			NoWait:                ctx.Bool("no-wait") || !manager.Config.Spec.Options.Wait.EnabledValue(),
 			NoDrain:               getNoDrainFlagOrConfig(ctx, manager.Config.Spec.Options.Drain),
 			DisableDowngradeCheck: ctx.Bool("disable-downgrade-check"),
 			RestoreFrom:           ctx.String("restore-from"),
@@ -134,5 +134,5 @@ func getNoDrainFlagOrConfig(ctx *cli.Context, drain cluster.DrainOption) bool {
 	if ctx.IsSet("no-drain") {
 		return ctx.Bool("no-drain")
 	}
-	return !drain.Enabled
+	return !drain.EnabledValue()
 }

--- a/cmd/apply_test.go
+++ b/cmd/apply_test.go
@@ -15,12 +15,12 @@ func TestGetNoDrainFlagOrConfig(t *testing.T) {
 	app := cli.NewApp()
 	ctx := cli.NewContext(app, set, nil)
 
-	cfg := cluster.DrainOption{Enabled: true}
+	cfg := cluster.DrainOption{Enabled: boolPtr(true)}
 	if got := getNoDrainFlagOrConfig(ctx, cfg); got {
 		t.Errorf("Expected false when config.Enabled is true and flag not set, got true")
 	}
 
-	cfg.Enabled = false
+	cfg.Enabled = boolPtr(false)
 	if got := getNoDrainFlagOrConfig(ctx, cfg); !got {
 		t.Errorf("Expected true when config.Enabled is false and flag not set, got false")
 	}
@@ -34,4 +34,8 @@ func TestGetNoDrainFlagOrConfig(t *testing.T) {
 	if got := getNoDrainFlagOrConfig(ctx, cfg); got {
 		t.Errorf("Expected false when flag is set to false, got true")
 	}
+}
+
+func boolPtr(value bool) *bool {
+	return &value
 }

--- a/pkg/apis/k0sctl.k0sproject.io/v1beta1/cluster/options.go
+++ b/pkg/apis/k0sctl.k0sproject.io/v1beta1/cluster/options.go
@@ -37,26 +37,43 @@ func (o *Options) UnmarshalYAML(unmarshal func(interface{}) error) error {
 
 // WaitOption controls the wait behavior for cluster operations.
 type WaitOption struct {
-	Enabled bool `yaml:"enabled" default:"true"`
+	Enabled *bool `yaml:"enabled" default:"true"`
 }
 
 // DrainOption controls the drain behavior for cluster operations.
 type DrainOption struct {
-	Enabled                  bool          `yaml:"enabled" default:"true"`
+	Enabled                  *bool         `yaml:"enabled" default:"true"`
 	GracePeriod              time.Duration `yaml:"gracePeriod" default:"120s"`
 	Timeout                  time.Duration `yaml:"timeout" default:"300s"`
-	Force                    bool          `yaml:"force" default:"true"`
-	IgnoreDaemonSets         bool          `yaml:"ignoreDaemonSets" default:"true"`
-	DeleteEmptyDirData       bool          `yaml:"deleteEmptyDirData" default:"true"`
+	Force                    *bool         `yaml:"force" default:"true"`
+	IgnoreDaemonSets         *bool         `yaml:"ignoreDaemonSets" default:"true"`
+	DeleteEmptyDirData       *bool         `yaml:"deleteEmptyDirData" default:"true"`
 	PodSelector              string        `yaml:"podSelector" default:""`
 	SkipWaitForDeleteTimeout time.Duration `yaml:"skipWaitForDeleteTimeout" default:"0s"`
+}
+
+// EnabledValue returns the effective enabled flag, defaulting to true when unset.
+func (w WaitOption) EnabledValue() bool {
+	return boolPtrValue(w.Enabled, true)
+}
+
+// EnabledValue returns the effective enabled flag, defaulting to true when unset.
+func (d DrainOption) EnabledValue() bool {
+	return boolPtrValue(d.Enabled, true)
+}
+
+func boolPtrValue(value *bool, def bool) bool {
+	if value == nil {
+		return def
+	}
+	return *value
 }
 
 // ToKubectlArgs converts the DrainOption to kubectl arguments.
 func (d *DrainOption) ToKubectlArgs() string {
 	args := []string{}
 
-	if d.Force {
+	if boolPtrValue(d.Force, true) {
 		args = append(args, "--force")
 	}
 
@@ -76,11 +93,11 @@ func (d *DrainOption) ToKubectlArgs() string {
 		args = append(args, fmt.Sprintf("--skip-wait-for-delete-timeout=%s", d.SkipWaitForDeleteTimeout))
 	}
 
-	if d.DeleteEmptyDirData {
+	if boolPtrValue(d.DeleteEmptyDirData, true) {
 		args = append(args, "--delete-emptydir-data")
 	}
 
-	if d.IgnoreDaemonSets {
+	if boolPtrValue(d.IgnoreDaemonSets, true) {
 		args = append(args, "--ignore-daemonsets")
 	}
 


### PR DESCRIPTION
Fixes #977 

The boolean options with default value true were always being set back to true if you tried to set them false.
