### PR TITLE
Ignore Roles when running `reset` with `--force`

### DIFF
--- a/action/reset.go
+++ b/action/reset.go
@@ -42,13 +42,15 @@ func (r Reset) Run(ctx context.Context) error {
 	}
 
 	lockPhase := &phase.Lock{}
-    r.Manager.AddPhase(
-        &phase.Connect{},
-        &phase.DetectOS{},
-        lockPhase,
+	r.Manager.AddPhase(
+		&phase.Connect{},
+		&phase.DetectOS{},
+		lockPhase,
 		&phase.PrepareHosts{},
 		&phase.GatherFacts{SkipMachineIDs: true},
-		&phase.GatherK0sFacts{},
+		&phase.GatherK0sFacts{
+			IgnoreNodeRoleMismatch: phase.Force,
+		},
 		&phase.ResetWorkers{
 			NoDrain:  true,
 			NoDelete: true,

--- a/phase/gather_k0s_facts.go
+++ b/phase/gather_k0s_facts.go
@@ -41,8 +41,9 @@ func (k *k0sstatus) isSingle() bool {
 // GatherK0sFacts gathers information about hosts, such as if k0s is already up and running
 type GatherK0sFacts struct {
 	GenericPhase
-	leader *cluster.Host
-	hosts  cluster.Hosts
+	leader                 *cluster.Host
+	hosts                  cluster.Hosts
+	IgnoreNodeRoleMismatch bool
 }
 
 // Title for the phase
@@ -341,7 +342,7 @@ func (p *GatherK0sFacts) investigateK0s(ctx context.Context, h *cluster.Host) er
 		}
 	}
 
-	if status.Role != h.Role {
+	if !p.IgnoreNodeRoleMismatch && status.Role != h.Role {
 		return fmt.Errorf("%s: is configured as k0s %s but is already running as %s - role change is not supported", h, h.Role, status.Role)
 	}
 


### PR DESCRIPTION
Simply ignore the existing node role and the role from the config file when the k0sctl reset command is called with --force flag.

For issue #1004 