### PR TITLE
Add GitHub workflow to bump the WinGet package

### DIFF
--- a/.github/workflows/bump-winget-package.yml
+++ b/.github/workflows/bump-winget-package.yml
@@ -1,0 +1,72 @@
+name: Bump WinGet package
+
+on:
+  release:
+    types:
+      - published
+
+  workflow_dispatch:
+    inputs:
+      tag-name:
+        description: Tag name of the GitHub release to publish to WinGet
+        required: true
+        type: string
+
+env:
+  KOMAC_VERSION: 2.16.0
+  KOMAC_SHA256: 7d2707fa6210f2789a3702de49fbd150b736dbf426ee0b9bc8e098736f9fd82d
+
+jobs:
+  bump:
+    name: Bump WinGet package
+    runs-on: ubuntu-slim
+    if: ${{ github.event_name == 'workflow_dispatch' || !github.event.release.prerelease }}
+
+    env:
+      KOMAC_FORK_OWNER: ${{ github.repository_owner }}
+      KOMAC_CREATED_WITH: k0sctl "Bump WinGet package" GitHub workflow
+      KOMAC_CREATED_WITH_URL: ${{ github.server_url }}/${{ github.repository }}/blob/${{ github.sha }}/.github/workflows/bump-winget-package.yml
+
+    steps:
+      - name: Resolve release metadata
+        id: metadata
+        env:
+          GH_REPO: k0sproject/k0sctl
+          GH_TOKEN: ${{ github.token }}
+          TAG_NAME: ${{ github.event.release.tag_name || inputs.tag-name }}
+        run: |
+          set -eu
+          gh api "repos/{owner}/{repo}/releases/tags/$TAG_NAME" -q '
+            [
+              "package-version=\(.tag_name | sub("^v"; ""))",
+              "installer-urls=\(
+                ([.assets[] | select(.name == "k0sctl-win-amd64.exe") | .browser_download_url] | first) // error("no installer URL found")
+              )"
+            ]
+            | join("\n")
+          ' >>"$GITHUB_OUTPUT"
+
+      - name: Download Komac
+        run: |
+          set -eu
+          curl -sSLo komac.tar.gz "https://github.com/russellbanks/Komac/releases/download/v$KOMAC_VERSION/komac-$KOMAC_VERSION-x86_64-unknown-linux-gnu.tar.gz"
+          echo "$KOMAC_SHA256" komac.tar.gz | sha256sum -c
+          tar xf komac.tar.gz komac
+          rm komac.tar.gz
+
+      - name: Sync WinGet packages fork
+        env:
+          GITHUB_TOKEN: ${{ secrets.WINGET_FORK_TOKEN }}
+        run: ./komac sync-fork
+
+      - name: Update WinGet package
+        env:
+          PACKAGE_VERSION: ${{ steps.metadata.outputs.package-version }}
+          INSTALLER_URLS: ${{ steps.metadata.outputs.installer-urls }}
+          GITHUB_TOKEN: ${{ secrets.WINGET_UPSTREAM_TOKEN }}
+        run: ./komac update k0sproject.k0sctl --version "$PACKAGE_VERSION" --submit --urls "$INSTALLER_URLS"
+
+      - name: Clean up old branches
+        env:
+          GITHUB_TOKEN: ${{ secrets.WINGET_FORK_TOKEN }}
+        run: ./komac cleanup


### PR DESCRIPTION
Use [komac](https://github.com/russellbanks/komac) to automatically manage the WinGet package update flow.

We still need to provision the secrets for @k0s-bot, so we can open PRs against the winget repo.

We need:

* `WINGET_FORK_TOKEN`  
  A fine-grained token for the `k0sproject/winget-pkgs` repository, which is the fork we need to create PRs against `microsoft/winget-pkgs`. It needs to have read and write permissions for `contents` and `workflows` on the fork.

* `WINGET_UPSTREAM_TOKEN`
  A classic token with the `public_repo` scope. This is required to open PRs against `microsoft/winget-pkgs`.

I was able to run this successfully from my fork in [job run 25379093689](https://github.com/twz123/k0sctl/actions/runs/25379093689/job/74422133307): microsoft/winget-pkgs#368880.

<details>
<summary>Raw job logs</summary>

```text
2026-05-05T13:24:34.8912826Z Current runner version: '2.334.0'
2026-05-05T13:24:34.8967372Z ##[group]Runner Image Provisioner
2026-05-05T13:24:34.8968246Z Hosted Compute Agent
2026-05-05T13:24:34.8968765Z Version: 20260415.520
2026-05-05T13:24:34.8969343Z Commit: af089020f5f67b61ccc91db6c07980876c02bf7b
2026-05-05T13:24:34.8970039Z Build Date: 2026-04-15T18:07:08Z
2026-05-05T13:24:34.8970677Z Worker ID: {2483ad8c-3764-47e8-912d-62185fc172bd}
2026-05-05T13:24:34.8971711Z Azure Region: northcentralus
2026-05-05T13:24:34.8972316Z ##[endgroup]
2026-05-05T13:24:34.8973742Z ##[group]VM Image
2026-05-05T13:24:34.8974262Z - OS: Linux (x64)
2026-05-05T13:24:34.8974840Z - Source: Docker
2026-05-05T13:24:34.8975341Z - Name: ubuntu:24.04
2026-05-05T13:24:34.8975826Z - Version: 20260504.56.2
2026-05-05T13:24:34.8976365Z ##[endgroup]
2026-05-05T13:24:34.8977426Z ##[group]GITHUB_TOKEN Permissions
2026-05-05T13:24:34.8979612Z Contents: read
2026-05-05T13:24:34.8980180Z Metadata: read
2026-05-05T13:24:34.8980828Z Packages: read
2026-05-05T13:24:34.8991995Z ##[endgroup]
2026-05-05T13:24:34.8994026Z Secret source: Actions
2026-05-05T13:24:34.8994822Z Prepare workflow directory
2026-05-05T13:24:35.0099326Z Prepare all required actions
2026-05-05T13:24:35.0202779Z Complete job name: Bump WinGet package
2026-05-05T13:24:35.1260828Z ##[group]Run set -eu
2026-05-05T13:24:35.1271959Z [36;1mset -eu[0m
2026-05-05T13:24:35.1272602Z [36;1mgh api "repos/{owner}/{repo}/releases/tags/$TAG_NAME" -q '[0m
2026-05-05T13:24:35.1273391Z [36;1m  [[0m
2026-05-05T13:24:35.1273985Z [36;1m    "package-version=\(.tag_name | sub("^v"; ""))",[0m
2026-05-05T13:24:35.1274786Z [36;1m    "installer-urls=\([0m
2026-05-05T13:24:35.1275815Z [36;1m      ([.assets[] | select(.name == "k0sctl-win-amd64.exe") | .browser_download_url] | first) // error("no installer URL found")[0m
2026-05-05T13:24:35.1276832Z [36;1m    )"[0m
2026-05-05T13:24:35.1277280Z [36;1m  ][0m
2026-05-05T13:24:35.1277908Z [36;1m  | join("\n")[0m
2026-05-05T13:24:35.1278412Z [36;1m' >>"$GITHUB_OUTPUT"[0m
2026-05-05T13:24:35.1980178Z shell: /usr/bin/bash -e {0}
2026-05-05T13:24:35.1981494Z env:
2026-05-05T13:24:35.1982049Z   KOMAC_VERSION: 2.16.0
2026-05-05T13:24:35.1982891Z   KOMAC_SHA256: 7d2707fa6210f2789a3702de49fbd150b736dbf426ee0b9bc8e098736f9fd82d
2026-05-05T13:24:35.1983764Z   KOMAC_FORK_OWNER: twz123
2026-05-05T13:24:35.1984425Z   KOMAC_CREATED_WITH: k0sctl "Bump WinGet package" GitHub workflow
2026-05-05T13:24:35.1985770Z   KOMAC_CREATED_WITH_URL: https://github.com/twz123/k0sctl/blob/3f8a495b0f21048dcef241bc76223d62a39462ea/.github/workflows/bump-winget-package.yml
2026-05-05T13:24:35.1987001Z   GH_REPO: k0sproject/k0sctl
2026-05-05T13:24:35.1987767Z   GH_TOKEN: ***
2026-05-05T13:24:35.1988220Z   TAG_NAME: v0.30.0
2026-05-05T13:24:35.1988701Z ##[endgroup]
2026-05-05T13:24:35.6884405Z ##[group]Run set -eu
2026-05-05T13:24:35.6885024Z [36;1mset -eu[0m
2026-05-05T13:24:35.6886252Z [36;1mcurl -sSLo komac.tar.gz "https://github.com/russellbanks/Komac/releases/download/v$KOMAC_VERSION/komac-$KOMAC_VERSION-x86_64-unknown-linux-gnu.tar.gz"[0m
2026-05-05T13:24:35.6887665Z [36;1mecho "$KOMAC_SHA256" komac.tar.gz | sha256sum -c[0m
2026-05-05T13:24:35.6888343Z [36;1mtar xf komac.tar.gz komac[0m
2026-05-05T13:24:35.6888949Z [36;1mrm komac.tar.gz[0m
2026-05-05T13:24:35.6904774Z shell: /usr/bin/bash -e {0}
2026-05-05T13:24:35.6905449Z env:
2026-05-05T13:24:35.6905880Z   KOMAC_VERSION: 2.16.0
2026-05-05T13:24:35.6906619Z   KOMAC_SHA256: 7d2707fa6210f2789a3702de49fbd150b736dbf426ee0b9bc8e098736f9fd82d
2026-05-05T13:24:35.6907499Z   KOMAC_FORK_OWNER: twz123
2026-05-05T13:24:35.6908142Z   KOMAC_CREATED_WITH: k0sctl "Bump WinGet package" GitHub workflow
2026-05-05T13:24:35.6909571Z   KOMAC_CREATED_WITH_URL: https://github.com/twz123/k0sctl/blob/3f8a495b0f21048dcef241bc76223d62a39462ea/.github/workflows/bump-winget-package.yml
2026-05-05T13:24:35.6910801Z ##[endgroup]
2026-05-05T13:24:36.1970475Z komac.tar.gz: OK
2026-05-05T13:24:36.2043377Z ##[group]Run ./komac sync-fork
2026-05-05T13:24:36.2043940Z [36;1m./komac sync-fork[0m
2026-05-05T13:24:36.2048563Z shell: /usr/bin/bash -e {0}
2026-05-05T13:24:36.2049027Z env:
2026-05-05T13:24:36.2049413Z   KOMAC_VERSION: 2.16.0
2026-05-05T13:24:36.2050066Z   KOMAC_SHA256: 7d2707fa6210f2789a3702de49fbd150b736dbf426ee0b9bc8e098736f9fd82d
2026-05-05T13:24:36.2050813Z   KOMAC_FORK_OWNER: twz123
2026-05-05T13:24:36.2061990Z   KOMAC_CREATED_WITH: k0sctl "Bump WinGet package" GitHub workflow
2026-05-05T13:24:36.2063356Z   KOMAC_CREATED_WITH_URL: https://github.com/twz123/k0sctl/blob/3f8a495b0f21048dcef241bc76223d62a39462ea/.github/workflows/bump-winget-package.yml
2026-05-05T13:24:36.2065064Z   GITHUB_TOKEN: ***
2026-05-05T13:24:36.2065537Z ##[endgroup]
2026-05-05T13:24:37.6672836Z Successfully merged 9 upstream commits from microsoft/winget-pkgs into twz123/winget-pkgs
2026-05-05T13:24:37.6716814Z ##[group]Run ./komac update k0sproject.k0sctl --version "$PACKAGE_VERSION" --submit --urls "$INSTALLER_URLS"
2026-05-05T13:24:37.6718207Z [36;1m./komac update k0sproject.k0sctl --version "$PACKAGE_VERSION" --submit --urls "$INSTALLER_URLS"[0m
2026-05-05T13:24:37.6726113Z shell: /usr/bin/bash -e {0}
2026-05-05T13:24:37.6726645Z env:
2026-05-05T13:24:37.6727043Z   KOMAC_VERSION: 2.16.0
2026-05-05T13:24:37.6727768Z   KOMAC_SHA256: 7d2707fa6210f2789a3702de49fbd150b736dbf426ee0b9bc8e098736f9fd82d
2026-05-05T13:24:37.6728591Z   KOMAC_FORK_OWNER: twz123
2026-05-05T13:24:37.6729240Z   KOMAC_CREATED_WITH: k0sctl "Bump WinGet package" GitHub workflow
2026-05-05T13:24:37.6730609Z   KOMAC_CREATED_WITH_URL: https://github.com/twz123/k0sctl/blob/3f8a495b0f21048dcef241bc76223d62a39462ea/.github/workflows/bump-winget-package.yml
2026-05-05T13:24:37.6732298Z   PACKAGE_VERSION: 0.30.0
2026-05-05T13:24:37.6733208Z   INSTALLER_URLS: https://github.com/k0sproject/k0sctl/releases/download/v0.30.0/k0sctl-win-amd64.exe
2026-05-05T13:24:37.6734371Z   GITHUB_TOKEN: ***
2026-05-05T13:24:37.6734823Z ##[endgroup]
2026-05-05T13:24:38.4037144Z Latest version of k0sproject.k0sctl: 0.29.0
2026-05-05T13:24:39.0605799Z # Created with k0sctl "Bump WinGet package" GitHub workflow using komac v2.16.0
2026-05-05T13:24:39.0609656Z # yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.12.0.schema.json
2026-05-05T13:24:39.0610475Z 
2026-05-05T13:24:39.0613176Z PackageIdentifier: k0sproject.k0sctl
2026-05-05T13:24:39.0616054Z PackageVersion: 0.30.0
2026-05-05T13:24:39.0618608Z InstallerLocale: en-US
2026-05-05T13:24:39.0621407Z InstallerType: portable
2026-05-05T13:24:39.0624024Z InstallModes:
2026-05-05T13:24:39.0626448Z - silent
2026-05-05T13:24:39.0628882Z Commands:
2026-05-05T13:24:39.0631919Z - k0sctl
2026-05-05T13:24:39.0634609Z ReleaseDate: 2026-04-29
2026-05-05T13:24:39.0637923Z Installers:
2026-05-05T13:24:39.0640647Z - Architecture: x64
2026-05-05T13:24:39.0644113Z   InstallerUrl: https://github.com/k0sproject/k0sctl/releases/download/v0.30.0/k0sctl-win-amd64.exe
2026-05-05T13:24:39.0647533Z   InstallerSha256: 9333C3C65CF43105581484F6B6236D5BF90A1F632F880EBDADABBBD5C00C757F
2026-05-05T13:24:39.0650649Z ManifestType: installer
2026-05-05T13:24:39.0653811Z ManifestVersion: 1.12.0
2026-05-05T13:24:39.0656502Z 
2026-05-05T13:24:39.0660492Z # Created with k0sctl "Bump WinGet package" GitHub workflow using komac v2.16.0
2026-05-05T13:24:39.0664181Z # yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
2026-05-05T13:24:39.0664912Z 
2026-05-05T13:24:39.0666430Z PackageIdentifier: k0sproject.k0sctl
2026-05-05T13:24:39.0667625Z PackageVersion: 0.30.0
2026-05-05T13:24:39.0669185Z PackageLocale: en-US
2026-05-05T13:24:39.0670522Z Publisher: k0sproject
2026-05-05T13:24:39.0671968Z PublisherUrl: https://github.com/k0sproject
2026-05-05T13:24:39.0673448Z PublisherSupportUrl: https://github.com/k0sproject/k0sctl/issues
2026-05-05T13:24:39.0674815Z Author: k0sproject authors
2026-05-05T13:24:39.0675986Z PackageName: k0sctl
2026-05-05T13:24:39.0677038Z PackageUrl: https://github.com/k0sproject/k0sctl
2026-05-05T13:24:39.0678153Z License: Apache-2.0
2026-05-05T13:24:39.0679293Z LicenseUrl: https://github.com/k0sproject/k0sctl/blob/HEAD/LICENSE
2026-05-05T13:24:39.0681325Z ShortDescription: A bootstrapping and management CLI tool for k0s clusters
2026-05-05T13:24:39.0686321Z Description: A command-line bootstrapping and management tool for k0s zero friction Kubernetes clusters.
2026-05-05T13:24:39.0687341Z Moniker: k0sctl
2026-05-05T13:24:39.0687766Z Tags:
2026-05-05T13:24:39.0688137Z - cli
2026-05-05T13:24:39.0688526Z - k0s
2026-05-05T13:24:39.0688909Z - kubernetes
2026-05-05T13:24:39.0689299Z - ssh
2026-05-05T13:24:39.0689720Z ReleaseNotes: |-
2026-05-05T13:24:39.0690148Z   What's Changed
2026-05-05T13:24:39.0690693Z   - Lowercase auto-detected hostname by @CmdrSharp in #1063
2026-05-05T13:24:39.0692570Z   - Fix dynamic node config to use lowercase metadata key instead of Metadata by @kke in #1077
2026-05-05T13:24:39.0693592Z   - ci: Add support for linux-riscv64 by @luhenry in #1067
2026-05-05T13:24:39.0694351Z   - Add all the k0sctl packages to the README by @twz123 in #1060
2026-05-05T13:24:39.0695444Z   - TestLocalBinaryProviderCreatesParentDir fixed for sandboxed environments by @twz123 in #1068
2026-05-05T13:24:39.0696753Z   - Bump github.com/go-playground/validator/v10 from 10.30.1 to 10.30.2 by @dependabot[bot] in #1058
2026-05-05T13:24:39.0697880Z   - Bump golang.org/x/text from 0.35.0 to 0.36.0 by @dependabot[bot] in #1065
2026-05-05T13:24:39.0698871Z   - Bump dependabot/fetch-metadata from 2 to 3 by @dependabot[bot] in #1066
2026-05-05T13:24:39.0699847Z   - Bump softprops/action-gh-release from 2 to 3 by @dependabot[bot] in #1069
2026-05-05T13:24:39.0700839Z   - Bump github.com/mattn/go-isatty from 0.0.20 to 0.0.21 by @dependabot[bot] in #1064
2026-05-05T13:24:39.0702961Z   - Bump k8s.io/apimachinery from 0.35.3 to 0.35.4 by @dependabot[bot] in #1070
2026-05-05T13:24:39.0703950Z   - Bump k8s.io/client-go from 0.35.3 to 0.35.4 by @dependabot[bot] in #1071
2026-05-05T13:24:39.0704937Z   - Bump github.com/k0sproject/rig from 0.21.2 to 0.21.4 by @dependabot[bot] in #1072
2026-05-05T13:24:39.0705928Z   - Bump k8s.io/apimachinery from 0.35.4 to 0.36.0 by @dependabot[bot] in #1073
2026-05-05T13:24:39.0706837Z   - Bump k8s.io/client-go from 0.35.4 to 0.36.0 by @dependabot[bot] in #1074
2026-05-05T13:24:39.0707792Z   - Bump github.com/Azure/go-ntlmssp from 0.1.0 to 0.1.1 by @dependabot[bot] in #1075
2026-05-05T13:24:39.0708858Z   - Bump github.com/mattn/go-isatty from 0.0.21 to 0.0.22 by @dependabot[bot] in #1076
2026-05-05T13:24:39.0709660Z   New Contributors
2026-05-05T13:24:39.0710184Z   - @CmdrSharp made their first contribution in #1063
2026-05-05T13:24:39.0710862Z   - @luhenry made their first contribution in #1067
2026-05-05T13:24:39.0711809Z   Full Changelog: v0.29.0...v0.30.0
2026-05-05T13:24:39.0712458Z   SHA256 Checksums
2026-05-05T13:24:39.0713678Z   9a5f7fcf32c2e430ccd26db1d2764074339098f12cb4134cda67c9bdea874512 *k0sctl-linux-amd64
2026-05-05T13:24:39.0714849Z   02f612f255f215d3c0a447c47db75a5c5b2794eb7627865b274941404de5d6e9 *k0sctl-linux-arm64
2026-05-05T13:24:39.0716001Z   e1d3aedcd89c28a33108fdb0aae0dd135d5aeb6f9ccfac508ddd67e811b61768 *k0sctl-linux-arm
2026-05-05T13:24:39.0717170Z   de44e8f058345b4c0085dadfabd6b4b33910a8989d022108fdaff88c0928e11f *k0sctl-linux-riscv64
2026-05-05T13:24:39.0718322Z   9333c3c65cf43105581484f6b6236d5bf90a1f632f880ebdadabbbd5c00c757f *k0sctl-win-amd64.exe
2026-05-05T13:24:39.0719462Z   3f902bd9a0a00bf93b1d98a490dcb5fbd67209c1901b57712ba6440ae3c8c627 *k0sctl-darwin-amd64
2026-05-05T13:24:39.0720599Z   e4b19ba76754d1c785fda885f57775a1bdcd9c7ba568446e00a345621c87978b *k0sctl-darwin-arm64
2026-05-05T13:24:39.0721904Z ReleaseNotesUrl: https://github.com/k0sproject/k0sctl/releases/tag/v0.30.0
2026-05-05T13:24:39.0722674Z ManifestType: defaultLocale
2026-05-05T13:24:39.0723173Z ManifestVersion: 1.12.0
2026-05-05T13:24:39.0723459Z 
2026-05-05T13:24:39.0723881Z # Created with k0sctl "Bump WinGet package" GitHub workflow using komac v2.16.0
2026-05-05T13:24:39.0724940Z # yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.12.0.schema.json
2026-05-05T13:24:39.0725817Z 
2026-05-05T13:24:39.0726041Z PackageIdentifier: k0sproject.k0sctl
2026-05-05T13:24:39.0726590Z PackageVersion: 0.30.0
2026-05-05T13:24:39.0727048Z DefaultLocale: en-US
2026-05-05T13:24:39.0727491Z ManifestType: version
2026-05-05T13:24:39.0727955Z ManifestVersion: 1.12.0
2026-05-05T13:24:39.0728234Z 
2026-05-05T13:24:45.6864792Z Successfully created microsoft/winget-pkgs#368880
2026-05-05T13:24:45.6866128Z https://github.com/microsoft/winget-pkgs/pull/368880
2026-05-05T13:24:45.8784100Z ##[group]Run ./komac cleanup
2026-05-05T13:24:45.8785369Z [36;1m./komac cleanup[0m
2026-05-05T13:24:45.8792019Z shell: /usr/bin/bash -e {0}
2026-05-05T13:24:45.8793192Z env:
2026-05-05T13:24:45.8794143Z   KOMAC_VERSION: 2.16.0
2026-05-05T13:24:45.8795895Z   KOMAC_SHA256: 7d2707fa6210f2789a3702de49fbd150b736dbf426ee0b9bc8e098736f9fd82d
2026-05-05T13:24:45.8797957Z   KOMAC_FORK_OWNER: twz123
2026-05-05T13:24:45.8799471Z   KOMAC_CREATED_WITH: k0sctl "Bump WinGet package" GitHub workflow
2026-05-05T13:24:45.8803350Z   KOMAC_CREATED_WITH_URL: https://github.com/twz123/k0sctl/blob/3f8a495b0f21048dcef241bc76223d62a39462ea/.github/workflows/bump-winget-package.yml
2026-05-05T13:24:45.8808115Z   GITHUB_TOKEN: ***
2026-05-05T13:24:45.8809189Z ##[endgroup]
2026-05-05T13:24:46.6452667Z There are no merged or closed pull requests with branches that can be deleted
2026-05-05T13:24:46.6557280Z Cleaning up orphan processes
```
</details>

See #1056.