### PR TITLE
Normalize k0s node names before drain, cordon, etc

### DIFF
--- a/phase/gather_facts.go
+++ b/phase/gather_facts.go
@@ -77,8 +77,8 @@ func (p *GatherFacts) investigateHost(_ context.Context, h *cluster.Host) error 
 	}
 
 	if h.HostnameOverride != "" {
-		log.Infof("%s: using %s from configuration as hostname", h, h.HostnameOverride)
-		h.Metadata.Hostname = h.HostnameOverride
+		h.Metadata.Hostname = strings.ToLower(h.HostnameOverride)
+		log.Infof("%s: using %s from configuration as hostname", h, h.Metadata.Hostname)
 	} else {
 		n := h.Configurer.Hostname(h)
 		if n == "" {

--- a/phase/gather_k0s_facts.go
+++ b/phase/gather_k0s_facts.go
@@ -414,7 +414,7 @@ func (p *GatherK0sFacts) investigateK0s(ctx context.Context, h *cluster.Host) er
 	}
 
 	if !h.IsController() {
-		log.Infof("%s: checking if worker %s has joined", p.leader, h.Metadata.Hostname)
+		log.Infof("%s: checking if worker %s has joined", p.leader, h.KubernetesNodeName())
 		if err := node.KubeNodeReadyFunc(h)(ctx); err != nil {
 			log.Debugf("%s: failed to get ready status: %s", h, err.Error())
 		} else {

--- a/phase/reset_controllers.go
+++ b/phase/reset_controllers.go
@@ -82,7 +82,7 @@ func (p *ResetControllers) Run(ctx context.Context) error {
 			if err := p.leader.DrainNode(
 				&cluster.Host{
 					Metadata: cluster.HostMetadata{
-						Hostname: h.Metadata.Hostname,
+						Hostname: h.KubernetesNodeName(),
 					},
 				},
 				p.Config.Spec.Options.Drain,
@@ -96,7 +96,7 @@ func (p *ResetControllers) Run(ctx context.Context) error {
 			log.Debugf("%s: deleting node...", h)
 			if err := p.leader.DeleteNode(&cluster.Host{
 				Metadata: cluster.HostMetadata{
-					Hostname: h.Metadata.Hostname,
+					Hostname: h.KubernetesNodeName(),
 				},
 			}); err != nil {
 				log.Warnf("%s: failed to delete node: %s", h, err.Error())

--- a/phase/reset_workers.go
+++ b/phase/reset_workers.go
@@ -81,7 +81,7 @@ func (p *ResetWorkers) Run(ctx context.Context) error {
 			if err := p.leader.DrainNode(
 				&cluster.Host{
 					Metadata: cluster.HostMetadata{
-						Hostname: h.Metadata.Hostname,
+						Hostname: h.KubernetesNodeName(),
 					},
 				},
 				p.Config.Spec.Options.Drain,
@@ -95,7 +95,7 @@ func (p *ResetWorkers) Run(ctx context.Context) error {
 		if !p.NoDelete {
 			if err := p.leader.DeleteNode(&cluster.Host{
 				Metadata: cluster.HostMetadata{
-					Hostname: h.Metadata.Hostname,
+					Hostname: h.KubernetesNodeName(),
 				},
 			}); err != nil {
 				log.Warnf("%s: failed to delete node: %s", h, err.Error())

--- a/phase/validate_hosts.go
+++ b/phase/validate_hosts.go
@@ -39,7 +39,7 @@ func (p *ValidateHosts) Run(ctx context.Context) error {
 	controllerCount := len(p.Config.Spec.Hosts.Controllers())
 	var resetControllerCount int
 	for _, h := range p.Config.Spec.Hosts {
-		p.hncount[h.Metadata.Hostname]++
+		p.hncount[h.KubernetesNodeName()]++
 		if p.machineidcount != nil {
 			p.machineidcount[h.Metadata.MachineID]++
 		}
@@ -82,8 +82,8 @@ func (p *ValidateHosts) warnK0sBinaryPath(_ context.Context, h *cluster.Host) er
 }
 
 func (p *ValidateHosts) validateUniqueHostname(_ context.Context, h *cluster.Host) error {
-	if p.hncount[h.Metadata.Hostname] > 1 {
-		return fmt.Errorf("hostname is not unique: %s", h.Metadata.Hostname)
+	if p.hncount[h.KubernetesNodeName()] > 1 {
+		return fmt.Errorf("hostname is not unique: %s", h.KubernetesNodeName())
 	}
 
 	return nil

--- a/phase/validate_hosts_test.go
+++ b/phase/validate_hosts_test.go
@@ -66,6 +66,43 @@ func TestValidateClockSkew(t *testing.T) {
 	})
 }
 
+func TestValidateUniqueHostname(t *testing.T) {
+	makeHost := func(hostname string) *cluster.Host {
+		h := &cluster.Host{Configurer: &mockconfigurer{}}
+		h.Metadata.Hostname = hostname
+		return h
+	}
+
+	t.Run("duplicate hostname same case", func(t *testing.T) {
+		hosts := cluster.Hosts{makeHost("worker-1"), makeHost("worker-1")}
+		p := &ValidateHosts{hncount: make(map[string]int, len(hosts))}
+		for _, h := range hosts {
+			p.hncount[h.KubernetesNodeName()]++
+		}
+		require.Error(t, p.validateUniqueHostname(context.Background(), hosts[0]))
+	})
+
+	t.Run("duplicate hostname different case", func(t *testing.T) {
+		hosts := cluster.Hosts{makeHost("Worker-1"), makeHost("worker-1")}
+		p := &ValidateHosts{hncount: make(map[string]int, len(hosts))}
+		for _, h := range hosts {
+			p.hncount[h.KubernetesNodeName()]++
+		}
+		require.Error(t, p.validateUniqueHostname(context.Background(), hosts[0]))
+		require.Error(t, p.validateUniqueHostname(context.Background(), hosts[1]))
+	})
+
+	t.Run("unique hostnames", func(t *testing.T) {
+		hosts := cluster.Hosts{makeHost("worker-1"), makeHost("worker-2")}
+		p := &ValidateHosts{hncount: make(map[string]int, len(hosts))}
+		for _, h := range hosts {
+			p.hncount[h.KubernetesNodeName()]++
+		}
+		require.NoError(t, p.validateUniqueHostname(context.Background(), hosts[0]))
+		require.NoError(t, p.validateUniqueHostname(context.Background(), hosts[1]))
+	})
+}
+
 func TestValidateConfigurer(t *testing.T) {
 	p := &ValidateHosts{}
 

--- a/pkg/apis/k0sctl.k0sproject.io/v1beta1/cluster/host.go
+++ b/pkg/apis/k0sctl.k0sproject.io/v1beta1/cluster/host.go
@@ -55,9 +55,9 @@ type Host struct {
 	Metadata   HostMetadata          `yaml:"-"`
 	Configurer configurer.Configurer `yaml:"-"`
 
-	binaryProvider              k0s.BinaryProvider  // user-set override via SetK0sBinaryProvider
-	cachedDefaultProvider       k0s.BinaryProvider  // auto-built default; rebuilt when target changes
-	cachedDefaultProviderTarget *version.Version    // target used to build cachedDefaultProvider
+	binaryProvider              k0s.BinaryProvider // user-set override via SetK0sBinaryProvider
+	cachedDefaultProvider       k0s.BinaryProvider // auto-built default; rebuilt when target changes
+	cachedDefaultProviderTarget *version.Version   // target used to build cachedDefaultProvider
 }
 
 // SetK0sBinaryProvider overrides the binary acquisition strategy for this host.
@@ -284,7 +284,6 @@ type HostMetadata struct {
 	MachineID         string
 	DryRunFakeLeader  bool
 }
-
 
 // Resolve prepares host-scoped data after unmarshalling by resolving upload files
 // and normalizing relative paths (like K0sBinaryPath) against baseDir.
@@ -631,29 +630,35 @@ func (h *Host) K0sDataDir() string {
 	return h.DataDir
 }
 
+// KubernetesNodeName returns the Kubernetes node name for this host.
+// Hostnames are normalized to match the lowercase node names created by k0s.
+func (h *Host) KubernetesNodeName() string {
+	return strings.ToLower(h.Metadata.Hostname)
+}
+
 // DrainNode drains the given node
 func (h *Host) DrainNode(node *Host, options DrainOption) error {
-	return h.Exec(h.Configurer.KubectlCmdf(h, h.K0sDataDir(), "drain %s %s", options.ToKubectlArgs(h.Configurer), quote(h.Configurer, node.Metadata.Hostname)), exec.Sudo(h))
+	return h.Exec(h.Configurer.KubectlCmdf(h, h.K0sDataDir(), "drain %s %s", options.ToKubectlArgs(h.Configurer), quote(h.Configurer, node.KubernetesNodeName())), exec.Sudo(h))
 }
 
 // CordonNode marks the node unschedulable
 func (h *Host) CordonNode(node *Host) error {
-	return h.Exec(h.Configurer.KubectlCmdf(h, h.K0sDataDir(), "cordon %s", quote(h.Configurer, node.Metadata.Hostname)), exec.Sudo(h))
+	return h.Exec(h.Configurer.KubectlCmdf(h, h.K0sDataDir(), "cordon %s", quote(h.Configurer, node.KubernetesNodeName())), exec.Sudo(h))
 }
 
 // UncordonNode marks the node schedulable
 func (h *Host) UncordonNode(node *Host) error {
-	return h.Exec(h.Configurer.KubectlCmdf(h, h.K0sDataDir(), "uncordon %s", quote(h.Configurer, node.Metadata.Hostname)), exec.Sudo(h))
+	return h.Exec(h.Configurer.KubectlCmdf(h, h.K0sDataDir(), "uncordon %s", quote(h.Configurer, node.KubernetesNodeName())), exec.Sudo(h))
 }
 
 // DeleteNode deletes the given node from kubernetes
 func (h *Host) DeleteNode(node *Host) error {
-	return h.Exec(h.Configurer.KubectlCmdf(h, h.K0sDataDir(), "delete node %s", quote(h.Configurer, node.Metadata.Hostname)), exec.Sudo(h))
+	return h.Exec(h.Configurer.KubectlCmdf(h, h.K0sDataDir(), "delete node %s", quote(h.Configurer, node.KubernetesNodeName())), exec.Sudo(h))
 }
 
 // Taints returns all taints added to the node.
 func (h *Host) Taints(node *Host) ([]string, error) {
-	output, err := h.ExecOutput(h.Configurer.KubectlCmdf(h, h.K0sDataDir(), `get node %s -o jsonpath='{range .spec.taints[*]}{.key}={.value}:{.effect}{"\n"}{end}'`, quote(h.Configurer, node.Metadata.Hostname)), exec.Sudo(h))
+	output, err := h.ExecOutput(h.Configurer.KubectlCmdf(h, h.K0sDataDir(), `get node %s -o jsonpath='{range .spec.taints[*]}{.key}={.value}:{.effect}{"\n"}{end}'`, quote(h.Configurer, node.KubernetesNodeName())), exec.Sudo(h))
 	if err != nil {
 		return nil, fmt.Errorf("failed to get node taints: %w", err)
 	}
@@ -662,7 +667,7 @@ func (h *Host) Taints(node *Host) ([]string, error) {
 
 // AddTaint adds a taint to the node.
 func (h *Host) AddTaint(node *Host, taint string) error {
-	return h.Exec(h.Configurer.KubectlCmdf(h, h.K0sDataDir(), "taint nodes --overwrite %s %s", quote(h.Configurer, node.Metadata.Hostname), quote(h.Configurer, taint)), exec.Sudo(h))
+	return h.Exec(h.Configurer.KubectlCmdf(h, h.K0sDataDir(), "taint nodes --overwrite %s %s", quote(h.Configurer, node.KubernetesNodeName()), quote(h.Configurer, taint)), exec.Sudo(h))
 }
 
 // RemoveTaint removes a taint from the node.
@@ -675,7 +680,7 @@ func (h *Host) RemoveTaint(node *Host, taint string) error {
 		// Removing a taint not on the node results in an error, so no action is taken
 		return nil
 	}
-	return h.Exec(h.Configurer.KubectlCmdf(h, h.K0sDataDir(), "taint nodes %s %s-", quote(h.Configurer, node.Metadata.Hostname), quote(h.Configurer, taint)), exec.Sudo(h))
+	return h.Exec(h.Configurer.KubectlCmdf(h, h.K0sDataDir(), "taint nodes %s %s-", quote(h.Configurer, node.KubernetesNodeName()), quote(h.Configurer, taint)), exec.Sudo(h))
 }
 
 // CheckHTTPStatus will perform a web request to the url and return an error if the http status is not the expected

--- a/pkg/apis/k0sctl.k0sproject.io/v1beta1/cluster/host_test.go
+++ b/pkg/apis/k0sctl.k0sproject.io/v1beta1/cluster/host_test.go
@@ -23,6 +23,11 @@ func TestHostK0sServiceName(t *testing.T) {
 	require.Equal(t, "k0scontroller", h.K0sServiceName())
 }
 
+func TestKubernetesNodeName(t *testing.T) {
+	h := Host{Metadata: HostMetadata{Hostname: "IN291O-worker-0"}}
+	require.Equal(t, "in291o-worker-0", h.KubernetesNodeName())
+}
+
 type mockconfigurer struct {
 	cfg.Linux
 	linux.Ubuntu

--- a/pkg/node/statusfunc.go
+++ b/pkg/node/statusfunc.go
@@ -46,7 +46,8 @@ type statusEvents struct {
 // On connection loss (e.g. SSH session dropped) it disconnects and reconnects so the next retry uses a fresh connection.
 func KubeNodeReadyFunc(h *cluster.Host) retryFunc {
 	return func(_ context.Context) error {
-		output, err := h.ExecOutput(h.Configurer.KubectlCmdf(h, h.K0sDataDir(), "get node %s -o json", h.Configurer.Quote(h.Metadata.Hostname)), exec.HideOutput(), exec.Sudo(h))
+		nodeName := h.KubernetesNodeName()
+		output, err := h.ExecOutput(h.Configurer.KubectlCmdf(h, h.K0sDataDir(), "get node %s -o json", h.Configurer.Quote(nodeName)), exec.HideOutput(), exec.Sudo(h))
 		if err != nil {
 			err = fmt.Errorf("failed to get node status: %w", err)
 			if IsConnectionError(err) {
@@ -70,10 +71,10 @@ func KubeNodeReadyFunc(h *cluster.Host) retryFunc {
 				if c.Status == "True" {
 					return nil
 				}
-				return fmt.Errorf("node %s is not ready", h.Metadata.Hostname)
+				return fmt.Errorf("node %s is not ready", nodeName)
 			}
 		}
-		return fmt.Errorf("node %s 'Ready' condition not found", h.Metadata.Hostname)
+		return fmt.Errorf("node %s 'Ready' condition not found", nodeName)
 	}
 }
 


### PR DESCRIPTION
- Normalize node names to lowercase before kubectl maintenance and readiness checks.
- Catch case-only hostname duplicates earlier and keep reset flows aligned with the same node identity.
