### PR TITLE
Fix missing kubelet-dir from controller reset command

### DIFF
--- a/phase/reset_controllers.go
+++ b/phase/reset_controllers.go
@@ -126,7 +126,7 @@ func (p *ResetControllers) Run(ctx context.Context) error {
 
 		log.Debugf("%s: resetting k0s...", h)
 		var stdoutbuf, stderrbuf bytes.Buffer
-		cmd, err := h.ExecStreams(h.Configurer.K0sCmdf("reset --data-dir=%s", h.K0sDataDir()), nil, &stdoutbuf, &stderrbuf, exec.Sudo(h))
+		cmd, err := h.ExecStreams(h.K0sResetCommand(), nil, &stdoutbuf, &stderrbuf, exec.Sudo(h))
 		if err != nil {
 			return fmt.Errorf("failed to run k0s reset: %w", err)
 		}


### PR DESCRIPTION
Fixes #986 

The `reset_controllers.go` phase was not calling the `h.K0sResetCommand` which deals with building the flags.
