### PR TITLE
Fix corrupted Windows k0s install command (Flags double-unquote, --kubelet-extra-args double-quote)

### DIFF
--- a/pkg/apis/k0sctl.k0sproject.io/v1beta1/cluster/flags.go
+++ b/pkg/apis/k0sctl.k0sproject.io/v1beta1/cluster/flags.go
@@ -11,6 +11,18 @@ import (
 // Flags is a slice of strings with added functions to ease manipulating lists of command-line flags
 type Flags []string
 
+// isQuoted reports whether s is wrapped in a matching pair of single or double
+// quotes. Only such values are safe to pass to shellescape.Unquote; a bare
+// value must be left untouched so that literal backslashes (Windows paths) are
+// not consumed as escape sequences.
+func isQuoted(s string) bool {
+	if len(s) < 2 {
+		return false
+	}
+	c := s[0]
+	return (c == '\'' || c == '"') && s[len(s)-1] == c
+}
+
 // Add adds a flag regardless if it exists already or not
 func (f *Flags) Add(s string) {
 	if ns, err := shellescape.Unquote(s); err == nil {
@@ -35,7 +47,10 @@ func (f *Flags) AddUnlessExist(s string) {
 	if f.Include(s) {
 		return
 	}
-	f.Add(s)
+	// s has already been unquoted above; append it directly rather than going
+	// through Add, which would unquote a second time and mangle values that
+	// contain backslashes (e.g. Windows paths like C:\var\lib\k0s).
+	*f = append(*f, s)
 }
 
 // AddOrReplace replaces a flag with the same prefix or adds a new one if one does not exist
@@ -48,7 +63,10 @@ func (f *Flags) AddOrReplace(s string) {
 		(*f)[idx] = s
 		return
 	}
-	f.Add(s)
+	// s has already been unquoted above; append it directly rather than going
+	// through Add, which would unquote a second time and mangle values that
+	// contain backslashes (e.g. Windows paths like C:\var\lib\k0s).
+	*f = append(*f, s)
 }
 
 // Include returns true if a flag with a matching prefix can be found
@@ -176,8 +194,14 @@ func (f Flags) Each(fn func(string, string)) {
 			fn(flag, "")
 		} else {
 			key, value := flag[:sepidx], flag[sepidx+1:]
-			if unq, err := shellescape.Unquote(value); err == nil {
-				value = unq
+			// Only unquote a value that is actually wrapped in matching quotes.
+			// A bare value (e.g. a Windows path like C:\var\lib\k0s) must be
+			// left intact, since shellescape.Unquote would consume its
+			// backslashes.
+			if isQuoted(value) {
+				if unq, err := shellescape.Unquote(value); err == nil {
+					value = unq
+				}
 			}
 			fn(key, value)
 		}

--- a/pkg/apis/k0sctl.k0sproject.io/v1beta1/cluster/flags_quoting_test.go
+++ b/pkg/apis/k0sctl.k0sproject.io/v1beta1/cluster/flags_quoting_test.go
@@ -1,0 +1,125 @@
+package cluster
+
+import (
+	"testing"
+
+	"github.com/k0sproject/rig/v2/powershell"
+	"github.com/stretchr/testify/require"
+)
+
+// posixQuoter (declared in flags_test.go) mirrors the ShellQuote of a POSIX
+// remotefs: simple tokens are left bare, only values that need it are quoted.
+
+// winQuoter mirrors remotefs.WinFS.ShellQuote, which is powershell.SingleQuote
+// and therefore *always* wraps its argument in single quotes.
+type winQuoter struct{}
+
+func (winQuoter) ShellQuote(s string) string { return powershell.SingleQuote(s) }
+
+// buildInstallFlags reproduces the flag construction that Host.K0sInstallFlags
+// performs for a worker (data-dir/token-file/kubelet-root-dir via the host
+// quoter, plus a --kubelet-extra-args built from a nested Flags), and returns
+// the final command tail as K0sInstallCommand would render it via Join.
+func buildInstallFlags(q quoter, dataDir, tokenFile, kubeletRootDir string) string {
+	var flags Flags
+	flags.AddOrReplace("--data-dir=" + quote(q, dataDir))
+	flags.AddUnlessExist("--token-file=" + quote(q, tokenFile))
+	flags.AddOrReplace("--kubelet-root-dir=" + quote(q, kubeletRootDir))
+
+	var extra Flags
+	extra.AddOrReplace("--cluster-dns=10.96.0.10")
+	extra.AddOrReplace("--hostname-override=EC2AMAZ-XXXX")
+	// K0sInstallFlags builds --kubelet-extra-args from extra.Join(q); the outer
+	// quote that used to wrap this has been removed (see issue #1114).
+	flags.AddOrReplace("--kubelet-extra-args=" + extra.Join(q))
+
+	return flags.Join(q)
+}
+
+// TestK0sInstallFlagsQuoting is the table form of the standalone repro from
+// issue #1114. It runs against both a POSIX quoter and a Windows SingleQuote
+// quoter so the Windows-specific double-unquote (backslash paths) and
+// double-quote (--kubelet-extra-args) regressions are guarded.
+func TestK0sInstallFlagsQuoting(t *testing.T) {
+	tests := []struct {
+		name           string
+		quoter         quoter
+		dataDir        string
+		tokenFile      string
+		kubeletRootDir string
+		expected       string
+	}{
+		{
+			name:           "posix",
+			quoter:         posixQuoter{},
+			dataDir:        "/var/lib/k0s",
+			tokenFile:      "/etc/k0s/k0stoken",
+			kubeletRootDir: "/var/lib/k0s/kubelet",
+			expected:       `--data-dir=/var/lib/k0s --token-file=/etc/k0s/k0stoken --kubelet-root-dir=/var/lib/k0s/kubelet --kubelet-extra-args='--cluster-dns=10.96.0.10 --hostname-override=EC2AMAZ-XXXX'`,
+		},
+		{
+			name:           "windows",
+			quoter:         winQuoter{},
+			dataDir:        powershell.ToWindowsPath("C:/var/lib/k0s"),
+			tokenFile:      powershell.ToWindowsPath("C:/etc/k0s/k0stoken"),
+			kubeletRootDir: powershell.ToWindowsPath("C:/var/lib/k0s/kubelet"),
+			expected:       `--data-dir='C:\var\lib\k0s' --token-file='C:\etc\k0s\k0stoken' --kubelet-root-dir='C:\var\lib\k0s\kubelet' --kubelet-extra-args='--cluster-dns=10.96.0.10 --hostname-override=EC2AMAZ-XXXX'`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := buildInstallFlags(tt.quoter, tt.dataDir, tt.tokenFile, tt.kubeletRootDir)
+			require.Equal(t, tt.expected, got)
+		})
+	}
+}
+
+// TestFlagsUnquoteOnce guards the primitive: a value quoted once by the host
+// quoter must be stored unquoted exactly once, with any literal backslashes
+// intact. Before the fix, AddOrReplace/AddUnlessExist unquoted a second time
+// via Add, and Each unquoted bare values, so Windows backslash paths were
+// silently corrupted (C:\var\lib\k0s -> C:varlibk0s).
+func TestFlagsUnquoteOnce(t *testing.T) {
+	quoters := []struct {
+		name string
+		q    quoter
+	}{
+		{"posix", posixQuoter{}},
+		{"windows", winQuoter{}},
+	}
+
+	for _, qc := range quoters {
+		t.Run(qc.name, func(t *testing.T) {
+			const winPath = `C:\var\lib\k0s`
+
+			t.Run("AddOrReplace preserves backslashes", func(t *testing.T) {
+				var f Flags
+				f.AddOrReplace("--data-dir=" + quote(qc.q, winPath))
+				require.Equal(t, []string{`--data-dir=` + winPath}, []string(f))
+			})
+
+			t.Run("AddUnlessExist preserves backslashes", func(t *testing.T) {
+				var f Flags
+				f.AddUnlessExist("--data-dir=" + quote(qc.q, winPath))
+				require.Equal(t, []string{`--data-dir=` + winPath}, []string(f))
+			})
+
+			t.Run("Each leaves a bare value untouched", func(t *testing.T) {
+				f := Flags{`--data-dir=` + winPath}
+				f.Each(func(k, v string) {
+					require.Equal(t, "--data-dir", k)
+					require.Equal(t, winPath, v)
+				})
+			})
+
+			t.Run("Each still unquotes a genuinely quoted value", func(t *testing.T) {
+				f := Flags{`--foo='bar baz'`}
+				f.Each(func(k, v string) {
+					require.Equal(t, "--foo", k)
+					require.Equal(t, "bar baz", v)
+				})
+			})
+		})
+	}
+}

--- a/pkg/apis/k0sctl.k0sproject.io/v1beta1/cluster/host.go
+++ b/pkg/apis/k0sctl.k0sproject.io/v1beta1/cluster/host.go
@@ -544,7 +544,12 @@ func (h *Host) K0sInstallFlags() (Flags, error) {
 			extra.AddOrReplace("--hostname-override=" + h.HostnameOverride)
 		}
 		if extra != nil {
-			flags.AddOrReplace(fmt.Sprintf("--kubelet-extra-args=%s", quote(h.FS(), extra.Join(h.FS()))))
+			// extra.Join already quotes each value with the host quoter; the
+			// final flags.Join in K0sInstallCommand quotes the whole
+			// --kubelet-extra-args value once more. Quoting here as well would
+			// double-quote it (on Windows SingleQuote wraps every value),
+			// producing a mangled, backtick-escaped result.
+			flags.AddOrReplace(fmt.Sprintf("--kubelet-extra-args=%s", extra.Join(h.FS())))
 		}
 	}
 


### PR DESCRIPTION
On a Windows worker host (`Host.FS()` is rig/v2 `WinFS`, whose `ShellQuote` is
`powershell.SingleQuote` and always wraps its argument in single quotes), the
generated `k0s install worker …` command is corrupted two ways:

- `--data-dir` / `--token-file` / `--kubelet-root-dir` lose their backslashes
  (`C:\var\lib\k0s` → `C:varlibk0s`), so k0s resolves them as relative paths.
- `--kubelet-extra-args` is double-quoted and backtick-mangled
  (`'--cluster-dns=``10.96.0.10`` …'`).

Root cause:

1. `Flags.AddOrReplace` / `AddUnlessExist` unquote their argument, then call
   `Flags.Add`, which unquotes again. `shellescape.Unquote` is not idempotent
   on backslashes — the second pass treats `\` as an escape and eats it.
2. `Flags.Each` (used by `Join`) unquotes the value part unconditionally, with
   the same hazard for a bare backslash value.
3. `Host.K0sInstallFlags` wraps `extra.Join(h.FS())` in an extra `quote(...)`,
   but the final `flags.Join` already quotes once; on Windows `SingleQuote`
   wraps every value, so this double-quotes.

All three are Windows-specific because rig/v2's `SingleQuote` wraps every value,
unlike POSIX `shellescape.Quote` which leaves simple tokens bare.

Fix:

1. `AddOrReplace` / `AddUnlessExist` append the already-unquoted value directly
   instead of routing through `Add` (which would unquote a second time).
2. `Flags.Each` only unquotes a value actually wrapped in matching quotes (new
   `isQuoted` helper), leaving bare backslash values intact.
3. `K0sInstallFlags` drops the redundant outer `quote(...)`; the final
   `flags.Join` in `K0sInstallCommand` quotes once, cleanly.

Per review on the issue, the standalone repro is now a table test run against
both a POSIX quoter and a Windows `SingleQuote` quoter: `TestK0sInstallFlagsQuoting`
asserts the full rendered command tail for both, and `TestFlagsUnquoteOnce`
guards the `Flags` primitives against backslash corruption on both. Both fail on
the pre-fix code and pass after; existing `host_posix_test.go` suites are
unchanged. `go vet` and `gofmt` are clean.

Fixes #1114
