### PR TITLE
Use hostname instead of label to query node readiness

### DIFF
--- a/pkg/node/statusfunc.go
+++ b/pkg/node/statusfunc.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"strings"
 	"time"
 
 	"github.com/k0sproject/k0sctl/pkg/apis/k0sctl.k0sproject.io/v1beta1/cluster"
@@ -18,7 +17,7 @@ import (
 
 type retryFunc func(context.Context) error
 
-// kubectl get node -o json
+// kubeNodeStatus represents the output of `kubectl get node <name> -o json` for a single Node
 type kubeNodeStatus struct {
 	Status struct {
 		Conditions []struct {
@@ -42,7 +41,7 @@ type statusEvents struct {
 // KubeNodeReady returns a function that returns an error unless the node is ready according to "kubectl get node"
 func KubeNodeReadyFunc(h *cluster.Host) retryFunc {
 	return func(_ context.Context) error {
-		output, err := h.ExecOutput(h.Configurer.KubectlCmdf(h, h.K0sDataDir(), "get node %s -o json", strings.ToLower(h.Metadata.Hostname)), exec.HideOutput(), exec.Sudo(h))
+		output, err := h.ExecOutput(h.Configurer.KubectlCmdf(h, h.K0sDataDir(), "get node %s -o json", h.Metadata.Hostname), exec.HideOutput(), exec.Sudo(h))
 		if err != nil {
 			return fmt.Errorf("failed to get node status: %w", err)
 		}


### PR DESCRIPTION
This PR addresses https://github.com/k0sproject/k0sctl/issues/1040 by changing the node readiness check to query a node by its name (hostname) instead of using a label selector, avoiding scenarios where the kubelet identity lacks RBAC permissions to list nodes by label.

Changes:

Switch kubectl get node invocation from -l kubernetes.io/hostname=... to get node <hostname>.
Update the JSON parsing struct and readiness condition traversal to match the single-Node JSON shape instead of a NodeList.