### PR TITLE
Use --feature-gates from host.installFlags also in k0s config validation

### DIFF
--- a/phase/configure_k0s.go
+++ b/phase/configure_k0s.go
@@ -228,8 +228,6 @@ func (p *ConfigureK0s) Run(ctx context.Context) error {
 func (p *ConfigureK0s) validateConfig(h *cluster.Host, configPath string) error {
 	log.Infof("%s: validating configuration", h)
 
-	var cmd string
-
 	if h.Metadata.K0sBinaryTempFile != "" {
 		oldK0sBinaryPath := h.K0sInstallLocation()
 		h.Configurer.SetPath("K0sBinaryPath", h.Metadata.K0sBinaryTempFile)
@@ -238,21 +236,8 @@ func (p *ConfigureK0s) validateConfig(h *cluster.Host, configPath string) error 
 		}()
 	}
 
-	log.Debugf("%s: comparing k0s version %s with %s", h, p.Config.Spec.K0s.Version, configCreateSince)
-	if p.Config.Spec.K0s.Version.GreaterThanOrEqual(configCreateSince) {
-		log.Debugf("%s: comparison result true", h)
-		cmd = h.Configurer.K0sCmdf(`config validate --config="%s"`, configPath)
-		if fg := h.InstallFlags.GetValue("--feature-gates"); fg != "" {
-			cmd += fmt.Sprintf(" --feature-gates=%s", shellescape.Quote(fg))
-			log.Debugf("%s: added --feature-gates from installFlags to config validation: %s", h, cmd)
-		}
-	} else {
-		log.Debugf("%s: comparison result false", h)
-		cmd = h.Configurer.K0sCmdf(`validate config --config "%s"`, configPath)
-	}
-
 	var stderrBuf bytes.Buffer
-	command, err := h.ExecStreams(cmd, nil, nil, &stderrBuf, exec.Sudo(h))
+	command, err := h.ExecStreams(p.buildConfigValidateCommand(h, configPath), nil, nil, &stderrBuf, exec.Sudo(h))
 	if err != nil {
 		return fmt.Errorf("can't run spec.k0s.config validation: %w", err)
 	}
@@ -261,6 +246,19 @@ func (p *ConfigureK0s) validateConfig(h *cluster.Host, configPath string) error 
 	}
 
 	return nil
+}
+
+func (p *ConfigureK0s) buildConfigValidateCommand(h *cluster.Host, configPath string) string {
+	if p.Config.Spec.K0s.Version.GreaterThanOrEqual(configCreateSince) {
+		cmd := h.Configurer.K0sCmdf(`config validate --config="%s"`, configPath)
+		if fg := h.InstallFlags.GetValue("--feature-gates"); fg != "" {
+			cmd += fmt.Sprintf(" --feature-gates=%s", shellescape.Quote(fg))
+			log.Debugf("%s: added --feature-gates from installFlags to config validation: %s", h, cmd)
+		}
+		return cmd
+	}
+	log.Debugf("%s: using legacy config validation command", h)
+	return h.Configurer.K0sCmdf(`validate config --config "%s"`, configPath)
 }
 
 func (p *ConfigureK0s) configureK0s(ctx context.Context, h *cluster.Host) error {

--- a/phase/configure_k0s_test.go
+++ b/phase/configure_k0s_test.go
@@ -1,0 +1,28 @@
+package phase
+
+import (
+	"testing"
+
+	"github.com/k0sproject/k0sctl/configurer/linux"
+	"github.com/k0sproject/k0sctl/pkg/apis/k0sctl.k0sproject.io/v1beta1"
+	"github.com/k0sproject/k0sctl/pkg/apis/k0sctl.k0sproject.io/v1beta1/cluster"
+	"github.com/k0sproject/version"
+	"github.com/stretchr/testify/require"
+)
+
+func TestBuildConfigValidateCommandAddsFeatureGates(t *testing.T) {
+	cfg := &v1beta1.Cluster{
+		Spec: &cluster.Spec{
+			K0s: &cluster.K0s{Version: version.MustParse("v1.24.0+k0s.0")},
+		},
+	}
+
+	p := &ConfigureK0s{GenericPhase: GenericPhase{Config: cfg}}
+	h := &cluster.Host{Configurer: &linux.Debian{}}
+	h.InstallFlags.Add("--feature-gates=IPv6DualStack=true")
+
+	cmd := p.buildConfigValidateCommand(h, "/etc/k0s/config.yaml")
+
+	require.Contains(t, cmd, "config validate --config=\"/etc/k0s/config.yaml\"")
+	require.Contains(t, cmd, "--feature-gates=IPv6DualStack=true")
+}


### PR DESCRIPTION
Fixes #1012 

When `installFlags` has a value for `--feature-gates`, use it also when running `k0s config validate`.

