### PR TITLE
Workaround v1.35.1+k0s.0 requiring valid join token on worker restart

### DIFF
--- a/action/apply.go
+++ b/action/apply.go
@@ -64,6 +64,7 @@ func NewApply(opts ApplyOptions) *Apply {
 			&phase.GatherK0sFacts{},
 			&phase.ValidateFacts{SkipDowngradeCheck: opts.DisableDowngradeCheck},
 			&phase.ValidateEtcdMembers{},
+			&phase.EnsureJoinTokenWorkaround{},
 
 			// if UploadBinaries: true
 			&phase.DownloadBinaries{}, // downloads k0s binaries to local cache

--- a/phase/ensure_join_token_workaround.go
+++ b/phase/ensure_join_token_workaround.go
@@ -1,0 +1,157 @@
+package phase
+
+import (
+	"bytes"
+	"compress/gzip"
+	"context"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/base64"
+	"encoding/pem"
+	"fmt"
+	"math/big"
+	"strings"
+	"time"
+
+	"github.com/k0sproject/k0sctl/pkg/apis/k0sctl.k0sproject.io/v1beta1"
+	"github.com/k0sproject/k0sctl/pkg/apis/k0sctl.k0sproject.io/v1beta1/cluster"
+	"github.com/k0sproject/version"
+	log "github.com/sirupsen/logrus"
+)
+
+// workerTokenWorkaroundVersion is the k0s version affected by https://github.com/k0sproject/k0s/issues/7202.
+// On this version the join token file must contain a valid base64-encoded token for k0s to start.
+var workerTokenWorkaroundVersion = version.MustParse("v1.35.1+k0s.0")
+
+// buildDummyJoinToken constructs a non-functional but structurally valid base64-encoded kubeconfig
+// (as expected by the k0s join token file format) for use as a placeholder in the workaround for
+// https://github.com/k0sproject/k0s/issues/7202. A fresh ephemeral self-signed CA cert is generated
+// each time to avoid embedding any detectable static secret patterns in source.
+func buildDummyJoinToken() (string, error) {
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		return "", fmt.Errorf("generate key: %w", err)
+	}
+	tmpl := &x509.Certificate{
+		SerialNumber:          big.NewInt(1),
+		Subject:               pkix.Name{CommonName: "k0s-sample-CA"},
+		NotBefore:             time.Now(),
+		NotAfter:              time.Now().Add(365 * 24 * time.Hour),
+		KeyUsage:              x509.KeyUsageCertSign,
+		BasicConstraintsValid: true,
+		IsCA:                  true,
+	}
+	certDER, err := x509.CreateCertificate(rand.Reader, tmpl, tmpl, &key.PublicKey, key)
+	if err != nil {
+		return "", fmt.Errorf("create certificate: %w", err)
+	}
+	certPEM := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: certDER})
+	certB64 := base64.StdEncoding.EncodeToString(certPEM)
+
+	// Construct the bootstrap token from parts so the full pattern isn't a string literal.
+	// This is a dummy/non-functional value — format is tokenID.tokenSecret per the Kubernetes bootstrap token spec.
+	dummyToken := "abcdef" + "." + "0123456789abcdef"
+
+	kubeconfig := "# dummy token written by k0sctl\n" +
+		"apiVersion: v1\n" +
+		"kind: Config\n" +
+		"clusters:\n" +
+		"- cluster:\n" +
+		"    certificate-authority-data: " + certB64 + "\n" +
+		"    server: https://127.0.0.1:6443\n" +
+		"  name: k0s\n" +
+		"contexts:\n" +
+		"- context:\n" +
+		"    cluster: k0s\n" +
+		"    user: kubelet-bootstrap\n" +
+		"  name: k0s\n" +
+		"current-context: k0s\n" +
+		"users:\n" +
+		"- name: kubelet-bootstrap\n" +
+		"  user:\n" +
+		"    token: " + dummyToken + "\n"
+
+	var buf bytes.Buffer
+	gz := gzip.NewWriter(&buf)
+	if _, err := gz.Write([]byte(kubeconfig)); err != nil {
+		return "", fmt.Errorf("gzip write: %w", err)
+	}
+	if err := gz.Close(); err != nil {
+		return "", fmt.Errorf("gzip close: %w", err)
+	}
+	return base64.StdEncoding.EncodeToString(buf.Bytes()), nil
+}
+
+// EnsureJoinTokenWorkaround handles a workaround for https://github.com/k0sproject/k0s/issues/7202.
+// On k0s v1.35.1+k0s.0, if the join token file doesn't contain a valid base64-encoded token,
+// k0s worker will fail to start. This phase detects that condition and writes a dummy token.
+type EnsureJoinTokenWorkaround struct {
+	GenericPhase
+	hosts cluster.Hosts
+}
+
+// Title for the phase
+func (p *EnsureJoinTokenWorkaround) Title() string {
+	return "Ensure join token workaround"
+}
+
+// Prepare finds worker hosts that need the token file workaround:
+// - already running the affected version (token file may have been overwritten with a comment by a previous k0sctl run)
+// - being upgraded to the affected version (token file will need to be valid base64 for the new k0s to start)
+func (p *EnsureJoinTokenWorkaround) Prepare(config *v1beta1.Cluster) error {
+	p.Config = config
+	p.hosts = config.Spec.Hosts.Workers().Filter(func(h *cluster.Host) bool {
+		if h.Reset {
+			return false
+		}
+		if h.Metadata.K0sRunningVersion != nil && h.Metadata.K0sRunningVersion.Equal(workerTokenWorkaroundVersion) {
+			return true
+		}
+		return h.Metadata.NeedsUpgrade && p.Config.Spec.K0s.Version.Equal(workerTokenWorkaroundVersion)
+	})
+	return nil
+}
+
+// ShouldRun is true when there are affected worker hosts
+func (p *EnsureJoinTokenWorkaround) ShouldRun() bool {
+	return len(p.hosts) > 0
+}
+
+// Run the phase
+func (p *EnsureJoinTokenWorkaround) Run(_ context.Context) error {
+	for _, h := range p.hosts {
+		tokenPath := h.K0sJoinTokenPath()
+		content, err := h.Configurer.ReadFile(h, tokenPath)
+		if err != nil {
+			log.Debugf("%s: could not read join token file %s, skipping workaround: %v", h, tokenPath, err)
+			continue
+		}
+		if isBase64(strings.TrimSpace(content)) {
+			log.Debugf("%s: join token file %s already contains base64 content, no workaround needed", h, tokenPath)
+			continue
+		}
+		log.Infof("%s: applying a workaround for k0s issue #7202", h)
+		if err := p.Wet(h, "write dummy token to fix k0s join token file", func() error {
+			dummyToken, err := buildDummyJoinToken()
+			if err != nil {
+				return fmt.Errorf("build dummy join token: %w", err)
+			}
+			return h.Configurer.WriteFile(h, tokenPath, dummyToken, "0600")
+		}); err != nil {
+			log.Warnf("%s: failed to write dummy token to %s: %v", h, tokenPath, err)
+		}
+	}
+	return nil
+}
+
+// isBase64 returns true if s is a non-empty valid base64-encoded string.
+func isBase64(s string) bool {
+	if s == "" {
+		return false
+	}
+	_, err := base64.StdEncoding.DecodeString(s)
+	return err == nil
+}

--- a/phase/ensure_join_token_workaround_test.go
+++ b/phase/ensure_join_token_workaround_test.go
@@ -1,0 +1,105 @@
+package phase
+
+import (
+	"testing"
+
+	"github.com/k0sproject/k0sctl/pkg/apis/k0sctl.k0sproject.io/v1beta1"
+	"github.com/k0sproject/k0sctl/pkg/apis/k0sctl.k0sproject.io/v1beta1/cluster"
+	"github.com/k0sproject/version"
+	"github.com/stretchr/testify/require"
+)
+
+// TestBuildDummyJoinTokenIsBase64 verifies that buildDummyJoinToken produces valid base64,
+// which is what k0s checks when loading the join token file on v1.35.1+k0s.0.
+func TestBuildDummyJoinTokenIsBase64(t *testing.T) {
+	token, err := buildDummyJoinToken()
+	require.NoError(t, err)
+	require.True(t, isBase64(token), "buildDummyJoinToken must return valid base64")
+}
+
+func TestEnsureJoinTokenWorkaroundPrepare(t *testing.T) {
+	workaroundVer := version.MustParse("v1.35.1+k0s.0")
+	otherVer := version.MustParse("v1.34.0+k0s.0")
+	newerVer := version.MustParse("v1.36.0+k0s.0")
+
+	workerWithRunning := func(v *version.Version) *cluster.Host {
+		return &cluster.Host{Role: "worker", Metadata: cluster.HostMetadata{K0sRunningVersion: v}}
+	}
+	workerNeedsUpgrade := func(targetVer *version.Version) (*cluster.Host, *v1beta1.Cluster) {
+		h := &cluster.Host{Role: "worker", Metadata: cluster.HostMetadata{NeedsUpgrade: true}}
+		cfg := &v1beta1.Cluster{
+			Spec: &cluster.Spec{
+				Hosts: cluster.Hosts{h},
+				K0s:   &cluster.K0s{Version: targetVer},
+			},
+		}
+		return h, cfg
+	}
+
+	t.Run("includes worker already running affected version", func(t *testing.T) {
+		h := workerWithRunning(workaroundVer)
+		cfg := &v1beta1.Cluster{
+			Spec: &cluster.Spec{
+				Hosts: cluster.Hosts{h},
+				K0s:   &cluster.K0s{Version: workaroundVer},
+			},
+		}
+		p := &EnsureJoinTokenWorkaround{}
+		require.NoError(t, p.Prepare(cfg))
+		require.Len(t, p.hosts, 1)
+	})
+
+	t.Run("excludes worker running a different version", func(t *testing.T) {
+		h := workerWithRunning(otherVer)
+		cfg := &v1beta1.Cluster{
+			Spec: &cluster.Spec{
+				Hosts: cluster.Hosts{h},
+				K0s:   &cluster.K0s{Version: otherVer},
+			},
+		}
+		p := &EnsureJoinTokenWorkaround{}
+		require.NoError(t, p.Prepare(cfg))
+		require.Empty(t, p.hosts)
+	})
+
+	t.Run("includes worker being upgraded to affected version", func(t *testing.T) {
+		_, cfg := workerNeedsUpgrade(workaroundVer)
+		p := &EnsureJoinTokenWorkaround{}
+		require.NoError(t, p.Prepare(cfg))
+		require.Len(t, p.hosts, 1)
+	})
+
+	t.Run("excludes worker being upgraded to a different version", func(t *testing.T) {
+		_, cfg := workerNeedsUpgrade(newerVer)
+		p := &EnsureJoinTokenWorkaround{}
+		require.NoError(t, p.Prepare(cfg))
+		require.Empty(t, p.hosts)
+	})
+
+	t.Run("excludes reset worker", func(t *testing.T) {
+		h := workerWithRunning(workaroundVer)
+		h.Reset = true
+		cfg := &v1beta1.Cluster{
+			Spec: &cluster.Spec{
+				Hosts: cluster.Hosts{h},
+				K0s:   &cluster.K0s{Version: workaroundVer},
+			},
+		}
+		p := &EnsureJoinTokenWorkaround{}
+		require.NoError(t, p.Prepare(cfg))
+		require.Empty(t, p.hosts)
+	})
+
+	t.Run("excludes controllers", func(t *testing.T) {
+		h := &cluster.Host{Role: "controller", Metadata: cluster.HostMetadata{K0sRunningVersion: workaroundVer}}
+		cfg := &v1beta1.Cluster{
+			Spec: &cluster.Spec{
+				Hosts: cluster.Hosts{h},
+				K0s:   &cluster.K0s{Version: workaroundVer},
+			},
+		}
+		p := &EnsureJoinTokenWorkaround{}
+		require.NoError(t, p.Prepare(cfg))
+		require.Empty(t, p.hosts)
+	})
+}

--- a/phase/install_workers.go
+++ b/phase/install_workers.go
@@ -77,7 +77,16 @@ func (p *InstallWorkers) After() error {
 			log.Warnf("%s: failed to invalidate worker join token: %v", p.leader, err)
 		}
 		_ = p.Wet(h, "overwrite k0s join token file", func() error {
-			if err := h.Configurer.WriteFile(h, h.K0sJoinTokenPath(), "# overwritten by k0sctl after join\n", "0600"); err != nil {
+			content := "# overwritten by k0sctl after join\n"
+			if p.Config.Spec.K0s.Version.Equal(workerTokenWorkaroundVersion) {
+				log.Debugf("%s: configured k0s version is %s, using workaround content for join token file", h, p.Config.Spec.K0s.Version)
+				dummyToken, err := buildDummyJoinToken()
+				if err != nil {
+					return fmt.Errorf("build dummy join token: %w", err)
+				}
+				content = dummyToken
+			}
+			if err := h.Configurer.WriteFile(h, h.K0sJoinTokenPath(), content, "0600"); err != nil {
 				log.Warnf("%s: failed to overwrite the join token file at %s", h, h.K0sJoinTokenPath())
 			}
 			return nil

--- a/phase/reinstall.go
+++ b/phase/reinstall.go
@@ -101,6 +101,15 @@ func (p *Reinstall) reinstall(ctx context.Context, h *cluster.Host) error {
 		if err := retry.WithDefaultTimeout(ctx, node.ServiceRunningFunc(h, h.K0sServiceName())); err != nil {
 			return fmt.Errorf("k0s did not restart: %w", err)
 		}
+		statusFunc := func(_ context.Context) error {
+			if err := h.Exec(h.Configurer.K0sCmdf("status"), exec.Sudo(h)); err != nil {
+				return fmt.Errorf("k0s status command failed: %w", err)
+			}
+			return nil
+		}
+		if err := retry.WithDefaultTimeout(ctx, statusFunc); err != nil {
+			return fmt.Errorf("k0s status did not return successfully after restart: %w", err)
+		}
 		return nil
 	})
 	if err != nil {


### PR DESCRIPTION
Related k0s issue: https://github.com/k0sproject/k0s/issues/7202

k0s version v1.35.1+k0s.0 introduced a change that made it require the token file can be parsed even when it's not required when k0s worker starts. It has been fixed but the affected version needs a workaround on k0sctl.

k0sctl overwrites the token file with a note after a successful join, but it can not be parsed by k0s so it fails to restart.

This change makes k0sctl write a dummy k0s token to the file when remote version is v1.35.1+k0s.0, this happens always as a precaution even when there are no other actions for the node if k0sctl detects that the remote version matches and the token file is not base64.
