### PR TITLE
Fix URL in README docker example

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,13 +76,13 @@ It is possible to use `k0sctl` as a docker/OCI container:
 
 ```sh
 # pull the image
-docker pull ghcr.io/k0sprojects/k0sctl:latest
+docker pull ghcr.io/k0sproject/k0sctl:latest
 
 # create a backup
 docker run -it --workdir /backup \
   -v ./backup:/backup \
   -v ./k0sctl.yaml:/etc/k0s/k0sctl.yaml \
-  ghcr.io/k0sprojects/k0sctl:latest k0sctl backup --config /etc/k0s/k0sctl.yaml
+  ghcr.io/k0sproject/k0sctl:latest k0sctl backup --config /etc/k0s/k0sctl.yaml
 ```
 
 #### Shell auto-completions


### PR DESCRIPTION
Fixes #981 

The docker example in README.md had `kosprojects` instead of `k0sproject`.