### PR TITLE
ci: Add support for linux-riscv64

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -67,7 +67,7 @@ jobs:
         with:
           builder: ${{ steps.buildx.outputs.name }}
           context: .
-          platforms: linux/amd64,linux/arm64,linux/arm/v7
+          platforms: linux/amd64,linux/arm64,linux/arm/v7,linux/riscv64
           tags: |
             ghcr.io/k0sproject/k0sctl:latest
             ghcr.io/k0sproject/k0sctl:${{ steps.tag-name.outputs.tag }}

--- a/Makefile
+++ b/Makefile
@@ -53,6 +53,19 @@ docker/build/linux-arm:
 		--load \
 		.
 
+bin/k0sctl-linux-riscv64: $(GO_SRCS)
+	GOOS=linux GOARCH=riscv64 CGO_ENABLED=0 go build $(BUILD_FLAGS) -o bin/k0sctl-linux-riscv64 main.go
+
+docker/build/linux-riscv64:
+	docker buildx build \
+		--platform=linux/riscv64 \
+		--build-arg ENVIRONMENT=$(ENVIRONMENT) \
+		--build-arg GIT_COMMIT=$(GIT_COMMIT) \
+		--build-arg TAG_NAME=$(TAG_NAME) \
+		-t ghcr.io/k0sproject/k0sctl:$(TAG_NAME)-riscv64 \
+		--load \
+		.
+
 bin/k0sctl-win-amd64.exe: $(GO_SRCS)
 	GOOS=windows GOARCH=amd64 go build $(BUILD_FLAGS) -o bin/k0sctl-win-amd64.exe main.go
 
@@ -62,9 +75,9 @@ bin/k0sctl-darwin-amd64: $(GO_SRCS)
 bin/k0sctl-darwin-arm64: $(GO_SRCS)
 	GOOS=darwin GOARCH=arm64 go build $(BUILD_FLAGS) -o bin/k0sctl-darwin-arm64 main.go
 
-bins := k0sctl-linux-amd64 k0sctl-linux-arm64 k0sctl-linux-arm k0sctl-win-amd64.exe k0sctl-darwin-amd64 k0sctl-darwin-arm64
+bins := k0sctl-linux-amd64 k0sctl-linux-arm64 k0sctl-linux-arm k0sctl-linux-riscv64 k0sctl-win-amd64.exe k0sctl-darwin-amd64 k0sctl-darwin-arm64
 
-dockers := linux-amd64 linux-arm64 linux-arm
+dockers := linux-amd64 linux-arm64 linux-arm linux-riscv64
 
 bin/checksums.txt: $(addprefix bin/,$(bins))
 	sha256sum -b $(addprefix bin/,$(bins)) | sed 's/bin\///' > $@
@@ -85,7 +98,7 @@ clean:
 
 .PHONY: clean-images
 clean-images:
-	docker rmi ghcr.io/k0sproject/k0sctl:$(TAG_NAME)-amd64 ghcr.io/k0sproject/k0sctl:$(TAG_NAME)-arm64 ghcr.io/k0sproject/k0sctl:$(TAG_NAME)-arm
+	docker rmi ghcr.io/k0sproject/k0sctl:$(TAG_NAME)-amd64 ghcr.io/k0sproject/k0sctl:$(TAG_NAME)-arm64 ghcr.io/k0sproject/k0sctl:$(TAG_NAME)-arm ghcr.io/k0sproject/k0sctl:$(TAG_NAME)-riscv64
 
 smoketests := smoke-basic smoke-basic-rootless smoke-files smoke-upgrade smoke-reset smoke-os-override smoke-init smoke-backup-restore smoke-dynamic smoke-basic-openssh smoke-dryrun smoke-downloadurl smoke-controller-swap smoke-reinstall smoke-multidoc
 .PHONY: $(smoketests)

--- a/README.md
+++ b/README.md
@@ -886,7 +886,7 @@ The maximum number of concurrent file uploads to perform. Same as the `--concurr
 The following tokens can be used in the `k0sDownloadURL` and `files.[*].src` fields:
 
 - `%%` - literal `%`
-- `%p` - host architecture (arm, arm64, amd64)
+- `%p` - host architecture (arm, arm64, amd64, riscv64)
 - `%v` - k0s version (v1.21.0+k0s.0)
 - `%x` - k0s binary extension (.exe on Windows, empty elsewhere)
 

--- a/configurer/linux.go
+++ b/configurer/linux.go
@@ -98,6 +98,8 @@ func (l *Linux) Arch(h os.Host) (string, error) {
 		return "arm64", nil
 	case "armv7l", "armv8l", "aarch32", "arm32", "armhfp", "arm-32":
 		return "arm", nil
+	case "riscv64":
+		return "riscv64", nil
 	default:
 		return arch, nil
 	}

--- a/pkg/apis/k0sctl.k0sproject.io/v1beta1/cluster/host.go
+++ b/pkg/apis/k0sctl.k0sproject.io/v1beta1/cluster/host.go
@@ -761,7 +761,7 @@ func (h *Host) FileChanged(lpath, rpath string) bool {
 // The supported tokens are:
 //
 //   - %% - literal %
-//   - %p - host architecture (arm, arm64, amd64)
+//   - %p - host architecture (arm, arm64, amd64, riscv64)
 //   - %v - k0s version (v1.21.0+k0s.0)
 //   - %x - k0s binary extension (.exe on Windows)
 //
@@ -789,7 +789,7 @@ func (h *Host) ExpandTokens(input string, k0sVersion *version.Version) string {
 				// Literal %.
 				builder.WriteByte('%')
 			case 'p':
-				// Host architecture (arm, arm64, amd64).
+				// Host architecture (arm, arm64, amd64, riscv64).
 				builder.WriteString(archToken)
 			case 'v':
 				// K0s version (v1.21.0+k0s.0)

--- a/smoke-test/smoke.common.sh
+++ b/smoke-test/smoke.common.sh
@@ -29,6 +29,7 @@ downloadKubectl() {
     ARCH="amd64"
     case $(uname -m) in
         arm,arm64) ARCH="arm64" ;;
+        riscv64) ARCH="riscv64" ;;
     esac
     [ -f kubectl ] || (curl -L https://dl.k8s.io/release/v1.28.2/bin/${OS}/${ARCH}/kubectl > ./kubectl && chmod +x ./kubectl)
     ./kubectl version --client


### PR DESCRIPTION
Relates to https://github.com/k0sproject/k0s/pull/7414