### PR TITLE
Allow host role mismatch when resetting nodes if --force given

### DIFF
--- a/phase/gather_k0s_facts.go
+++ b/phase/gather_k0s_facts.go
@@ -342,12 +342,9 @@ func (p *GatherK0sFacts) investigateK0s(ctx context.Context, h *cluster.Host) er
 	}
 
 	if status.Role != h.Role {
-		if !h.Reset || h.Role == "worker" || status.Role == "worker" {
-			return fmt.Errorf("%s: is configured as k0s %s but is already running as %s - role change is not supported", h, h.Role, status.Role)
+		if err := p.handleRoleMismatch(h, status.Role); err != nil {
+			return err
 		}
-
-		log.Warnf("%s: was configured as %s but is already running as %s - proceeding with reset using the discovered role", h, h.Role, status.Role)
-		h.Role = status.Role
 	}
 
 	h.Metadata.K0sRunningVersion = status.Version
@@ -407,6 +404,20 @@ func (p *GatherK0sFacts) investigateK0s(ctx context.Context, h *cluster.Host) er
 		}
 	}
 
+	return nil
+}
+
+func (p *GatherK0sFacts) handleRoleMismatch(h *cluster.Host, detectedRole string) error {
+	if !h.Reset {
+		return fmt.Errorf("%s: is configured as k0s %s but is already running as %s - role change is not supported", h, h.Role, detectedRole)
+	}
+
+	if !Force {
+		return fmt.Errorf("%s: is configured as k0s %s but is already running as %s - role change is not supported, use --force to ignore the mismatch during reset", h, h.Role, detectedRole)
+	}
+
+	log.Warnf("%s: was configured as %s but is already running as %s - proceeding with reset using the discovered role because --force was given", h, h.Role, detectedRole)
+	h.Role = detectedRole
 	return nil
 }
 


### PR DESCRIPTION
Closes #1006 (alternate)
Fixes #1004 

Ignores configured vs discovered role mismatch when resetting nodes. The discovered role will be used to determine how to reset. A warning will be logged.
