### PR TITLE
Add test for GetResources not-found error path

### DIFF
--- a/pkg/manifest/reader_test.go
+++ b/pkg/manifest/reader_test.go
@@ -151,6 +151,22 @@ metadata:
 	assert.Len(t, services, 1, "Expected 1 Service to be returned")
 }
 
+func TestReader_GetResources_NotFound(t *testing.T) {
+	input := `
+apiVersion: v1
+kind: Pod
+metadata:
+  name: pod1
+`
+	r := &manifest.Reader{}
+	require.NoError(t, r.Parse(strings.NewReader(input)))
+
+	services, err := r.GetResources("v1", "Service")
+	require.Error(t, err, "GetResources should return an error when nothing matches")
+	assert.Nil(t, services)
+	assert.Contains(t, err.Error(), "apiVersion=v1, kind=Service")
+}
+
 func TestReader_ParseHandlesLargeManifest(t *testing.T) {
 	largeData := strings.Repeat("x", 70*1024)
 	manifestStr := fmt.Sprintf(`apiVersion: v1


### PR DESCRIPTION
`Reader.GetResources` in `pkg/manifest/reader.go` returns an error when no parsed resources match the given apiVersion and kind. The existing test (`TestReader_GetResources`) only exercised the success path (Pod/Service found); the not-found branch had no coverage. This adds `TestReader_GetResources_NotFound`, which parses a manifest with only a Pod, queries for a Service, and asserts the error is returned with the expected apiVersion/kind mentioned in the message.

Test only change, no production code touched.

Tested with `go test ./pkg/manifest/... -run TestReader_GetResources -v`, which passes both the existing and new test, plus `go build ./...` and `gofmt -l`, both clean.
