### PR TITLE
Handle unexpected names in the kubeconfig

### DIFF
--- a/phase/get_kubeconfig.go
+++ b/phase/get_kubeconfig.go
@@ -76,23 +76,35 @@ func (p *GetKubeconfig) Run(_ context.Context) error {
 func kubeConfig(raw string, name string, address, user string) (string, error) {
 	config, err := clientcmd.Load([]byte(raw))
 	if err != nil {
-		return "", err
+		return "", fmt.Errorf("parse kubeconfig: %w", err)
 	}
 
-	sourceContext := config.Contexts[config.CurrentContext]
+	// Prefer the explicit current-context, but fall back to the sole context
+	// when current-context is empty or points to a missing entry, as a
+	// kubeconfig with a single context may legally omit it.
+	contextName := config.CurrentContext
+	sourceContext := config.Contexts[contextName]
 	if sourceContext == nil {
-		return "", fmt.Errorf("current context %s not found in config", config.CurrentContext)
+		if len(config.Contexts) != 1 {
+			if contextName == "" {
+				return "", fmt.Errorf("no current-context set and config does not contain exactly one context to fall back to")
+			}
+			return "", fmt.Errorf("current context %s not found in config", contextName)
+		}
+		for ctxName, ctx := range config.Contexts {
+			contextName, sourceContext = ctxName, ctx
+		}
 	}
 
 	sourceCluster := config.Clusters[sourceContext.Cluster]
 	if sourceCluster == nil {
-		return "", fmt.Errorf("cluster %s referenced by context %s not found in config", sourceContext.Cluster, config.CurrentContext)
+		return "", fmt.Errorf("cluster %s referenced by context %s not found in config", sourceContext.Cluster, contextName)
 	}
 	sourceCluster.Server = address
 
 	sourceAuthInfo := config.AuthInfos[sourceContext.AuthInfo]
 	if sourceAuthInfo == nil {
-		return "", fmt.Errorf("auth info %s referenced by context %s not found in config", sourceContext.AuthInfo, config.CurrentContext)
+		return "", fmt.Errorf("auth info %s referenced by context %s not found in config", sourceContext.AuthInfo, contextName)
 	}
 
 	config.Clusters = map[string]*api.Cluster{
@@ -110,7 +122,7 @@ func kubeConfig(raw string, name string, address, user string) (string, error) {
 
 	out, err := clientcmd.Write(*config)
 	if err != nil {
-		return "", err
+		return "", fmt.Errorf("serialize kubeconfig: %w", err)
 	}
 
 	return string(out), nil

--- a/phase/get_kubeconfig.go
+++ b/phase/get_kubeconfig.go
@@ -3,9 +3,11 @@ package phase
 import (
 	"context"
 	"fmt"
+
 	"github.com/k0sproject/k0sctl/pkg/apis/k0sctl.k0sproject.io/v1beta1/cluster"
 	"github.com/k0sproject/rig/exec"
 	"k8s.io/client-go/tools/clientcmd"
+	"k8s.io/client-go/tools/clientcmd/api"
 
 	log "github.com/sirupsen/logrus"
 )
@@ -72,26 +74,41 @@ func (p *GetKubeconfig) Run(_ context.Context) error {
 // kubeConfig reads in the raw kubeconfig and changes the given address
 // and cluster name into it
 func kubeConfig(raw string, name string, address, user string) (string, error) {
-	cfg, err := clientcmd.Load([]byte(raw))
+	config, err := clientcmd.Load([]byte(raw))
 	if err != nil {
 		return "", err
 	}
 
-	cfg.Clusters[name] = cfg.Clusters["local"]
-	delete(cfg.Clusters, "local")
-	cfg.Clusters[name].Server = address
+	sourceContext := config.Contexts[config.CurrentContext]
+	if sourceContext == nil {
+		return "", fmt.Errorf("current context %s not found in config", config.CurrentContext)
+	}
 
-	cfg.Contexts[name] = cfg.Contexts["Default"]
-	delete(cfg.Contexts, "Default")
-	cfg.Contexts[name].Cluster = name
-	cfg.Contexts[name].AuthInfo = user
+	sourceCluster := config.Clusters[sourceContext.Cluster]
+	if sourceCluster == nil {
+		return "", fmt.Errorf("cluster %s referenced by context %s not found in config", sourceContext.Cluster, config.CurrentContext)
+	}
+	sourceCluster.Server = address
 
-	cfg.CurrentContext = name
+	sourceAuthInfo := config.AuthInfos[sourceContext.AuthInfo]
+	if sourceAuthInfo == nil {
+		return "", fmt.Errorf("auth info %s referenced by context %s not found in config", sourceContext.AuthInfo, config.CurrentContext)
+	}
 
-	cfg.AuthInfos[user] = cfg.AuthInfos["user"]
-	delete(cfg.AuthInfos, "user")
+	config.Clusters = map[string]*api.Cluster{
+		name: sourceCluster,
+	}
+	config.AuthInfos = map[string]*api.AuthInfo{
+		user: sourceAuthInfo,
+	}
+	sourceContext.Cluster = name
+	sourceContext.AuthInfo = user
+	config.Contexts = map[string]*api.Context{
+		name: sourceContext,
+	}
+	config.CurrentContext = name
 
-	out, err := clientcmd.Write(*cfg)
+	out, err := clientcmd.Write(*config)
 	if err != nil {
 		return "", err
 	}

--- a/phase/get_kubeconfig_test.go
+++ b/phase/get_kubeconfig_test.go
@@ -13,6 +13,10 @@ import (
 	"k8s.io/client-go/tools/clientcmd"
 )
 
+const ExpectedClusterAndContextName = "expected-context"
+const ExpectedUserName = "expected-user"
+const ExpectedClusterUrl = "https://example.org"
+
 func fakeReader(h *cluster.Host) (string, error) {
 	return strings.ReplaceAll(`apiVersion: v1
 clusters:
@@ -62,4 +66,196 @@ func TestGetKubeconfig(t *testing.T) {
 	conf, err = clientcmd.Load([]byte(cfg.Metadata.Kubeconfig))
 	require.NoError(t, err)
 	require.Equal(t, "https://[abcd:efgh:ijkl:mnop]:6443", conf.Clusters["k0s"].Server)
+}
+
+func TestConfigExtensionsRemain(t *testing.T) {
+	input := `apiVersion: v1
+clusters:
+- cluster:
+    server: https://localhost:6443
+  name: test-cluster
+contexts:
+- context:
+    cluster: test-cluster
+    user: test-user
+  name: test-context
+current-context: test-context
+extensions:
+- extension:
+    test: test
+  name: test
+kind: Config
+users:
+- name: test-user
+  user: {}
+`
+	expectedOutput := `apiVersion: v1
+clusters:
+- cluster:
+    server: https://example.org
+  name: expected-context
+contexts:
+- context:
+    cluster: expected-context
+    user: expected-user
+  name: expected-context
+current-context: expected-context
+extensions:
+- extension:
+    test: test
+  name: test
+kind: Config
+users:
+- name: expected-user
+  user: {}
+`
+	actualOutput, err := kubeConfig(input, ExpectedClusterAndContextName, ExpectedClusterUrl, ExpectedUserName)
+
+	require.NoError(t, err)
+	require.Equal(t, expectedOutput, actualOutput)
+}
+
+func TestContextExtensionsRemain(t *testing.T) {
+	input := `apiVersion: v1
+clusters:
+- cluster:
+    server: https://localhost:6443
+  name: local-cluster
+contexts:
+- context:
+    cluster: local-cluster
+    extensions:
+    - extension:
+        test: test
+      name: test
+    user: user
+  name: Default
+current-context: Default
+kind: Config
+users:
+- name: user
+  user: {}
+`
+	expectedOutput := `apiVersion: v1
+clusters:
+- cluster:
+    server: https://example.org
+  name: expected-context
+contexts:
+- context:
+    cluster: expected-context
+    extensions:
+    - extension:
+        test: test
+      name: test
+    user: expected-user
+  name: expected-context
+current-context: expected-context
+kind: Config
+users:
+- name: expected-user
+  user: {}
+`
+	actualOutput, err := kubeConfig(input, ExpectedClusterAndContextName, ExpectedClusterUrl, ExpectedUserName)
+
+	require.NoError(t, err)
+	require.Equal(t, expectedOutput, actualOutput)
+}
+
+func TestNonCurrentContextObjectsAreDropped(t *testing.T) {
+	input := `apiVersion: v1
+clusters:
+- cluster:
+    server: https://example.org
+  name: test-cluster
+- cluster:
+    server: https://example.org
+  name: test-cluster2
+contexts:
+- context:
+    cluster: test-cluster
+    user: test-user
+  name: test-context
+- context:
+    cluster: test-cluster2
+    user: test-user2
+  name: test-context2
+current-context: test-context
+kind: Config
+users:
+- name: test-user
+  user: {}
+- name: test-user2
+  user: {}
+`
+	expectedOutput := `apiVersion: v1
+clusters:
+- cluster:
+    server: https://example.org
+  name: expected-context
+contexts:
+- context:
+    cluster: expected-context
+    user: expected-user
+  name: expected-context
+current-context: expected-context
+kind: Config
+users:
+- name: expected-user
+  user: {}
+`
+	actualOutput, err := kubeConfig(input, ExpectedClusterAndContextName, ExpectedClusterUrl, ExpectedUserName)
+
+	require.NoError(t, err)
+	require.Equal(t, expectedOutput, actualOutput)
+}
+
+func TestMissingContext(t *testing.T) {
+	input := `apiVersion: v1
+current-context: test-context
+kind: Config
+`
+	_, err := kubeConfig(input, ExpectedClusterAndContextName, ExpectedClusterUrl, ExpectedUserName)
+
+	require.Errorf(t, err, "missing context should fail")
+	require.Equal(t, err.Error(), "current context test-context not found in config")
+}
+
+func TestMissingAuthInfo(t *testing.T) {
+	input := `apiVersion: v1
+clusters:
+- cluster:
+    server: https://example.org
+  name: test-cluster
+contexts:
+- context:
+    cluster: test-cluster
+    user: test-user
+  name: test-context
+current-context: test-context
+kind: Config
+`
+	_, err := kubeConfig(input, ExpectedClusterAndContextName, ExpectedClusterUrl, ExpectedUserName)
+
+	require.Errorf(t, err, "missing user should fail")
+	require.Equal(t, err.Error(), "auth info test-user referenced by context test-context not found in config")
+}
+
+func TestMissingCluster(t *testing.T) {
+	input := `apiVersion: v1
+contexts:
+- context:
+    cluster: test-cluster
+    user: test-user
+  name: test-context
+current-context: test-context
+kind: Config
+users:
+- name: test-user
+  user: {}
+`
+	_, err := kubeConfig(input, ExpectedClusterAndContextName, ExpectedClusterUrl, ExpectedUserName)
+
+	require.Errorf(t, err, "missing user should fail")
+	require.Equal(t, err.Error(), "cluster test-cluster referenced by context test-context not found in config")
 }

--- a/phase/get_kubeconfig_test.go
+++ b/phase/get_kubeconfig_test.go
@@ -15,7 +15,7 @@ import (
 
 const ExpectedClusterAndContextName = "expected-context"
 const ExpectedUserName = "expected-user"
-const ExpectedClusterUrl = "https://example.org"
+const ExpectedClusterURL = "https://example.org"
 
 func fakeReader(h *cluster.Host) (string, error) {
 	return strings.ReplaceAll(`apiVersion: v1
@@ -35,6 +35,18 @@ users:
 - name: user
   user:
 `, "\t", "  "), nil
+}
+
+// requireKubeConfigEqual compares two kubeconfig YAML strings semantically by
+// parsing both, so the assertion is not coupled to clientcmd.Write formatting
+// or field ordering, which can change across client-go versions.
+func requireKubeConfigEqual(t *testing.T, expected, actual string) {
+	t.Helper()
+	expectedConfig, err := clientcmd.Load([]byte(expected))
+	require.NoError(t, err)
+	actualConfig, err := clientcmd.Load([]byte(actual))
+	require.NoError(t, err)
+	require.Equal(t, expectedConfig, actualConfig)
 }
 
 func TestGetKubeconfig(t *testing.T) {
@@ -109,10 +121,10 @@ users:
 - name: expected-user
   user: {}
 `
-	actualOutput, err := kubeConfig(input, ExpectedClusterAndContextName, ExpectedClusterUrl, ExpectedUserName)
+	actualOutput, err := kubeConfig(input, ExpectedClusterAndContextName, ExpectedClusterURL, ExpectedUserName)
 
 	require.NoError(t, err)
-	require.Equal(t, expectedOutput, actualOutput)
+	requireKubeConfigEqual(t, expectedOutput, actualOutput)
 }
 
 func TestContextExtensionsRemain(t *testing.T) {
@@ -156,10 +168,10 @@ users:
 - name: expected-user
   user: {}
 `
-	actualOutput, err := kubeConfig(input, ExpectedClusterAndContextName, ExpectedClusterUrl, ExpectedUserName)
+	actualOutput, err := kubeConfig(input, ExpectedClusterAndContextName, ExpectedClusterURL, ExpectedUserName)
 
 	require.NoError(t, err)
-	require.Equal(t, expectedOutput, actualOutput)
+	requireKubeConfigEqual(t, expectedOutput, actualOutput)
 }
 
 func TestNonCurrentContextObjectsAreDropped(t *testing.T) {
@@ -204,10 +216,48 @@ users:
 - name: expected-user
   user: {}
 `
-	actualOutput, err := kubeConfig(input, ExpectedClusterAndContextName, ExpectedClusterUrl, ExpectedUserName)
+	actualOutput, err := kubeConfig(input, ExpectedClusterAndContextName, ExpectedClusterURL, ExpectedUserName)
 
 	require.NoError(t, err)
-	require.Equal(t, expectedOutput, actualOutput)
+	requireKubeConfigEqual(t, expectedOutput, actualOutput)
+}
+
+func TestMissingCurrentContextFallsBackToSoleContext(t *testing.T) {
+	input := `apiVersion: v1
+clusters:
+- cluster:
+    server: https://localhost:6443
+  name: test-cluster
+contexts:
+- context:
+    cluster: test-cluster
+    user: test-user
+  name: test-context
+kind: Config
+users:
+- name: test-user
+  user: {}
+`
+	expectedOutput := `apiVersion: v1
+clusters:
+- cluster:
+    server: https://example.org
+  name: expected-context
+contexts:
+- context:
+    cluster: expected-context
+    user: expected-user
+  name: expected-context
+current-context: expected-context
+kind: Config
+users:
+- name: expected-user
+  user: {}
+`
+	actualOutput, err := kubeConfig(input, ExpectedClusterAndContextName, ExpectedClusterURL, ExpectedUserName)
+
+	require.NoError(t, err)
+	requireKubeConfigEqual(t, expectedOutput, actualOutput)
 }
 
 func TestMissingContext(t *testing.T) {
@@ -215,10 +265,34 @@ func TestMissingContext(t *testing.T) {
 current-context: test-context
 kind: Config
 `
-	_, err := kubeConfig(input, ExpectedClusterAndContextName, ExpectedClusterUrl, ExpectedUserName)
+	_, err := kubeConfig(input, ExpectedClusterAndContextName, ExpectedClusterURL, ExpectedUserName)
 
-	require.Errorf(t, err, "missing context should fail")
-	require.Equal(t, err.Error(), "current context test-context not found in config")
+	require.EqualError(t, err, "current context test-context not found in config")
+}
+
+func TestEmptyCurrentContextWithMultipleContexts(t *testing.T) {
+	input := `apiVersion: v1
+clusters:
+- cluster:
+    server: https://example.org
+  name: test-cluster
+- cluster:
+    server: https://example.org
+  name: test-cluster2
+contexts:
+- context:
+    cluster: test-cluster
+    user: test-user
+  name: test-context
+- context:
+    cluster: test-cluster2
+    user: test-user2
+  name: test-context2
+kind: Config
+`
+	_, err := kubeConfig(input, ExpectedClusterAndContextName, ExpectedClusterURL, ExpectedUserName)
+
+	require.EqualError(t, err, "no current-context set and config does not contain exactly one context to fall back to")
 }
 
 func TestMissingAuthInfo(t *testing.T) {
@@ -235,10 +309,9 @@ contexts:
 current-context: test-context
 kind: Config
 `
-	_, err := kubeConfig(input, ExpectedClusterAndContextName, ExpectedClusterUrl, ExpectedUserName)
+	_, err := kubeConfig(input, ExpectedClusterAndContextName, ExpectedClusterURL, ExpectedUserName)
 
-	require.Errorf(t, err, "missing user should fail")
-	require.Equal(t, err.Error(), "auth info test-user referenced by context test-context not found in config")
+	require.EqualError(t, err, "auth info test-user referenced by context test-context not found in config")
 }
 
 func TestMissingCluster(t *testing.T) {
@@ -254,8 +327,7 @@ users:
 - name: test-user
   user: {}
 `
-	_, err := kubeConfig(input, ExpectedClusterAndContextName, ExpectedClusterUrl, ExpectedUserName)
+	_, err := kubeConfig(input, ExpectedClusterAndContextName, ExpectedClusterURL, ExpectedUserName)
 
-	require.Errorf(t, err, "missing user should fail")
-	require.Equal(t, err.Error(), "cluster test-cluster referenced by context test-context not found in config")
+	require.EqualError(t, err, "cluster test-cluster referenced by context test-context not found in config")
 }


### PR DESCRIPTION
Previously the names have been hardcoded, but it seems that my experimental 1.36 cluster has different names, which lead to segfaults. I changed to the logic to take the first and only available key and normalizes it to the expected names.