### PR TITLE
fix: read the existing k0s config with sudo

### DIFF
--- a/phase/configure_k0s.go
+++ b/phase/configure_k0s.go
@@ -281,7 +281,7 @@ func (p *ConfigureK0s) buildConfigValidateCommand(h *cluster.Host, configPath st
 
 func (p *ConfigureK0s) configureK0s(ctx context.Context, h *cluster.Host) error {
 	path := h.K0sConfigPath()
-	if h.FS().FileExist(path) {
+	if h.Sudo().FS().FileExist(path) {
 		if ok, _ := h.Sudo().FS().FileContains(path, " generated-by-k0sctl"); !ok {
 			newpath := path + ".old"
 			log.Warnf("%s: an existing config was found and will be backed up as %s", h, newpath)
@@ -305,7 +305,7 @@ func (p *ConfigureK0s) configureK0s(ctx context.Context, h *cluster.Host) error 
 	configPath := h.K0sConfigPath()
 	configDir := gopath.Dir(configPath)
 
-	if !h.FS().FileExist(configDir) {
+	if !h.Sudo().FS().FileExist(configDir) {
 		if err := h.Sudo().FS().MkdirAll(configDir, 0o750); err != nil {
 			return fmt.Errorf("failed to create k0s configuration directory: %w", err)
 		}

--- a/phase/gather_k0s_facts.go
+++ b/phase/gather_k0s_facts.go
@@ -291,10 +291,16 @@ func (p *GatherK0sFacts) investigateK0s(ctx context.Context, h *cluster.Host) er
 
 	log.Debugf("%s: has k0s binary version %s", h, h.Metadata.K0sBinaryVersion)
 
-	if h.IsController() && h.FS().FileExist(h.K0sConfigPath()) {
-		cfgData, err := h.FS().ReadFile(h.K0sConfigPath())
-		cfg := string(cfgData)
-		if cfg != "" && err == nil {
+	// The k0s config is written as root:root 0600 into a 0750 directory, so both
+	// the existence check and the read require elevation. Without it the config
+	// looks missing to any non-root connection, which makes every apply believe
+	// the configuration changed.
+	if h.IsController() && h.Sudo().FS().FileExist(h.K0sConfigPath()) {
+		cfgData, err := h.Sudo().FS().ReadFile(h.K0sConfigPath())
+		if err != nil {
+			return fmt.Errorf("failed to read existing k0s configuration %s: %w", h.K0sConfigPath(), err)
+		}
+		if cfg := string(cfgData); cfg != "" {
 			log.Infof("%s: found existing configuration", h)
 			h.Metadata.K0sExistingConfig = cfg
 		}

--- a/smoke-test/.gitignore
+++ b/smoke-test/.gitignore
@@ -3,3 +3,4 @@ id_rsa*
 k0sctl_040
 *.tar.gz
 *.iid
+*.log

--- a/smoke-test/smoke-basic-rootless.sh
+++ b/smoke-test/smoke-basic-rootless.sh
@@ -29,6 +29,19 @@ echo "* Starting apply"
 ../k0sctl apply --config "${K0SCTL_CONFIG}" --kubeconfig-out applykubeconfig --debug
 echo "* Apply OK"
 
+echo "* Re-applying to verify a non-root apply is idempotent"
+../k0sctl apply --config "${K0SCTL_CONFIG}" --debug > reapply.log 2>&1 || { cat reapply.log; exit 1; }
+echo "* Re-apply OK"
+
+echo "* Verify the existing k0s config was readable as ${SSH_USER}"
+grep -q "found existing configuration" reapply.log
+
+echo "* Verify k0s was not reconfigured and restarted for no reason"
+if grep -q "restarting k0s service" reapply.log; then
+  echo "FAIL: k0s was restarted even though nothing changed"
+  exit 1
+fi
+
 echo "* Verify hooks were executed on the host"
 bootloose ssh root@manager0 -- grep -q hello "~${SSH_USER}/apply.hook"
 


### PR DESCRIPTION
Partially fixes #1142

k0sctl writes /etc/k0s/k0s.yaml as root:root 0600 into a 0750 directory, but GatherK0sFacts stat'd and read it without elevation. For any host connected as a non-root sudo user the stat fails with EACCES, so the file looks missing, Metadata.K0sExistingConfig stays empty and every apply concludes the configuration changed. That rewrote the config and restarted k0s on all controllers on every apply, in parallel.

Because the FileExist guard failed, the ReadFile below it was never reached, so there was no error to report and nothing was logged. Both calls need sudo. A failing read is now reported instead of being treated as "no existing config", since falling through to configSourceDefault replaces a customized config with a generated k0s default. Note this turns a previously ignored condition into a hard apply failure.

configureK0s had the same problem in two places. The backup branch is gated on a non-sudo FileExist, so a hand-written config was overwritten without the promised .old backup, and the config directory check always reported missing.

Verified with bootloose against a non-root sudo user: before the fix a no-op re-apply logs "configuration will change" and "restarting k0s service" and never logs "found existing configuration"; after it, the re-apply is a no-op. The same run as root was already idempotent despite a differing "# generated-by-k0sctl" timestamp header, confirming the header is not involved - the comparison unmarshals both configs to maps before comparing, so YAML comments cannot reach it.

smoke-basic-rootless applied exactly once, so it could not catch this. It now applies twice and asserts the existing config was found and that k0s was not restarted.

