### PR TITLE
Fix unnecessary reinstall when dynamicConfig is enabled

### DIFF
--- a/phase/gather_k0s_facts.go
+++ b/phase/gather_k0s_facts.go
@@ -401,7 +401,7 @@ func (p *GatherK0sFacts) investigateK0s(ctx context.Context, h *cluster.Host) er
 		}
 
 		if p.Config.Spec.K0s.DynamicConfig {
-			h.InstallFlags.AddOrReplace("--enable-dynamic-config")
+			h.InstallFlags.AddOrReplace("--enable-dynamic-config=true")
 		}
 	}
 


### PR DESCRIPTION
Fixes #1094

When dynamicConfig is enabled, k0sctl added `--enable-dynamic-config` without a value but k0s returns the value as `--enable-dynamic-config=true`, which made k0sctl think the flag changed, which caused k0sctl to trigger a reinstall.
