### PR TITLE
Remove long-removed podSecurityPolicy from k0sctl's init default config

### DIFF
--- a/cmd/init.go
+++ b/cmd/init.go
@@ -40,8 +40,6 @@ spec:
     kubeProxy:
       disabled: false
       mode: iptables
-  podSecurityPolicy:
-    defaultPolicy: 00-k0s-privileged
   telemetry:
     enabled: true
   installConfig:


### PR DESCRIPTION
See:

* #648
* k0sproject/k0s#3986
* k0sproject/k0s#8018