### PR TITLE
Add host.useExistingK0s to use preinstalled k0s binary on node

### DIFF
--- a/README.md
+++ b/README.md
@@ -315,6 +315,10 @@ When `true` and used in conjuction with the `controller+worker` role, the defaul
 When `true`, the k0s binaries for target host will be downloaded and cached on the local host and uploaded to the target.
 When `false`, the k0s binary downloading is performed on the target host itself
 
+###### `spec.hosts[*].useExistingK0s` &lt;boolean&gt; (optional) (default: `false`)
+
+When `true`, k0sctl reuses the k0s binary that already exists on the host. No binary downloads or uploads are performed, and upgrades for the host are skipped. This option cannot be combined with `uploadBinary`, `k0sBinaryPath`, or `k0sDownloadURL`.
+
 ###### `spec.hosts[*].k0sBinaryPath` &lt;string&gt; (optional)
 
 A path to a file on the local host that contains a k0s binary to be uploaded to the host. Can be used to test drive a custom development build of k0s.

--- a/phase/download_binaries.go
+++ b/phase/download_binaries.go
@@ -31,7 +31,7 @@ func (p *DownloadBinaries) Title() string {
 func (p *DownloadBinaries) Prepare(config *v1beta1.Cluster) error {
 	p.Config = config
 	p.hosts = p.Config.Spec.Hosts.Filter(func(h *cluster.Host) bool {
-		return !h.Reset && h.UploadBinary && !h.Metadata.K0sBinaryVersion.Equal(config.Spec.K0s.Version)
+		return !h.Reset && h.UploadBinary && !h.UseExistingK0s && !h.Metadata.K0sBinaryVersion.Equal(config.Spec.K0s.Version)
 	})
 	return nil
 }

--- a/phase/download_k0s.go
+++ b/phase/download_k0s.go
@@ -28,6 +28,9 @@ func (p *DownloadK0s) Prepare(config *v1beta1.Cluster) error {
 	p.Config = config
 
 	p.hosts = p.Config.Spec.Hosts.Filter(func(h *cluster.Host) bool {
+		if h.UseExistingK0s {
+			return false
+		}
 		// Nothing to download
 		if h.UploadBinary {
 			return false

--- a/phase/gather_k0s_facts_test.go
+++ b/phase/gather_k0s_facts_test.go
@@ -30,4 +30,43 @@ func TestNeedsUpgrade(t *testing.T) {
 	require.False(t, p.needsUpgrade(h))
 	h.Metadata.K0sRunningVersion = version.MustParse("1.23.3+k0s.0")
 	require.True(t, p.needsUpgrade(h))
+	h.UseExistingK0s = true
+	require.False(t, p.needsUpgrade(h))
+}
+
+func TestReportUseExistingHostsDryMessages(t *testing.T) {
+	clusterVersion := version.MustParse("1.24.0+k0s.0")
+	h := &cluster.Host{
+		UseExistingK0s: true,
+		Metadata: cluster.HostMetadata{
+			K0sBinaryVersion: version.MustParse("1.23.0+k0s.0"),
+		},
+	}
+	cfg := &v1beta1.Cluster{
+		Spec: &cluster.Spec{
+			Hosts: cluster.Hosts{h},
+			K0s:   &cluster.K0s{Version: clusterVersion},
+		},
+	}
+	p := GatherK0sFacts{GenericPhase: GenericPhase{Config: cfg}}
+	mgr := &Manager{DryRun: true, Config: cfg}
+	p.SetManager(mgr)
+	require.NoError(t, p.reportUseExistingHosts())
+	require.Len(t, mgr.dryMessages, 1)
+	for _, msgs := range mgr.dryMessages {
+		require.Len(t, msgs, 2)
+		require.Contains(t, msgs[0], "reuse existing k0s v1.23.0+k0s.0")
+		require.Contains(t, msgs[1], "WARNING")
+	}
+}
+
+func TestReportUseExistingHostsFailsWithoutBinary(t *testing.T) {
+	h := &cluster.Host{UseExistingK0s: true}
+	cfg := &v1beta1.Cluster{
+		Spec: &cluster.Spec{Hosts: cluster.Hosts{h}},
+	}
+	p := GatherK0sFacts{GenericPhase: GenericPhase{Config: cfg}}
+	mgr := &Manager{Config: cfg}
+	p.SetManager(mgr)
+	require.ErrorContains(t, p.reportUseExistingHosts(), "useExistingK0s=true but no k0s binary found on host")
 }

--- a/phase/install_binaries.go
+++ b/phase/install_binaries.go
@@ -34,6 +34,9 @@ func (p *InstallBinaries) Prepare(config *v1beta1.Cluster) error {
 			return false
 		}
 
+		if h.UseExistingK0s {
+			return false
+		}
 		return h.Metadata.K0sBinaryTempFile != ""
 	})
 	return nil

--- a/phase/upload_k0s.go
+++ b/phase/upload_k0s.go
@@ -28,6 +28,9 @@ func (p *UploadK0s) Title() string {
 func (p *UploadK0s) Prepare(config *v1beta1.Cluster) error {
 	p.Config = config
 	p.hosts = p.Config.Spec.Hosts.Filter(func(h *cluster.Host) bool {
+		if h.UseExistingK0s {
+			return false
+		}
 		// Nothing to upload
 		if h.UploadBinaryPath == "" {
 			return false

--- a/pkg/apis/k0sctl.k0sproject.io/v1beta1/cluster/host_test.go
+++ b/pkg/apis/k0sctl.k0sproject.io/v1beta1/cluster/host_test.go
@@ -142,6 +142,18 @@ func TestValidation(t *testing.T) {
 		h.InstallFlags = []string{"--bar='"}
 		require.ErrorContains(t, h.Validate(), "unbalanced quotes")
 	})
+	t.Run("useExistingK0s", func(t *testing.T) {
+		h := Host{Role: "worker", UseExistingK0s: true, UploadBinary: true}
+		require.ErrorContains(t, h.Validate(), "uploadBinary cannot be true")
+		h.UploadBinary = false
+		h.K0sBinaryPath = "/tmp/k0s"
+		require.ErrorContains(t, h.Validate(), "k0sBinaryPath cannot be set")
+		h.K0sBinaryPath = ""
+		h.K0sDownloadURL = "https://example.test/k0s"
+		require.ErrorContains(t, h.Validate(), "k0sDownloadURL cannot be set")
+		h.K0sDownloadURL = ""
+		require.NoError(t, h.Validate())
+	})
 }
 
 func TestBinaryPath(t *testing.T) {


### PR DESCRIPTION
For special occasions, skip all uploading/downloading of k0s binaries and just accept the version that is on the host already.

```yaml
spec:
  hosts:
    - role: controller
      useExistingK0s: true
```
