### PR TITLE
Fix backup and reset with --kubelet-root-dir and unknown k0s version

### DIFF
--- a/action/backup.go
+++ b/action/backup.go
@@ -21,11 +21,12 @@ func (b Backup) Run(ctx context.Context) error {
 
 	lockPhase := &phase.Lock{}
 
-    b.Manager.AddPhase(
-        &phase.Connect{},
-        &phase.DetectOS{},
-        lockPhase,
-        &phase.PrepareHosts{},
+	b.Manager.AddPhase(
+		&phase.DefaultK0sVersion{},
+		&phase.Connect{},
+		&phase.DetectOS{},
+		lockPhase,
+		&phase.PrepareHosts{},
 		&phase.GatherFacts{SkipMachineIDs: true},
 		&phase.GatherK0sFacts{},
 		&phase.Backup{Out: b.Out},

--- a/action/reset.go
+++ b/action/reset.go
@@ -42,10 +42,11 @@ func (r Reset) Run(ctx context.Context) error {
 	}
 
 	lockPhase := &phase.Lock{}
-    r.Manager.AddPhase(
-        &phase.Connect{},
-        &phase.DetectOS{},
-        lockPhase,
+	r.Manager.AddPhase(
+		&phase.DefaultK0sVersion{},
+		&phase.Connect{},
+		&phase.DetectOS{},
+		lockPhase,
 		&phase.PrepareHosts{},
 		&phase.GatherFacts{SkipMachineIDs: true},
 		&phase.GatherK0sFacts{},


### PR DESCRIPTION
Fixes #1019 

The `k0sctl backup` and `k0sctl reset` flows did not include defaulting for the k0s version, so when using a custom `kubeletRootDir` / `--kubelet-root-dir` without specifying k0s version, k0sctl failed to check if the k0s version is recent enough to have that feature.