### PR TITLE
Fix TestLocalBinaryProviderCreatesParentDir in sandboxed environments

### DIFF
--- a/phase/upload_k0s_test.go
+++ b/phase/upload_k0s_test.go
@@ -1,14 +1,18 @@
 package phase
 
 import (
+	"errors"
 	"os"
 	"path/filepath"
 	"runtime"
 	"testing"
 
+	"github.com/k0sproject/k0sctl/configurer/linux"
+	"github.com/k0sproject/k0sctl/configurer/windows"
 	"github.com/k0sproject/k0sctl/pkg/apis/k0sctl.k0sproject.io/v1beta1/cluster"
 	"github.com/k0sproject/k0sctl/pkg/k0s/binprovider"
 	"github.com/k0sproject/rig"
+	rigos "github.com/k0sproject/rig/os"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -30,10 +34,13 @@ func TestLocalBinaryProviderCreatesParentDir(t *testing.T) {
 	}
 	dest := filepath.Join(destDir, destName)
 
-	h := &cluster.Host{
-		Connection:     rig.Connection{Localhost: &rig.Localhost{Enabled: true}},
+	h := &genericHost{cluster.Host{
+		Connection: rig.Connection{
+			OSVersion: &rig.OSVersion{Name: "unknown", ID: "unknown"},
+			Localhost: &rig.Localhost{Enabled: true},
+		},
 		K0sInstallPath: dest,
-	}
+	}}
 	h.SetSudofn(func(cmd string) string { return cmd })
 	h.Connection.SetDefaults()
 	require.NoError(t, h.Connect())
@@ -60,4 +67,33 @@ func TestLocalBinaryProviderCreatesParentDir(t *testing.T) {
 	if content, err := os.ReadFile(h.Metadata.K0sBinaryTempFile); assert.NoError(t, err) {
 		assert.Equal(t, "test", string(content))
 	}
+}
+
+type genericHost struct {
+	cluster.Host
+}
+
+// Stub out OS detection parts
+func (h *genericHost) ResolveConfigurer() error {
+	switch runtime.GOOS {
+	case "linux":
+		h.OSVersion = &rig.OSVersion{Name: "linux", ID: "linux"}
+		h.Configurer = &genericLinux{}
+		return nil
+	case "windows":
+		h.OSVersion = &rig.OSVersion{Name: "windows", ID: "windows"}
+		h.Configurer = &windows.Windows{}
+		return nil
+	}
+
+	return errors.ErrUnsupported
+}
+
+type genericLinux struct {
+	rigos.Linux
+	linux.BaseLinux
+}
+
+func (*genericLinux) InstallPackage(rigos.Host, ...string) error {
+	return errors.ErrUnsupported
 }


### PR DESCRIPTION
The test performed "real" OS detection, i.e. it expected a full-blown supported OS. This failed when the tests were executed in sandboxed environments, e.g. when there was no `/etc/os-release`.

Wrap `cluster.Host` in a struct that implements a basic OS detection without inspecting anything.

See:

* #1061