### PR TITLE
`manager.Run()` set right log level for printing k0sctl config

### DIFF
--- a/phase/manager.go
+++ b/phase/manager.go
@@ -192,7 +192,7 @@ func (m *Manager) Run(ctx context.Context) error {
 		return fmt.Errorf("failed to set defaults: %w", err)
 	}
 	log.Debug("final configuration:")
-	log.Print(m.Config.String())
+	log.Debug(m.Config.String())
 
 	defer func() {
 		if m.DryRun {


### PR DESCRIPTION
Reason for the change - 
k0sctl prints it's config when `manager.Run()` called and prints it with Info level (note the last line in the output)
```
time="2025-11-19T10:00:26+02:00" level=debug msg="setting defaults"
time="2025-11-19T10:00:26+02:00" level=debug msg="final configuration:"
time="2025-11-19T10:00:26+02:00" level=info msg="apiVersion: k0sctl.k0sproject.io/v1beta1\nkind: Cluster\nmetadata:\n
```
With the fix it looks like (note that last line is printed with debug level):
```
time="2025-11-19T09:56:25+02:00" level=debug msg="setting defaults"
time="2025-11-19T09:56:25+02:00" level=debug msg="final configuration:"
time="2025-11-19T09:56:25+02:00" level=debug msg="apiVersion: k0sctl.k0sproject.io/v1beta1\nkind: Cluster\nmetadata:\n  
```
If log level set to INFO these lines are not printed
```
time="2025-11-19T09:56:25+02:00" level=debug msg="setting defaults"
time="2025-11-19T09:56:25+02:00" level=debug msg="final configuration:"
```
But config is printed that confuses, and looks like it is too verbose for INFO level.