### PR TITLE
ci: test against latest and previous bootloose images

### DIFF
--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -36,14 +36,21 @@ jobs:
 
   smoke-basic:
     strategy:
+      fail-fast: false
       matrix:
+        # Latest and previous release of each distro family that bootloose
+        # ships images for. See the "Choosing the OS image to run" section of
+        # https://github.com/k0sproject/bootloose for the current image list.
         image:
-          - quay.io/k0sproject/bootloose-alpine3.22
-          - quay.io/k0sproject/bootloose-amazonlinux2023
-          - quay.io/k0sproject/bootloose-debian12
-          - quay.io/k0sproject/bootloose-fedora42
-          - quay.io/k0sproject/bootloose-rockylinux9
-          - quay.io/k0sproject/bootloose-ubuntu24.04
+          - quay.io/k0sproject/bootloose-alpine3.23:latest
+          - quay.io/k0sproject/bootloose-alpine3.22:latest
+          - quay.io/k0sproject/bootloose-amazonlinux2023:latest
+          - quay.io/k0sproject/bootloose-debian13:latest
+          - quay.io/k0sproject/bootloose-debian12:latest
+          - quay.io/k0sproject/bootloose-fedora42:latest
+          - quay.io/k0sproject/bootloose-rockylinux9:latest
+          - quay.io/k0sproject/bootloose-ubuntu26.04:latest
+          - quay.io/k0sproject/bootloose-ubuntu24.04:latest
     name: Basic 1+1 smoke
     needs: build
     runs-on: ubuntu-24.04
@@ -60,8 +67,8 @@ jobs:
     strategy:
       matrix:
         image:
-          - quay.io/k0sproject/bootloose-debian12
-          - quay.io/k0sproject/bootloose-ubuntu24.04
+          - quay.io/k0sproject/bootloose-debian13:latest
+          - quay.io/k0sproject/bootloose-ubuntu26.04:latest
     name: Basic 1+1 smoke (regular user login)
     needs: build
     runs-on: ubuntu-24.04
@@ -96,7 +103,7 @@ jobs:
     strategy:
       matrix:
         image:
-          - quay.io/k0sproject/bootloose-alpine3.22
+          - quay.io/k0sproject/bootloose-alpine3.23:latest
     name: Basic 1+1 smoke using openssh client
     needs: build
     runs-on: ubuntu-24.04
@@ -113,7 +120,7 @@ jobs:
     strategy:
       matrix:
         image:
-          - quay.io/k0sproject/bootloose-alpine3.22
+          - quay.io/k0sproject/bootloose-alpine3.23:latest
     name: Basic 1+1 smoke using multidoc yamls
     needs: build
     runs-on: ubuntu-24.04
@@ -129,9 +136,11 @@ jobs:
   smoke-files:
     strategy:
       matrix:
+        # Debian family only: smoke-files.sh installs `tree` with apt-get and
+        # creates its test user with useradd, neither of which Alpine has.
         image:
-          - quay.io/k0sproject/bootloose-ubuntu24.04
-          - quay.io/k0sproject/bootloose-alpine3.22
+          - quay.io/k0sproject/bootloose-ubuntu26.04:latest
+          - quay.io/k0sproject/bootloose-debian13:latest
     name: Basic file upload smoke
     needs: build
     runs-on: ubuntu-24.04
@@ -140,13 +149,15 @@ jobs:
       - uses: actions/checkout@v7
       - uses: ./.github/actions/smoke-test-cache
       - name: Run smoke tests
+        env:
+          LINUX_IMAGE: ${{ matrix.image }}
         run: make smoke-files
 
   smoke-dynamic:
     strategy:
       matrix:
         image:
-          - quay.io/k0sproject/bootloose-alpine3.22
+          - quay.io/k0sproject/bootloose-alpine3.23:latest
     name: Basic dynamic config smoke
     needs: build
     runs-on: ubuntu-24.04
@@ -155,6 +166,8 @@ jobs:
       - uses: actions/checkout@v7
       - uses: ./.github/actions/smoke-test-cache
       - name: Run smoke tests
+        env:
+          LINUX_IMAGE: ${{ matrix.image }}
         run: make smoke-dynamic
 
   smoke-os-override:
@@ -183,10 +196,10 @@ jobs:
     strategy:
       matrix:
         image:
-          - quay.io/k0sproject/bootloose-alpine3.22
-          - quay.io/k0sproject/bootloose-amazonlinux2023
-          - quay.io/k0sproject/bootloose-rockylinux9
-          - quay.io/k0sproject/bootloose-ubuntu24.04
+          - quay.io/k0sproject/bootloose-alpine3.23:latest
+          - quay.io/k0sproject/bootloose-amazonlinux2023:latest
+          - quay.io/k0sproject/bootloose-rockylinux9:latest
+          - quay.io/k0sproject/bootloose-ubuntu26.04:latest
         k0s_from:
           - v1.21.6+k0s.0
     name: Upgrade
@@ -206,8 +219,8 @@ jobs:
     strategy:
       matrix:
         image:
-          - quay.io/k0sproject/bootloose-alpine3.22
-          - quay.io/k0sproject/bootloose-ubuntu24.04
+          - quay.io/k0sproject/bootloose-alpine3.23:latest
+          - quay.io/k0sproject/bootloose-ubuntu26.04:latest
         k0s_from:
           - v1.21.6+k0s.0
     name: Dry run
@@ -227,8 +240,8 @@ jobs:
     strategy:
       matrix:
         image:
-          - quay.io/k0sproject/bootloose-rockylinux9
-          - quay.io/k0sproject/bootloose-ubuntu24.04
+          - quay.io/k0sproject/bootloose-rockylinux9:latest
+          - quay.io/k0sproject/bootloose-ubuntu26.04:latest
 
     name: Apply + reset
     needs: build
@@ -246,9 +259,9 @@ jobs:
     strategy:
       matrix:
         image:
-          - quay.io/k0sproject/bootloose-alpine3.22
-          - quay.io/k0sproject/bootloose-rockylinux9
-          - quay.io/k0sproject/bootloose-ubuntu24.04
+          - quay.io/k0sproject/bootloose-alpine3.23:latest
+          - quay.io/k0sproject/bootloose-rockylinux9:latest
+          - quay.io/k0sproject/bootloose-ubuntu26.04:latest
 
     name: Apply + backup + reset + restore
     needs: build
@@ -279,7 +292,7 @@ jobs:
     strategy:
       matrix:
         image:
-          - quay.io/k0sproject/bootloose-alpine3.22
+          - quay.io/k0sproject/bootloose-alpine3.23:latest
 
     name: Controller swap
     needs: build
@@ -297,8 +310,8 @@ jobs:
     strategy:
       matrix:
         image:
-          - quay.io/k0sproject/bootloose-alpine3.22
-          - quay.io/k0sproject/bootloose-ubuntu24.04
+          - quay.io/k0sproject/bootloose-alpine3.23:latest
+          - quay.io/k0sproject/bootloose-ubuntu26.04:latest
 
     name: Reinstall (modify install flags)
     needs: build

--- a/smoke-test/.gitignore
+++ b/smoke-test/.gitignore
@@ -4,3 +4,4 @@ k0sctl_040
 *.tar.gz
 *.iid
 *.log
+kubectl

--- a/smoke-test/bootloose.yaml.osoverride.tpl
+++ b/smoke-test/bootloose.yaml.osoverride.tpl
@@ -5,7 +5,7 @@ machines:
 - count: 1
   backend: docker
   spec:
-    image: quay.io/k0sproject/bootloose-ubuntu22.04
+    image: quay.io/k0sproject/bootloose-ubuntu26.04:latest
     name: manager%d
     privileged: true
     volumes:

--- a/smoke-test/bootloose.yaml.single.tpl
+++ b/smoke-test/bootloose.yaml.single.tpl
@@ -5,7 +5,7 @@ machines:
 - count: 1
   backend: docker
   spec:
-    image: quay.io/k0sproject/bootloose-ubuntu22.04
+    image: quay.io/k0sproject/bootloose-ubuntu26.04:latest
     name: manager%d
     privileged: true
     volumes:

--- a/smoke-test/smoke.common.sh
+++ b/smoke-test/smoke.common.sh
@@ -1,6 +1,6 @@
 BOOTLOOSE_TEMPLATE=${BOOTLOOSE_TEMPLATE:-"bootloose.yaml.tpl"}
 
-export LINUX_IMAGE="${LINUX_IMAGE:-"quay.io/k0sproject/bootloose-ubuntu22.04"}"
+export LINUX_IMAGE="${LINUX_IMAGE:-"quay.io/k0sproject/bootloose-ubuntu26.04:latest"}"
 export PRESERVE_CLUSTER="${PRESERVE_CLUSTER:-""}"
 export K0S_VERSION
 


### PR DESCRIPTION
The smoke matrices had drifted behind the images bootloose actually ships: alpine3.22, debian12 and ubuntu24.04 are all one release behind their family. Bump the broad smoke-basic matrix to the latest and previous release of each family, taken from the "Choosing the OS image to run" list in the bootloose README. amazonlinux2023, fedora42 and rockylinux9 have no previous release in bootloose, so they stay as they are.

The narrower feature jobs are not distro-coverage matrices, so rather than doubling every one of them they just move forward to the newest image of the family they already pinned.

All refs carry an explicit :latest. That was already the effective behaviour for untagged refs, and pinning to a version tag is not possible uniformly — :latest is only re-pushed when an image changes, so the established repos have a newer vX.Y.Z tag than their :latest while the newest repos have only :latest.

smoke-basic gains fail-fast: false so that one bad distro no longer cancels the other eight legs.

Two stray fixes in the same block:

smoke-files and smoke-dynamic declared a matrix.image but never passed it to the run step, so smoke-files ran twice on the same image and smoke-dynamic's matrix was decoration — both actually ran on whatever smoke.common.sh defaulted to. They now set LINUX_IMAGE like every other job, which also keeps the default bump below from silently relocating them.

The smoke.common.sh default and the two hardcoded templates were on ubuntu22.04, two releases behind and the image the jobs above were accidentally using. They now track the newest ubuntu. smoke-init and smoke-backup-restore-out have no matrix of their own and inherit that default, so they move to ubuntu26.04 along with it.

Also add the generated smoke-test/kubectl to .gitignore; smoke.common.sh downloads it and it was never ignored.