### PR TITLE
fix: restart controllers one at a time when the config changes

### DIFF
--- a/phase/configure_k0s.go
+++ b/phase/configure_k0s.go
@@ -3,11 +3,13 @@ package phase
 import (
 	"bytes"
 	"context"
+	"errors"
 	"fmt"
 	"io/fs"
 	gopath "path"
 	"slices"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/k0sproject/dig"
@@ -200,7 +202,65 @@ func (p *ConfigureK0s) Run(ctx context.Context) error {
 	controllers := p.Config.Spec.Hosts.Controllers().Filter(func(h *cluster.Host) bool {
 		return !h.Reset && len(h.Metadata.K0sNewConfig) > 0
 	})
-	return p.parallelDo(ctx, controllers, p.configureK0s)
+
+	return p.configureControllers(ctx, controllers, p.installConfig, p.restartK0s)
+}
+
+// configureControllers installs the new configuration on every controller and
+// then restarts the ones that need it. The install and restart functions are
+// parameters so that the ordering guarantees below can be tested without a
+// remote host.
+func (p *ConfigureK0s) configureControllers(ctx context.Context, controllers cluster.Hosts, install, restart func(context.Context, *cluster.Host) error) error {
+	var mu sync.Mutex
+	installed := make(map[*cluster.Host]struct{}, len(controllers))
+
+	// Installing the configuration file does not disrupt a running controller,
+	// so it can happen on every host at once.
+	installErr := p.parallelDo(ctx, controllers, func(ctx context.Context, h *cluster.Host) error {
+		if err := install(ctx, h); err != nil {
+			return err
+		}
+		mu.Lock()
+		defer mu.Unlock()
+		installed[h] = struct{}{}
+		return nil
+	})
+
+	// A host that received the new configuration but was never restarted keeps
+	// running the old one, and the next apply reads the file back as the
+	// existing config and considers the host unchanged, so it would never
+	// restart. Restart what did get installed even when another host failed,
+	// and report the installation failure afterwards.
+	pending := controllers.Filter(func(h *cluster.Host) bool {
+		_, ok := installed[h]
+		return ok
+	})
+
+	// Restarting is disruptive. With embedded etcd, restarting every controller
+	// at once loses quorum, so restart them one at a time and wait for each to
+	// report ready before touching the next, the same way UpgradeControllers
+	// does it.
+	//
+	// Hosts.Each returns the callback error as-is, unlike the parallel helpers
+	// which prefix it with the host, so name the host here.
+	restartErr := controllersNeedingRestart(pending).Each(ctx, func(ctx context.Context, h *cluster.Host) error {
+		if err := restart(ctx, h); err != nil {
+			return fmt.Errorf("%s: %w", h, err)
+		}
+		return nil
+	})
+
+	return errors.Join(installErr, restartErr)
+}
+
+// controllersNeedingRestart returns the hosts that must be restarted for a new
+// configuration to take effect. Hosts that are not running k0s yet get started
+// by a later phase, and hosts pending an upgrade are restarted by
+// UpgradeControllers, which already serializes and gates on readiness.
+func controllersNeedingRestart(controllers cluster.Hosts) cluster.Hosts {
+	return controllers.Filter(func(h *cluster.Host) bool {
+		return h.Metadata.K0sRunningVersion != nil && !h.Metadata.NeedsUpgrade
+	})
 }
 
 // hostsSans returns a dedicated copy of the base sans extended with the
@@ -290,7 +350,7 @@ func (p *ConfigureK0s) buildConfigValidateCommand(h *cluster.Host, configPath st
 	return h.Configurer.K0sCmdf(`validate config --config "%s"`, configPath)
 }
 
-func (p *ConfigureK0s) configureK0s(ctx context.Context, h *cluster.Host) error {
+func (p *ConfigureK0s) installConfig(_ context.Context, h *cluster.Host) error {
 	path := h.K0sConfigPath()
 	if h.Sudo().FS().FileExist(path) {
 		if ok, _ := h.Sudo().FS().FileContains(path, " generated-by-k0sctl"); !ok {
@@ -329,18 +389,39 @@ func (p *ConfigureK0s) configureK0s(ctx context.Context, h *cluster.Host) error 
 		log.Debugf("%s: failed to chmod configuration file %s: %v", h, configPath, err)
 	}
 
-	if h.Metadata.K0sRunningVersion != nil && !h.Metadata.NeedsUpgrade {
-		log.Infof("%s: restarting k0s service", h)
-		svc, err := h.Sudo().Service(h.K0sServiceName())
-		if err != nil {
-			return fmt.Errorf("get service %s: %w", h.K0sServiceName(), err)
-		}
-		if err := svc.Restart(ctx); err != nil {
-			return err
-		}
+	return nil
+}
 
-		log.Infof("%s: waiting for k0s service to start", h)
-		return retry.WithDefaultTimeout(ctx, node.ServiceRunningFunc(h, h.K0sServiceName()))
+// restartK0s restarts a single controller and waits until it serves traffic
+// again. Callers must invoke this one host at a time to keep etcd quorum.
+func (p *ConfigureK0s) restartK0s(ctx context.Context, h *cluster.Host) error {
+	log.Infof("%s: restarting k0s service", h)
+	svc, err := h.Sudo().Service(h.K0sServiceName())
+	if err != nil {
+		return fmt.Errorf("get service %s: %w", h.K0sServiceName(), err)
+	}
+	if err := svc.Restart(ctx); err != nil {
+		return err
+	}
+
+	log.Infof("%s: waiting for k0s service to start", h)
+	if err := retry.WithDefaultTimeout(ctx, node.ServiceRunningFunc(h, h.K0sServiceName())); err != nil {
+		return fmt.Errorf("wait for k0s service start: %w", err)
+	}
+
+	// A running service is not the same as a ready controller. Moving on while
+	// the api server is still coming up would stack another restart on top of a
+	// cluster that has not recovered from the previous one yet.
+	log.Infof("%s: waiting for the controller to become ready", h)
+	err = retry.WithDefaultTimeout(ctx, func(_ context.Context) error {
+		out, err := h.Sudo().ExecOutput(h.Configurer.KubectlCmdf(h, h.K0sDataDir(), "get --raw='/readyz?verbose=true'"))
+		if err != nil {
+			return fmt.Errorf("readiness endpoint reports %q: %w", out, err)
+		}
+		return nil
+	})
+	if err != nil {
+		return fmt.Errorf("controller did not reach ready state: %w", err)
 	}
 
 	return nil

--- a/phase/configure_k0s_test.go
+++ b/phase/configure_k0s_test.go
@@ -1,8 +1,12 @@
 package phase
 
 import (
+	"context"
+	"errors"
 	"strings"
+	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/k0sproject/dig"
 	"github.com/k0sproject/k0sctl/configurer/linux"
@@ -172,4 +176,131 @@ func apiAddressFromConfig(t *testing.T, cfg string) string {
 func sansFromConfig(t *testing.T, cfg string) []string {
 	t.Helper()
 	return parseAPISpec(t, cfg).Spec.API.Sans
+}
+
+func TestControllersNeedingRestart(t *testing.T) {
+	running := &cluster.Host{Role: "controller"}
+	running.Metadata.K0sRunningVersion = version.MustParse("v1.36.3+k0s.2")
+
+	notRunning := &cluster.Host{Role: "controller"}
+
+	pendingUpgrade := &cluster.Host{Role: "controller"}
+	pendingUpgrade.Metadata.K0sRunningVersion = version.MustParse("v1.36.2+k0s.0")
+	pendingUpgrade.Metadata.NeedsUpgrade = true
+
+	got := controllersNeedingRestart(cluster.Hosts{running, notRunning, pendingUpgrade})
+
+	// A host that is not running k0s yet is started by a later phase, and a host
+	// pending an upgrade is restarted by UpgradeControllers.
+	require.Equal(t, cluster.Hosts{running}, got)
+}
+
+// runningController returns a controller that is up and not pending an upgrade,
+// which is the only kind that configureControllers restarts.
+func runningController(t *testing.T, address string) *cluster.Host {
+	t.Helper()
+	h := &cluster.Host{Role: "controller"}
+	h.SSH = &ssh.Config{Address: address}
+	h.Metadata.K0sRunningVersion = version.MustParse("v1.36.3+k0s.2")
+	return h
+}
+
+func TestConfigureControllersRestartsOneAtATime(t *testing.T) {
+	h1 := runningController(t, "10.0.0.1")
+	h2 := runningController(t, "10.0.0.2")
+
+	var (
+		inFlight    atomic.Int32
+		maxInFlight atomic.Int32
+	)
+	started := make(chan *cluster.Host, 2)
+	release := make(chan struct{})
+
+	restart := func(_ context.Context, h *cluster.Host) error {
+		n := inFlight.Add(1)
+		for {
+			m := maxInFlight.Load()
+			if n <= m || maxInFlight.CompareAndSwap(m, n) {
+				break
+			}
+		}
+		defer inFlight.Add(-1)
+
+		started <- h
+		if h == h1 {
+			// Stand in for a controller that has restarted but is not serving
+			// /readyz yet.
+			<-release
+		}
+		return nil
+	}
+
+	p := &ConfigureK0s{}
+	p.SetManager(&Manager{})
+
+	done := make(chan error, 1)
+	go func() {
+		done <- p.configureControllers(t.Context(), cluster.Hosts{h1, h2}, func(context.Context, *cluster.Host) error { return nil }, restart)
+	}()
+
+	require.Same(t, h1, <-started, "the first controller should be restarted first")
+
+	select {
+	case h := <-started:
+		close(release)
+		t.Fatalf("%s was restarted while the first controller was still coming up", h)
+	case <-time.After(50 * time.Millisecond):
+	}
+
+	close(release)
+	require.Same(t, h2, <-started, "the second controller should be restarted after the first one is ready")
+	require.NoError(t, <-done)
+
+	// The real guard: an accidental switch back to parallel execution would let
+	// the second restart enter while the first one is held.
+	require.Equal(t, int32(1), maxInFlight.Load(), "controllers were restarted concurrently")
+}
+
+func TestConfigureControllersRestartsHostsThatInstalledWhenAnotherFails(t *testing.T) {
+	h1 := runningController(t, "10.0.0.1")
+	h2 := runningController(t, "10.0.0.2")
+
+	install := func(_ context.Context, h *cluster.Host) error {
+		if h == h2 {
+			return errors.New("disk full")
+		}
+		return nil
+	}
+
+	var restarted cluster.Hosts
+	restart := func(_ context.Context, h *cluster.Host) error {
+		restarted = append(restarted, h)
+		return nil
+	}
+
+	p := &ConfigureK0s{}
+	p.SetManager(&Manager{})
+
+	err := p.configureControllers(t.Context(), cluster.Hosts{h1, h2}, install, restart)
+	require.ErrorContains(t, err, "disk full")
+
+	// h1 has the new configuration on disk. If it is not restarted now, the next
+	// apply reads that file back as the existing config and skips the host, so
+	// it would keep running the old configuration indefinitely.
+	require.Equal(t, cluster.Hosts{h1}, restarted)
+}
+
+func TestConfigureControllersNamesTheHostThatFailedToRestart(t *testing.T) {
+	h := runningController(t, "10.0.0.1")
+
+	restart := func(context.Context, *cluster.Host) error {
+		return errors.New("wait for k0s service start")
+	}
+
+	p := &ConfigureK0s{}
+	p.SetManager(&Manager{})
+
+	err := p.configureControllers(t.Context(), cluster.Hosts{h}, func(context.Context, *cluster.Host) error { return nil }, restart)
+	require.ErrorContains(t, err, "wait for k0s service start")
+	require.ErrorContains(t, err, "10.0.0.1", "the error should identify the controller that failed")
 }


### PR DESCRIPTION
Fixes #1142

ConfigureK0s handed every controller to parallelDo, which batches at spec.options.concurrency.limit (default 30). With three controllers that put all three k0s restarts in a single batch, so an embedded-etcd cluster lost quorum on every configuration change. The only gate after the restart was ServiceRunningFunc, which just asks the init system whether the unit is active and says nothing about the api server being reachable.

Split the phase into the two halves it always was. Installing the config file does not disrupt a running controller, so that stays parallel. Restarting does, so it now walks the controllers with Hosts.Each and waits for /readyz on each one before touching the next, matching what UpgradeControllers already does.

This is not a theoretical window. On a single controller, k0s reports the service as running roughly six seconds before the api server accepts connections:

    16:24:14  waiting for the controller to become ready
    16:24:15  The connection to the server localhost:6443 was refused
    16:24:20  [+]ping ok

The old code returned as soon as the service was active, so on a multi-controller cluster it would restart the next controller inside that window.

Hosts that are not running k0s yet are skipped, as before, and so are hosts pending an upgrade, since UpgradeControllers restarts those serially with its own readiness gate. That selection is now named and unit tested.

Serialization is enforced by using Hosts.Each rather than parallelDo, and is
covered by a hermetic test that holds one controller inside its restart and
asserts the next one does not start until it is released.

- BatchedParallelEach short-circuits on the first failing batch, so with a low spec.options.concurrency.limit the installed set is a prefix of the controllers, not "all minus the failures". Intended.
- Restarting the successful subset means a config change can now land on some controllers and not others when install fails partway — that's the deliberate tradeoff versus permanent silent staleness.
- Each still stops at the first failed restart, so a controller whose restart never ran has the new file on disk and gets skipped next apply. Left as-is on purpose: continuing past a controller that didn't come back ready is exactly the quorum loss this PR fixes.

