### PR TITLE
Ensure IPv6 API address with node-local LB

### DIFF
--- a/phase/configure_k0s.go
+++ b/phase/configure_k0s.go
@@ -7,6 +7,7 @@ import (
 	"io/fs"
 	gopath "path"
 	"slices"
+	"strings"
 	"time"
 
 	"al.essio.dev/pkg/shellescape"
@@ -226,6 +227,19 @@ func (p *ConfigureK0s) Run(ctx context.Context) error {
 	return p.parallelDo(ctx, controllers, p.configureK0s)
 }
 
+func requiresIPv6NodeLocalAPIAddress(cfg dig.Mapping) bool {
+	if cfg == nil {
+		return false
+	}
+	if !strings.EqualFold(cfg.DigString("spec", "network", "dualStack", "primaryAddressFamily"), "ipv6") {
+		return false
+	}
+	if enabled, ok := cfg.Dig("spec", "network", "nodeLocalLoadBalancing", "enabled").(bool); ok && enabled {
+		return true
+	}
+	return false
+}
+
 func (p *ConfigureK0s) validateConfig(h *cluster.Host, configPath string) error {
 	log.Infof("%s: validating configuration", h)
 
@@ -338,7 +352,14 @@ func (p *ConfigureK0s) configFor(h *cluster.Host) (string, error) {
 	}
 
 	if cfg.DigString("spec", "api", "address") == "" {
+		forceAddress := false
 		if onlyBindAddr, ok := cfg.Dig("spec", "api", "onlyBindToAddress").(bool); ok && onlyBindAddr {
+			forceAddress = true
+		}
+		if !forceAddress && requiresIPv6NodeLocalAPIAddress(cfg) {
+			forceAddress = true
+		}
+		if forceAddress {
 			cfg.DigMapping("spec", "api")["address"] = addr
 		}
 	}

--- a/phase/configure_k0s_test.go
+++ b/phase/configure_k0s_test.go
@@ -1,13 +1,16 @@
 package phase
 
 import (
+	"strings"
 	"testing"
 
+	"github.com/k0sproject/dig"
 	"github.com/k0sproject/k0sctl/configurer/linux"
 	"github.com/k0sproject/k0sctl/pkg/apis/k0sctl.k0sproject.io/v1beta1"
 	"github.com/k0sproject/k0sctl/pkg/apis/k0sctl.k0sproject.io/v1beta1/cluster"
 	"github.com/k0sproject/version"
 	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v2"
 )
 
 func TestBuildConfigValidateCommandAddsFeatureGates(t *testing.T) {
@@ -25,4 +28,61 @@ func TestBuildConfigValidateCommandAddsFeatureGates(t *testing.T) {
 
 	require.Contains(t, cmd, "config validate --config=\"/etc/k0s/config.yaml\"")
 	require.Contains(t, cmd, "--feature-gates=IPv6DualStack=true")
+}
+
+func TestConfigForSetsAPIAddressWhenIPv6NodeLocalLBEnabled(t *testing.T) {
+	base := dig.Mapping{
+		"spec": dig.Mapping{
+			"api": dig.Mapping{},
+			"network": dig.Mapping{
+				"dualStack":              dig.Mapping{"primaryAddressFamily": "IPv6"},
+				"nodeLocalLoadBalancing": dig.Mapping{"enabled": true},
+			},
+		},
+	}
+
+	clusterConfig := &v1beta1.Cluster{Spec: &cluster.Spec{K0s: &cluster.K0s{}}}
+	p := &ConfigureK0s{GenericPhase: GenericPhase{Config: clusterConfig}, newBaseConfig: base}
+	h := &cluster.Host{PrivateAddress: "fc00::101"}
+
+	config, err := p.configFor(h)
+	require.NoError(t, err)
+	require.Equal(t, "fc00::101", apiAddressFromConfig(t, config))
+}
+
+func TestConfigForLeavesAPIAddressWhenIPv6NodeLocalLBDisabled(t *testing.T) {
+	base := dig.Mapping{
+		"spec": dig.Mapping{
+			"api": dig.Mapping{},
+			"network": dig.Mapping{
+				"dualStack":              dig.Mapping{"primaryAddressFamily": "IPv6"},
+				"nodeLocalLoadBalancing": dig.Mapping{"enabled": false},
+			},
+		},
+	}
+
+	clusterConfig := &v1beta1.Cluster{Spec: &cluster.Spec{K0s: &cluster.K0s{}}}
+	p := &ConfigureK0s{GenericPhase: GenericPhase{Config: clusterConfig}, newBaseConfig: base}
+	h := &cluster.Host{PrivateAddress: "fc00::102"}
+
+	config, err := p.configFor(h)
+	require.NoError(t, err)
+	require.Equal(t, "", apiAddressFromConfig(t, config))
+}
+
+type apiSpec struct {
+	Spec struct {
+		API struct {
+			Address string `yaml:"address"`
+		} `yaml:"api"`
+	} `yaml:"spec"`
+}
+
+func apiAddressFromConfig(t *testing.T, cfg string) string {
+	t.Helper()
+	parts := strings.SplitN(cfg, "\n", 2)
+	require.Len(t, parts, 2)
+	var parsed apiSpec
+	require.NoError(t, yaml.Unmarshal([]byte(parts[1]), &parsed))
+	return parsed.Spec.API.Address
 }


### PR DESCRIPTION
Fixes #1038

Controllers now auto-populate spec.api.address with each host’s IPv6 when dual‑stack NodeLocal LB needs it.
