### PR TITLE
fix(files): stop re-downloading unchanged URL sources

### DIFF
--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -138,6 +138,7 @@ jobs:
 
   smoke-files:
     strategy:
+      fail-fast: false
       matrix:
         # Debian family only: smoke-files.sh installs `tree` with apt-get and
         # creates its test user with useradd, neither of which Alpine has.

--- a/README.md
+++ b/README.md
@@ -413,6 +413,16 @@ Example:
   perm: 0600
 ```
 
+Remote source with a checksum:
+
+```yaml
+- name: airgap-bundle
+  src: https://example.com/k0s/k0s-airgap-bundle-%v-linux-%p.tar
+  dstDir: /var/lib/k0s/images/
+  sha256: 0c1f2e5b0a5ea1f0ff5b6ca0b7f6c2a1e5b0a5ea1f0ff5b6ca0b7f6c2a1e5b0a
+  perm: 0600
+```
+
 Inline data example:
 
 ```yaml
@@ -426,12 +436,41 @@ Inline data example:
 * `name`: name of the file "bundle", used only for logging purposes (optional)
 * `src`: File path, an URL or [Glob pattern](https://golang.org/pkg/path/filepath/#Match) to match files to be uploaded. URL sources will be directly downloaded using the target host. If the value is a URL, '%'-prefixed tokens can be used, see [tokens](#tokens). (required when `data` is not set)
 * `data`: Inline file data to write to the destination. Use together with `dst` or `dst` + `dstDir`. (required when `src` is not set)
+* `sha256`: Expected hex encoded sha256 sum of the file. Every source is verified against it: a URL source after the download, a local source before it is uploaded. For an `http` or `https` source it additionally allows a transfer that dies part way through to be continued instead of restarted, up to a few attempts within the same apply; nothing is left on the host between applies, as a download that never finishes is discarded and the next apply starts it over. Can not be used with `data` or with a `src` that matches multiple files. (optional)
 * `dstDir`: Destination directory for the file(s). `k0sctl` will create full directory structure if it does not already exist on the host (default: user home)
 * `dst`: Destination filename for the file. Only usable for single file uploads (default: basename of file)
 * `perm`: File permission mode for uploaded file(s) (default: same as local)
 * `dirPerm`: Directory permission mode for created directories (default: 0755)
 * `user`: User name of file/directory owner, must exist on the host (optional)
 * `group`: Group name of file/directory owner, must exist on the host (optional)
+
+URL sources are not re-downloaded on every apply. After a download, `k0sctl`
+records what an HTTP `HEAD` request from the host reported for the URL, together
+with the size and modification time of the file it wrote, under
+`k0sctl/downloads` in the connecting user's cache directory on the host. A later
+apply skips the download while the file on the host is still the one that was
+written and a fresh `HEAD` still agrees with the record. The record identifies
+the URL by a digest rather than storing it, since a download URL can carry its
+own authorization.
+
+Agreement means a strong `ETag` that has not changed, or an unchanged
+`Last-Modified` (with `Content-Length`, when the server sends one, corroborating
+it). A weak `ETag` promises only that two responses mean the same thing rather
+than that they are the same bytes, and a `Content-Length` on its own cannot tell
+different content of the same length apart, so neither is enough on its own: a
+server that offers nothing better has its file downloaded on every apply, as it
+did before.
+
+A configured `sha256` answers the question instead of the `HEAD` request: a
+destination that was verified against it and has not been written to since is
+left alone, and one that has no record yet is checksummed on the host rather
+than downloaded again. That first checksum is recorded, so a file that was put
+in place by other means is read in full once rather than on every apply.
+
+The `HEAD` comparison and the resuming both need `http` or `https`. A `src` with
+any other scheme is still accepted and still handed to the host's `curl` or
+`wget` as before, and a `sha256` still verifies it and still spares it a
+download, but without one such a source is fetched on every apply.
 
 ###### `spec.hosts[*].hooks` &lt;mapping&gt; (optional)
 

--- a/phase/downloads.go
+++ b/phase/downloads.go
@@ -1,0 +1,18 @@
+package phase
+
+import (
+	"github.com/k0sproject/k0sctl/pkg/apis/k0sctl.k0sproject.io/v1beta1/cluster"
+	"github.com/k0sproject/k0sctl/pkg/download"
+)
+
+// hostTracker returns a download tracker for a host's URL file sources.
+//
+// The transfers go through the sudo filesystem, since the destinations are
+// commonly root-owned, while the bookkeeping goes through the plain one so that
+// it lands in the login user's cache directory and needs no elevated privileges.
+//
+// Create one per host and reuse it for the host's files: it looks the host's
+// cache directory up once and remembers it.
+func hostTracker(h *cluster.Host) *download.Tracker {
+	return download.NewTracker(h.Sudo().FS(), h.FS(), h.String())
+}

--- a/phase/gather_k0s_facts.go
+++ b/phase/gather_k0s_facts.go
@@ -385,7 +385,7 @@ func (p *GatherK0sFacts) investigateK0s(ctx context.Context, h *cluster.Host) er
 		p.Config.Spec.K0s.Version = status.Version
 	}
 
-	needsUpgrade, err := p.needsUpgrade(h)
+	needsUpgrade, err := p.needsUpgrade(ctx, h)
 	if err != nil {
 		return err
 	}
@@ -458,14 +458,18 @@ func (p *GatherK0sFacts) handleRoleMismatch(h *cluster.Host, detectedRole string
 	return nil
 }
 
-func (p *GatherK0sFacts) needsUpgrade(h *cluster.Host) (bool, error) {
+func (p *GatherK0sFacts) needsUpgrade(ctx context.Context, h *cluster.Host) (bool, error) {
 	if h.Reset {
 		return false, nil
 	}
+	var urlFiles []*cluster.UploadFile
 	for _, f := range h.Files {
 		if f.IsURL() {
-			log.Debugf("%s: marked for upgrade because there are URL source file uploads for the host", h)
-			return true, nil
+			// Held back until the local comparisons are done, since asking
+			// whether a URL source is still current talks to the host and to the
+			// server, and a local file that changed has already answered this.
+			urlFiles = append(urlFiles, f)
+			continue
 		}
 		for _, s := range f.Sources {
 			dest := f.DestinationFile
@@ -475,6 +479,18 @@ func (p *GatherK0sFacts) needsUpgrade(h *cluster.Host) (bool, error) {
 			src := path.Join(f.Base, s.Path)
 			if h.FileChanged(src, dest) {
 				log.Debugf("%s: marked for upgrade because file was changed for upload %s", h, src)
+				return true, nil
+			}
+		}
+	}
+	if len(urlFiles) > 0 {
+		// Asking the same question the upload phase will ask keeps a re-apply
+		// from restarting k0s for a download that is not going to happen.
+		tracker := hostTracker(h)
+		for _, f := range urlFiles {
+			dlURL := h.ExpandTokens(f.Source, p.Config.Spec.K0s.Version)
+			if verdict := tracker.Needed(ctx, dlURL, f.DestinationFile, f.Sha256); verdict.Download {
+				log.Debugf("%s: marked for upgrade because %s will be downloaded (%s)", h, f.DestinationFile, verdict.Reason)
 				return true, nil
 			}
 		}

--- a/phase/gather_k0s_facts_test.go
+++ b/phase/gather_k0s_facts_test.go
@@ -1,6 +1,7 @@
 package phase
 
 import (
+	"context"
 	"testing"
 
 	"github.com/k0sproject/k0sctl/pkg/apis/k0sctl.k0sproject.io/v1beta1"
@@ -27,20 +28,22 @@ func TestNeedsUpgrade(t *testing.T) {
 
 	p := GatherK0sFacts{GenericPhase: GenericPhase{Config: cfg}}
 
-	result, err := p.needsUpgrade(h)
+	ctx := context.Background()
+
+	result, err := p.needsUpgrade(ctx, h)
 	require.NoError(t, err)
 	require.False(t, result)
 	h.Metadata.K0sRunningVersion = version.MustParse("1.23.3+k0s.2")
-	result, err = p.needsUpgrade(h)
+	result, err = p.needsUpgrade(ctx, h)
 	require.NoError(t, err)
 	require.True(t, result)
 	h.Metadata.K0sRunningVersion = version.MustParse("1.23.3+k0s.0")
-	result, err = p.needsUpgrade(h)
+	result, err = p.needsUpgrade(ctx, h)
 	require.NoError(t, err)
 	require.True(t, result)
 
 	// UseExistingK0s on a fresh host: binary is unknown so NeedsUpgrade returns false.
-	result, err = p.needsUpgrade(&cluster.Host{UseExistingK0s: true})
+	result, err = p.needsUpgrade(ctx, &cluster.Host{UseExistingK0s: true})
 	require.NoError(t, err)
 	require.False(t, result)
 }

--- a/phase/uploadfiles.go
+++ b/phase/uploadfiles.go
@@ -2,15 +2,21 @@ package phase
 
 import (
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
 	"fmt"
+	"io"
 	"io/fs"
 	"os"
 	"path"
 	"strconv"
+	"strings"
+	"sync"
 	"time"
 
 	"github.com/k0sproject/k0sctl/pkg/apis/k0sctl.k0sproject.io/v1beta1"
 	"github.com/k0sproject/k0sctl/pkg/apis/k0sctl.k0sproject.io/v1beta1/cluster"
+	"github.com/k0sproject/k0sctl/pkg/download"
 	"github.com/k0sproject/rig/v2/remotefs"
 
 	log "github.com/sirupsen/logrus"
@@ -21,6 +27,7 @@ type UploadFiles struct {
 	GenericPhase
 
 	hosts cluster.Hosts
+	sums  sumCache
 }
 
 // Title for the phase
@@ -49,13 +56,17 @@ func (p *UploadFiles) Run(ctx context.Context) error {
 }
 
 func (p *UploadFiles) uploadFiles(ctx context.Context, h *cluster.Host) error {
+	var tracker *download.Tracker
 	for _, f := range h.Files {
 		if ctx.Err() != nil {
 			return fmt.Errorf("upload canceled: %w", ctx.Err())
 		}
 		var err error
 		if f.IsURL() {
-			err = p.uploadURL(h, f)
+			if tracker == nil {
+				tracker = hostTracker(h)
+			}
+			err = p.uploadURL(ctx, h, tracker, f)
 		} else if len(f.Sources) > 0 {
 			err = p.uploadFile(h, f)
 		} else if f.HasData() {
@@ -120,6 +131,16 @@ func (p *UploadFiles) uploadFile(h *cluster.Host, f *cluster.UploadFile) error {
 		}
 
 		owner := f.Owner()
+
+		if f.Sha256 != "" {
+			// Checked whether or not this host is about to receive the file, so
+			// that a wrong artifact is reported on every apply rather than only
+			// on the one that happens to upload it. rig's upload compares the
+			// two ends afterwards, which covers the transfer itself.
+			if err := p.sums.verify(src, f.Sha256); err != nil {
+				return err
+			}
+		}
 
 		if err := p.ensureDir(h, path.Dir(dest), f.DirPermString, owner); err != nil {
 			return err
@@ -208,20 +229,47 @@ func (p *UploadFiles) uploadData(h *cluster.Host, f *cluster.UploadFile) error {
 	return p.applyFileMetadata(h, dest, owner, "", nil)
 }
 
-func (p *UploadFiles) uploadURL(h *cluster.Host, f *cluster.UploadFile) error {
-	log.Infof("%s: downloading %s to host %s", h, f, f.DestinationFile)
+func (p *UploadFiles) uploadURL(ctx context.Context, h *cluster.Host, tracker *download.Tracker, f *cluster.UploadFile) error {
 	owner := f.Owner()
+	expandedURL := h.ExpandTokens(f.Source, p.Config.Spec.K0s.Version)
 
+	// The destination directory has to exist before the download can be told
+	// whether it is already there, and it is created even for a skipped download
+	// so that its ownership and permissions still follow the configuration.
 	if err := p.ensureDir(h, path.Dir(f.DestinationFile), f.DirPermString, owner); err != nil {
 		return err
 	}
 
-	expandedURL := h.ExpandTokens(f.Source, p.Config.Spec.K0s.Version)
-	err := p.Wet(h, fmt.Sprintf("download file %s => %s", expandedURL, f.DestinationFile), func() error {
-		return h.DownloadURL(expandedURL, f.DestinationFile)
-	})
-	if err != nil {
-		return err
+	verdict := tracker.Needed(ctx, expandedURL, f.DestinationFile, f.Sha256)
+	if verdict.Download {
+		log.Infof("%s: downloading %s to host %s (%s)", h, f, f.DestinationFile, verdict.Reason)
+		// GatherK0sFacts asked the same question earlier and set NeedsUpgrade
+		// from the answer. If the answer has changed since, because the content
+		// behind the url was replaced between the two, the host is about to
+		// receive a new file and the upgrade phases still have to hear about it.
+		//
+		// Only for a host that is already running k0s: on one that is not, the
+		// flag would divert the pending install into the upgrade phases, which
+		// have no k0s to upgrade.
+		if !h.Reset && !h.Metadata.NeedsUpgrade && h.Metadata.K0sRunningVersion != nil {
+			log.Debugf("%s: marking for upgrade because %s is being downloaded to %s", h, expandedURL, f.DestinationFile)
+			h.Metadata.NeedsUpgrade = true
+		}
+		err := p.Wet(h, fmt.Sprintf("download file %s => %s", expandedURL, f.DestinationFile), func() error {
+			return tracker.Fetch(ctx, expandedURL, f.DestinationFile, f.Sha256)
+		})
+		if err != nil {
+			return err
+		}
+	} else {
+		log.Infof("%s: %s is already downloaded to %s (%s)", h, f, f.DestinationFile, verdict.Reason)
+		if verdict.Adopt && p.IsWet() {
+			// The destination was accepted by reading the whole file, which is
+			// what every later apply would have to do again without a record of
+			// it. Writing one is a change to the host, so it waits for a run
+			// that is allowed to make changes.
+			tracker.Remember(ctx, expandedURL, f.DestinationFile, f.Sha256)
+		}
 	}
 
 	perm := ""
@@ -275,4 +323,54 @@ func chmodWithString(h *cluster.Host, path, perm string) error {
 
 func chmodWithMode(h *cluster.Host, path string, mode fs.FileMode) error {
 	return h.Sudo().FS().Chmod(path, mode)
+}
+
+// sumCache remembers the local files that have been checked against a configured
+// sha256 during this run, so that an artifact is read once instead of once per
+// host that wants it. Hosts are uploaded to in parallel, hence the lock, which
+// is held across the read: two hosts waiting for one checksum beats both of them
+// computing it.
+type sumCache struct {
+	mu     sync.Mutex
+	result map[string]error
+}
+
+// verify checks a local file against want, at most once per file and sum.
+func (c *sumCache) verify(name, want string) error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	key := name + "\x00" + want
+	if err, ok := c.result[key]; ok {
+		return err
+	}
+	err := verifyLocalSum(name, want)
+	if c.result == nil {
+		c.result = make(map[string]error)
+	}
+	c.result[key] = err
+	return err
+}
+
+// verifyLocalSum reports whether a local file has the sha256 sum the
+// configuration says it should have.
+func verifyLocalSum(name, want string) error {
+	f, err := os.Open(name)
+	if err != nil {
+		return fmt.Errorf("failed to open %s for checksumming: %w", name, err)
+	}
+	defer func() {
+		if err := f.Close(); err != nil {
+			log.Debugf("failed to close %s: %s", name, err)
+		}
+	}()
+
+	digest := sha256.New()
+	if _, err := io.Copy(digest, f); err != nil {
+		return fmt.Errorf("failed to checksum %s: %w", name, err)
+	}
+	if sum := hex.EncodeToString(digest.Sum(nil)); !strings.EqualFold(sum, want) {
+		return fmt.Errorf("%w: %s: expected sha256 %s, got %s", download.ErrChecksumMismatch, name, want, sum)
+	}
+	return nil
 }

--- a/phase/uploadfiles_test.go
+++ b/phase/uploadfiles_test.go
@@ -1,0 +1,28 @@
+package phase
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/k0sproject/k0sctl/pkg/download"
+	"github.com/stretchr/testify/require"
+)
+
+func TestVerifyLocalSum(t *testing.T) {
+	dir := t.TempDir()
+	name := filepath.Join(dir, "a.txt")
+	require.NoError(t, os.WriteFile(name, []byte("hello"), 0o644))
+
+	// sha256 of "hello"
+	const sum = "2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824"
+
+	require.NoError(t, verifyLocalSum(name, sum))
+	require.NoError(t, verifyLocalSum(name, "2CF24DBA5FB0A30E26E83B2AC5B9E29E1B161E5C1FA7425E73043362938B9824"))
+
+	err := verifyLocalSum(name, "0000000000000000000000000000000000000000000000000000000000000000")
+	require.ErrorIs(t, err, download.ErrChecksumMismatch)
+	require.ErrorContains(t, err, sum)
+
+	require.ErrorContains(t, verifyLocalSum(filepath.Join(dir, "missing.txt"), sum), "failed to open")
+}

--- a/pkg/apis/k0sctl.k0sproject.io/v1beta1/cluster/hosts.go
+++ b/pkg/apis/k0sctl.k0sproject.io/v1beta1/cluster/hosts.go
@@ -15,20 +15,26 @@ func (hosts Hosts) Validate() error {
 		return fmt.Errorf("at least one host required")
 	}
 
-	if len(hosts) > 1 {
-		hostmap := make(map[string]struct{}, len(hosts))
-		for idx, h := range hosts {
-			if err := h.Validate(); err != nil {
-				return fmt.Errorf("host #%d: %v", idx+1, err)
-			}
-			if h.Role == "single" {
-				return fmt.Errorf("%d hosts defined but includes a host with role 'single': %s", len(hosts), h)
-			}
-			if _, ok := hostmap[h.String()]; ok {
-				return fmt.Errorf("%s: is not unique", h)
-			}
-			hostmap[h.String()] = struct{}{}
+	// Every host is validated, however many there are: a one host cluster is a
+	// perfectly ordinary configuration and its host has the same way of being
+	// wrong as any other. Only the two rules that are about hosts sharing a
+	// cluster - the 'single' role and uniqueness - need more than one host to
+	// mean anything.
+	hostmap := make(map[string]struct{}, len(hosts))
+	for idx, h := range hosts {
+		if err := h.Validate(); err != nil {
+			return fmt.Errorf("host #%d: %v", idx+1, err)
 		}
+		if len(hosts) == 1 {
+			continue
+		}
+		if h.Role == "single" {
+			return fmt.Errorf("%d hosts defined but includes a host with role 'single': %s", len(hosts), h)
+		}
+		if _, ok := hostmap[h.String()]; ok {
+			return fmt.Errorf("%s: is not unique", h)
+		}
+		hostmap[h.String()] = struct{}{}
 	}
 
 	if len(hosts.Controllers()) < 1 {

--- a/pkg/apis/k0sctl.k0sproject.io/v1beta1/cluster/hosts_test.go
+++ b/pkg/apis/k0sctl.k0sproject.io/v1beta1/cluster/hosts_test.go
@@ -50,3 +50,37 @@ func TestHostsEach(t *testing.T) {
 		require.ErrorContains(t, err, "test")
 	})
 }
+
+func TestHostsValidateSingleHost(t *testing.T) {
+	// A one host cluster used to skip host validation entirely, which let every
+	// per-host rule through unchecked on the most ordinary configuration there
+	// is.
+	t.Run("host rules apply", func(t *testing.T) {
+		hosts := Hosts{
+			&Host{
+				Role: "single",
+				Files: []*UploadFile{
+					{Source: "https://example.com/a.tar", DestinationFile: "/tmp/a.tar", Sha256: "nothex"},
+				},
+			},
+		}
+		require.ErrorContains(t, hosts.Validate(), "must be a hex encoded sha256 sum")
+	})
+
+	t.Run("the single role is allowed", func(t *testing.T) {
+		hosts := Hosts{&Host{Role: "single"}}
+		require.NoError(t, hosts.Validate())
+	})
+
+	t.Run("a valid host passes", func(t *testing.T) {
+		hosts := Hosts{
+			&Host{
+				Role: "controller",
+				Files: []*UploadFile{
+					{Source: "https://example.com/a.tar", DestinationFile: "/tmp/a.tar", Sha256: "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"},
+				},
+			},
+		}
+		require.NoError(t, hosts.Validate())
+	})
+}

--- a/pkg/apis/k0sctl.k0sproject.io/v1beta1/cluster/uploadfile.go
+++ b/pkg/apis/k0sctl.k0sproject.io/v1beta1/cluster/uploadfile.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"path"
 	"path/filepath"
+	"regexp"
 	"strconv"
 	"strings"
 
@@ -23,6 +24,7 @@ type UploadFile struct {
 	Name            string       `yaml:"name,omitempty"`
 	Source          string       `yaml:"src,omitempty"`
 	Data            string       `yaml:"data,omitempty"`
+	Sha256          string       `yaml:"sha256,omitempty"`
 	DestinationDir  string       `yaml:"dstDir,omitempty"`
 	DestinationFile string       `yaml:"dst,omitempty"`
 	PermMode        any          `yaml:"perm,omitempty"`
@@ -35,8 +37,15 @@ type UploadFile struct {
 	Base            string       `yaml:"-"`
 }
 
+// sha256Pattern matches a hex encoded sha256 sum in either case.
+var sha256Pattern = regexp.MustCompile(`^[0-9a-fA-F]{64}$`)
+
 func (u UploadFile) Validate() error {
 	return validation.ValidateStruct(&u,
+		validation.Field(&u.Sha256,
+			validation.Empty.When(u.HasData()).Error("sha256 can not be used with inline data"),
+			validation.Match(sha256Pattern).Error("must be a hex encoded sha256 sum"),
+		),
 		validation.Field(&u.Name, validation.Required.When(u.HasData() && u.DestinationFile == "").Error("name or dst required for data")),
 		validation.Field(&u.Source, validation.Required.When(!u.HasData()).Error("src or data required")),
 		validation.Field(&u.Data, validation.Required.When(u.Source == "").Error("src or data required")),
@@ -226,6 +235,10 @@ func (u *UploadFile) glob(src string) error {
 
 	if u.DestinationFile != "" && len(u.Sources) > 1 {
 		return fmt.Errorf("found multiple files for %s but single file dst %s defined", u, u.DestinationFile)
+	}
+
+	if u.Sha256 != "" && len(u.Sources) > 1 {
+		return fmt.Errorf("found multiple files for %s but a sha256 sum can only describe a single file", u)
 	}
 
 	return nil

--- a/pkg/apis/k0sctl.k0sproject.io/v1beta1/cluster/uploadfile_test.go
+++ b/pkg/apis/k0sctl.k0sproject.io/v1beta1/cluster/uploadfile_test.go
@@ -3,6 +3,7 @@ package cluster
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -154,4 +155,46 @@ func TestUploadFileResolveRelativeSingleFile(t *testing.T) {
 	require.Equal(t, tmp, u.Base)
 	require.Len(t, u.Sources, 1)
 	require.Equal(t, "a.txt", u.Sources[0].Path)
+}
+
+func TestUploadFileValidateSha256(t *testing.T) {
+	const sum = "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+
+	t.Run("hex sum", func(t *testing.T) {
+		u := UploadFile{Source: "https://example.com/a.tar", DestinationFile: "/tmp/a.tar", Sha256: sum}
+		require.NoError(t, u.Validate())
+	})
+
+	t.Run("uppercase hex sum", func(t *testing.T) {
+		u := UploadFile{Source: "https://example.com/a.tar", DestinationFile: "/tmp/a.tar", Sha256: strings.ToUpper(sum)}
+		require.NoError(t, u.Validate())
+	})
+
+	t.Run("too short", func(t *testing.T) {
+		u := UploadFile{Source: "https://example.com/a.tar", DestinationFile: "/tmp/a.tar", Sha256: sum[:63]}
+		require.ErrorContains(t, u.Validate(), "must be a hex encoded sha256 sum")
+	})
+
+	t.Run("not hex", func(t *testing.T) {
+		u := UploadFile{Source: "https://example.com/a.tar", DestinationFile: "/tmp/a.tar", Sha256: strings.Repeat("z", 64)}
+		require.ErrorContains(t, u.Validate(), "must be a hex encoded sha256 sum")
+	})
+
+	t.Run("with inline data", func(t *testing.T) {
+		u := UploadFile{Data: "hello", DestinationFile: "/tmp/a.txt", Sha256: sum}
+		require.ErrorContains(t, u.Validate(), "sha256 can not be used with inline data")
+	})
+}
+
+func TestUploadFileResolveGlobRejectsSha256(t *testing.T) {
+	dir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "a.yaml"), []byte("a"), 0o644))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "b.yaml"), []byte("b"), 0o644))
+
+	u := &UploadFile{
+		Source:         "*.yaml",
+		DestinationDir: "/tmp",
+		Sha256:         "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+	}
+	require.ErrorContains(t, u.ResolveRelativeTo(filepath.ToSlash(dir)), "can only describe a single file")
 }

--- a/pkg/apis/k0sctl.k0sproject.io/v1beta1/cluster_test.go
+++ b/pkg/apis/k0sctl.k0sproject.io/v1beta1/cluster_test.go
@@ -39,3 +39,27 @@ func TestK0sVersionValidation(t *testing.T) {
 	cfg.Spec.K0s.Version = version.MustParse(cluster.K0sMinVersion)
 	require.NoError(t, cfg.Validate())
 }
+
+func TestSingleHostValidation(t *testing.T) {
+	// Host rules have to reach a one host cluster the same as any other, which
+	// they did not when Hosts.Validate only looked at hosts in the plural.
+	cfg := Cluster{
+		APIVersion: APIVersion,
+		Kind:       "cluster",
+		Spec: &cluster.Spec{
+			Hosts: cluster.Hosts{
+				&cluster.Host{
+					Role: "single",
+					Files: []*cluster.UploadFile{
+						{Data: "hello", DestinationFile: "/tmp/a.txt", Sha256: "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"},
+					},
+				},
+			},
+		},
+	}
+
+	require.ErrorContains(t, cfg.Validate(), "sha256 can not be used with inline data")
+
+	cfg.Spec.Hosts[0].Files[0].Sha256 = ""
+	require.NoError(t, cfg.Validate())
+}

--- a/pkg/download/download.go
+++ b/pkg/download/download.go
@@ -1,0 +1,606 @@
+// Package download transfers URL sources to a host without repeating work that
+// a previous run already did.
+//
+// A download is remembered by writing down what the server said about the URL at
+// the time it was fetched. A later run asks the server the same question with an
+// HTTP HEAD and skips the transfer when the answers still agree, which is what
+// keeps a re-apply from pulling gigabytes that are already on the host.
+//
+// The records live in the login user's cache directory on the host rather than
+// beside the downloaded file: the destination is typically a root-owned
+// directory, and one of them, the k0s images directory, is scanned by k0s
+// itself, where an unexpected file has no business being.
+package download
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io/fs"
+	"net/url"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/k0sproject/k0sctl/pkg/retry"
+	"github.com/k0sproject/rig/v2/remotefs"
+
+	log "github.com/sirupsen/logrus"
+)
+
+// ErrChecksumMismatch is returned when a downloaded file does not match the
+// sha256 sum it was expected to have.
+var ErrChecksumMismatch = errors.New("checksum mismatch")
+
+// errNoCacheDir is returned when the host has no cache directory to keep the
+// download records in, which turns the bookkeeping off rather than failing
+// anything.
+var errNoCacheDir = errors.New("no usable user cache directory on the host")
+
+// resumeAttempts is how many times a transfer is continued within a single run
+// before the run gives up on it. Only reached when a sha256 sum is known, since
+// that is what confirms the resumed bytes afterwards.
+const resumeAttempts = 3
+
+// Record describes a file that was downloaded to the host.
+//
+// The validators are what the server reported for the URL when the file was
+// fetched. They are compared against a fresh HEAD response to tell whether the
+// content behind the URL is still the content that was downloaded.
+//
+// The URL itself is not kept, only a digest of it. A download URL routinely
+// carries its own authorization -- a presigned object store link is the ordinary
+// way to serve a private artifact -- and a record stays on the host long after
+// the apply that wrote it, backups included. The digest does everything the
+// record needs the URL for, which is telling one download apart from another.
+type Record struct {
+	URLDigest   string `json:"urlDigest"`
+	Destination string `json:"destination"`
+
+	// Size and ModTime are of the destination as the download left it. They are
+	// what separates a destination that has been left alone from one that has
+	// been written to since, which is something no server header and no recorded
+	// checksum can say.
+	Size    int64     `json:"size"`
+	ModTime time.Time `json:"modTime"`
+
+	ContentLength int64     `json:"contentLength"`
+	ETag          string    `json:"etag,omitempty"`
+	LastModified  time.Time `json:"lastModified,omitempty"`
+	Sha256        string    `json:"sha256,omitempty"`
+
+	// DownloadedAt is not compared against anything and is here for whoever
+	// ends up reading these files.
+	DownloadedAt time.Time `json:"downloadedAt"`
+}
+
+// Tracker downloads URLs to a single host and remembers what it downloaded.
+//
+// Create one per host and reuse it for every file, so that the host's cache
+// directory is only looked up once.
+type Tracker struct {
+	// files is the filesystem the downloads are written to, usually sudo-enabled
+	// since the destinations are commonly root-owned.
+	files remotefs.FS
+
+	// user is the same host without elevated privileges, and is used for the
+	// records alone: they land in the login user's cache directory, which is
+	// what keeps the bookkeeping out of sudo's way.
+	//
+	// Nothing that talks to the server goes through it. A HEAD has to describe
+	// what the transfer would fetch, and the transfer runs as files: the two
+	// identities can differ in proxy variables, credentials and .netrc, and a
+	// validator collected under one of them says nothing about the other.
+	user remotefs.FS
+
+	// label prefixes the log messages, normally the host it is tracking.
+	label string
+
+	dirOnce sync.Once
+	dir     string
+}
+
+// NewTracker returns a Tracker for a host. The files filesystem is where the
+// downloads land and where the requests to the server are made from, so it needs
+// whatever privileges the destinations require; user is the same host as the
+// login user, and is where the records are kept.
+func NewTracker(files, user remotefs.FS, label string) *Tracker {
+	return &Tracker{files: files, user: user, label: label}
+}
+
+// Verdict is what [Tracker.Needed] concluded about a destination.
+type Verdict struct {
+	// Download is whether the transfer has to happen.
+	Download bool
+
+	// Reason is why, for a log line rather than for anyone to act on.
+	Reason string
+
+	// Adopt is set when the destination already holds the file the
+	// configuration asks for but nothing on the host records that, so the next
+	// run would have to read the whole file again to find out. Passing it to
+	// [Tracker.Remember] settles that, once the caller is somewhere it may write
+	// to the host.
+	Adopt bool
+}
+
+// Needed reports whether url has to be transferred to dst, along with the reason
+// for the answer, which is meant for a log line rather than for a user to act
+// on.
+//
+// wantSum is the sha256 sum the configuration expects of the destination, or
+// empty when it names none. It is the strongest answer available and takes over
+// from the header comparison entirely: a destination that was verified against
+// the sum the configuration asks for is the file that was asked for, whatever
+// the server serves now, so the server is not even asked.
+//
+// Anything that cannot be determined counts as needing the download: it is only
+// ever wasted work, where a wrong skip leaves the host with the wrong file.
+//
+// Nothing is written here, so it is safe to ask during a dry run or from a phase
+// that is only gathering facts. Only [Tracker.Fetch] leaves a record behind,
+// which is why a destination that k0sctl did not download itself is checksummed
+// on every run rather than once.
+func (t *Tracker) Needed(ctx context.Context, dlURL, dst, wantSum string) Verdict {
+	stat, err := t.files.Stat(dst)
+	if err != nil {
+		if !errors.Is(err, fs.ErrNotExist) {
+			log.Debugf("%s: stat %s failed: %s", t.label, dst, err)
+		}
+		return Verdict{Download: true, Reason: "not downloaded yet"}
+	}
+
+	rec := t.loadRecord(dlURL, dst)
+	ok, why := usable(rec, stat, wantSum)
+	if ok && wantSum != "" {
+		// The record says this destination was verified against exactly the sum
+		// the configuration asks for, and it has not been written to since.
+		// Nothing the server could say makes the file more correct than the
+		// content the configuration named, so it is not asked.
+		return Verdict{Reason: "sha256 matches the recorded download"}
+	}
+	if ok {
+		info, err := remotefs.HTTPHead(ctx, t.files, dlURL)
+		switch {
+		case err != nil:
+			// The error names the url, and rig's does too, so it is kept to the
+			// debug log: a reason travels into the ordinary output of an apply.
+			log.Debugf("%s: head request for %s failed: %s", t.label, dst, err)
+			return Verdict{Download: true, Reason: "could not check whether the url changed"}
+		case info.StatusCode < 200 || info.StatusCode > 299:
+			// Includes the 405 of a server that refuses HEAD. Whether the URL is
+			// gone or just unwilling to answer, the download is what finds out.
+			return Verdict{Download: true, Reason: fmt.Sprintf("the url answered %d", info.StatusCode)}
+		}
+		same, why := unchanged(rec, info)
+		return Verdict{Download: !same, Reason: why}
+	}
+	if wantSum == "" {
+		return Verdict{Download: true, Reason: why}
+	}
+
+	// Without a usable record the sum is the only thing that can still spare the
+	// transfer, and it is worth the read: reading the file on the host beats
+	// pulling it over the network again.
+	sum, err := t.files.Sha256(dst)
+	if err != nil {
+		return Verdict{Download: true, Reason: fmt.Sprintf("can not checksum %s: %s", dst, err)}
+	}
+	if !strings.EqualFold(sum, wantSum) {
+		return Verdict{Download: true, Reason: "checksum does not match the configured sha256"}
+	}
+	// Reading the whole file is what answered this, and nothing on the host
+	// remembers the answer, so the caller is told to write it down.
+	return Verdict{Reason: "checksum matches the configured sha256", Adopt: true}
+}
+
+// Remember records a destination that already holds the file the configuration
+// asks for, so that a later run can tell without reading the whole file again.
+//
+// It belongs with the Adopt of a [Verdict]. Needed itself writes nothing, since
+// it is asked during dry runs and by phases that only gather facts, which leaves
+// the caller to say when the host may be written to.
+//
+// Failing to record is not an error, only a later run doing the reading over.
+func (t *Tracker) Remember(ctx context.Context, dlURL, dst, sum string) {
+	if sum == "" {
+		// Without a sum there is nothing a record could be believed on: the
+		// validators belong to a download this did not make.
+		return
+	}
+	stat, err := t.files.Stat(dst)
+	if err != nil {
+		log.Debugf("%s: not recording %s: %s", t.label, dst, err)
+		return
+	}
+	// Asked so that the record can answer a later run that has no sum to go on,
+	// for instance after the sum is taken out of the configuration again.
+	info, err := remotefs.HTTPHead(ctx, t.files, dlURL)
+	if err != nil {
+		log.Debugf("%s: no url information for %s: %s", t.label, dst, err)
+	}
+	t.record(dlURL, dst, stat, sum, info)
+}
+
+// Fetch downloads url to dst on the host and records what was downloaded.
+//
+// When wantSum is set the file is verified against it, and an attempt that dies
+// part way through is continued rather than restarted, which is what carries a
+// large download over a link that drops. Resuming is deliberately limited to
+// that case: neither curl nor wget can tell whether the bytes already on disk
+// are still a valid prefix of what the URL serves, and the sum over the finished
+// file is what settles it.
+//
+// Resuming lives and dies with the call: the attempts continue each other, and
+// once they are spent what is left of the transfer is discarded rather than left
+// on the host for a later run to find.
+//
+// A transfer reaches the destination before it can be checksummed, so a download
+// that turns out not to match takes whatever was at the destination with it and
+// is then removed: the destination is never left holding content the
+// configuration did not ask for.
+func (t *Tracker) Fetch(ctx context.Context, dlURL, dst, wantSum string) error {
+	// Asking before the transfer rather than after means the record describes
+	// what the transfer was started against. Should the content change in
+	// between, the record is of the older content and the next run downloads
+	// again, where recording afterwards could describe content that was never
+	// downloaded and skip a transfer that is due.
+	info, headErr := remotefs.HTTPHead(ctx, t.files, dlURL)
+	if headErr != nil {
+		log.Debugf("%s: no url information for %s: %s", t.label, dst, headErr)
+	}
+
+	if err := t.transfer(ctx, dlURL, dst, wantSum != ""); err != nil {
+		return err
+	}
+
+	if wantSum != "" {
+		if err := t.verify(dlURL, dst, wantSum); err != nil {
+			return err
+		}
+	}
+
+	// The size and modification time of what was just written are what a later
+	// run holds the destination against, so they are read here rather than
+	// guessed. Without them there is nothing to compare and the record is not
+	// worth writing.
+	stat, err := t.files.Stat(dst)
+	if err != nil {
+		log.Debugf("%s: stat %s after download failed: %s", t.label, dst, err)
+	}
+	t.record(dlURL, dst, stat, wantSum, info)
+	return nil
+}
+
+// transfer runs the download itself, retrying a resumable one so that a
+// transfer that dies part way through continues within the same run.
+//
+// What it says about a failure names the destination. The url is left to the
+// error underneath, which rig composes and which is all that ever repeats it: a
+// url can carry its own authorization, and an error travels further than a debug
+// line does.
+func (t *Tracker) transfer(ctx context.Context, dlURL, dst string, resume bool) error {
+	if !isHTTP(dlURL) {
+		// rig's Download only speaks http and https, but curl and wget accept
+		// more than that and always have here, so anything else keeps going
+		// through the plain download. It gets no resume, and no HEAD to compare
+		// against later either, so without a configured sha256 such a source is
+		// downloaded on every run, exactly as it was before.
+		log.Debugf("%s: the source of %s is not an http url, downloading without resume support", t.label, dst)
+		if err := t.files.DownloadURL(dlURL, dst); err != nil {
+			return fmt.Errorf("download to %s: %w", dst, err)
+		}
+		return nil
+	}
+
+	if !resume {
+		if err := remotefs.Download(ctx, t.files, dlURL, dst); err != nil {
+			return fmt.Errorf("download to %s: %w", dst, err)
+		}
+		return nil
+	}
+
+	err := retry.Times(ctx, resumeAttempts, func(ctx context.Context) error {
+		return remotefs.Download(ctx, t.files, dlURL, dst, remotefs.WithResume())
+	})
+	if err != nil {
+		// Every attempt is spent and nothing is going to continue what is left of
+		// the transfer, so the run clears up after itself rather than parking the
+		// bytes beside the destination indefinitely. In a directory k0s reads,
+		// like the images directory, that leftover is a truncated artifact that
+		// something else would eventually try to make sense of.
+		//
+		// A cancelled run is no exception. Every Fetch asks to resume, so a
+		// partial left by one would be continued by the next apply -- the
+		// across-applies resuming that keeping this to a single call is meant to
+		// rule out, and a way to end up assembling bytes from two different
+		// versions of the url. Removing it is best effort: a host that has gone
+		// away cannot be told to remove anything, and that is what the warning
+		// is for.
+		if dErr := remotefs.DiscardPartial(t.files, dlURL, dst); dErr != nil {
+			log.Warnf("%s: failed to discard the partial download of %s: %s", t.label, dst, dErr)
+		}
+		return fmt.Errorf("download to %s: %w", dst, err)
+	}
+	return nil
+}
+
+// verify compares the downloaded file against the expected sum, and clears out
+// the bytes when they do not match.
+func (t *Tracker) verify(dlURL, dst, wantSum string) error {
+	sum, err := t.files.Sha256(dst)
+	if err != nil {
+		// Not knowing what the bytes are is the same position as knowing they
+		// are wrong: either way nothing has confirmed them, and the destination
+		// does not get to keep content that never passed its check.
+		t.discard(dlURL, dst)
+		return fmt.Errorf("checksum %s: %w", dst, err)
+	}
+	if strings.EqualFold(sum, wantSum) {
+		return nil
+	}
+	t.discard(dlURL, dst)
+	return fmt.Errorf("%w: %s: expected sha256 %s, got %s", ErrChecksumMismatch, dst, wantSum, sum)
+}
+
+// discard throws away a download that could not be confirmed, along with
+// everything that would let a later run take it for one that was.
+//
+// Leaving the bytes at the destination would hand whatever reads them a file
+// that failed its check. A completed transfer has already had its partial
+// renamed onto the destination, so discarding one is usually a no-op, but a
+// partial that did outlive the transfer would be resumed onto the same bad
+// bytes forever.
+func (t *Tracker) discard(dlURL, dst string) {
+	if err := t.files.Remove(dst); err != nil {
+		log.Warnf("%s: failed to remove the unverified download %s: %s", t.label, dst, err)
+	}
+	if err := remotefs.DiscardPartial(t.files, dlURL, dst); err != nil {
+		log.Debugf("%s: failed to discard the partial download of %s: %s", t.label, dst, err)
+	}
+	t.forget(dlURL, dst)
+}
+
+// usable reports whether a record still describes the file at the destination,
+// and when it does not, why.
+//
+// Both the size and the modification time have to match. Everything else a
+// record carries is about the URL, so without this the destination could be
+// replaced by same-length content and every later run would go on skipping it.
+func usable(rec *Record, stat fs.FileInfo, wantSum string) (bool, string) {
+	switch {
+	case rec == nil:
+		return false, "no record of an earlier download"
+	case rec.Size != stat.Size():
+		// Someone or something has written to the file since, so what the record
+		// says about it no longer describes what is there.
+		return false, fmt.Sprintf("file size %d does not match the downloaded %d", stat.Size(), rec.Size)
+	case rec.ModTime.IsZero():
+		// The destination could not be measured when the download was recorded,
+		// which leaves nothing to hold it against now.
+		return false, "the earlier download was recorded without a modification time"
+	case !rec.ModTime.Equal(stat.ModTime()):
+		return false, fmt.Sprintf("file was modified at %s, the download left it at %s", stat.ModTime().UTC(), rec.ModTime.UTC())
+	case wantSum != "" && !strings.EqualFold(rec.Sha256, wantSum):
+		// The configured sum is not the sum the file was accepted with, either
+		// because it changed in the configuration or because it was added after
+		// the download. Either way the file has not been checked against it.
+		return false, "configured sha256 differs from the downloaded file's sum"
+	}
+	return true, ""
+}
+
+// strongETag reports whether an entity tag is one that proves byte identity. A
+// weak validator, the ones prefixed with W/, promises only that two
+// representations mean the same thing, which is not enough to leave a file that
+// has to match the URL byte for byte alone.
+func strongETag(tag string) bool {
+	return tag != "" && !strings.HasPrefix(tag, "W/")
+}
+
+// unchanged reports whether a HEAD response still describes the content that was
+// downloaded, and what that verdict rests on.
+//
+// Only a strong ETag or a Last-Modified can conclude that nothing changed. A
+// Content-Length cannot: a server that swaps an artifact for different bytes of
+// the same length would report the same one forever, so a length is only ever
+// used to corroborate a timestamp. Where neither validator is on offer the
+// answer is to download, which is what every URL source did before any of this
+// was recorded, and a configured sha256 is the way out of it.
+func unchanged(rec *Record, info *remotefs.URLInfo) (bool, string) {
+	if rec.ETag != "" && info.ETag != "" {
+		if rec.ETag != info.ETag {
+			// Two different tags are two different representations, whether the
+			// tags are weak or strong.
+			return false, "etag changed"
+		}
+		if strongETag(rec.ETag) && strongETag(info.ETag) {
+			return true, "etag unchanged"
+		}
+		// Equal weak tags leave it open, so the timestamp below gets a say.
+	}
+	if !rec.LastModified.IsZero() && !info.LastModified.IsZero() {
+		if !rec.LastModified.Equal(info.LastModified) {
+			return false, "last-modified changed"
+		}
+		if info.ContentLength >= 0 && info.ContentLength != rec.Size {
+			return false, "content-length changed"
+		}
+		return true, "last-modified unchanged"
+	}
+	return false, "server reports no strong etag or last-modified"
+}
+
+// record writes down a download. A record is a shortcut for the next run, so
+// failing to write one is logged and otherwise ignored: the only consequence is
+// that the next run has to download the file again.
+func (t *Tracker) record(dlURL, dst string, stat fs.FileInfo, sum string, info *remotefs.URLInfo) {
+	rec := Record{
+		URLDigest:     urlDigest(dlURL),
+		Destination:   dst,
+		Size:          -1,
+		ContentLength: -1,
+		Sha256:        sum,
+		DownloadedAt:  time.Now().UTC(),
+	}
+	if stat != nil {
+		rec.Size = stat.Size()
+		rec.ModTime = stat.ModTime()
+	}
+	if info != nil {
+		rec.ContentLength = info.ContentLength
+		rec.ETag = info.ETag
+		rec.LastModified = info.LastModified
+	}
+	switch {
+	case rec.ModTime.IsZero():
+		// Without the state of the destination there is nothing to tell a file
+		// that was left alone from one that was replaced.
+		log.Debugf("%s: not recording the download of %s: the destination could not be measured", t.label, dst)
+		return
+	case !strongETag(rec.ETag) && rec.LastModified.IsZero() && sum == "":
+		// Nothing here could ever confirm the file later: a weak etag and a
+		// length can say that something changed but never that nothing did, and
+		// a record that can only answer "download it again" is not worth
+		// keeping around.
+		log.Debugf("%s: not recording the download of %s: nothing to compare it by later", t.label, dst)
+		return
+	}
+
+	data, err := json.Marshal(rec)
+	if err != nil {
+		log.Debugf("%s: failed to marshal the download record for %s: %s", t.label, dst, err)
+		return
+	}
+	dir, err := t.recordsDir()
+	if err != nil {
+		log.Debugf("%s: not recording the download of %s: %s", t.label, dst, err)
+		return
+	}
+	if err := t.user.MkdirAll(dir, 0o700); err != nil {
+		log.Debugf("%s: failed to create %s: %s", t.label, dir, err)
+		return
+	}
+	path := t.user.Join(dir, recordName(t.user, dlURL, dst))
+	if err := t.user.WriteFile(path, data, 0o600); err != nil {
+		log.Debugf("%s: failed to write the download record %s: %s", t.label, path, err)
+		return
+	}
+	log.Debugf("%s: recorded the download of %s in %s", t.label, dst, path)
+}
+
+// forget drops the record for a download, so that the next run makes its own
+// mind up about the destination instead of trusting a record that has been
+// proven wrong.
+func (t *Tracker) forget(dlURL, dst string) {
+	dir, err := t.recordsDir()
+	if err != nil {
+		return
+	}
+	path := t.user.Join(dir, recordName(t.user, dlURL, dst))
+	if err := t.user.Remove(path); err != nil && !errors.Is(err, fs.ErrNotExist) {
+		log.Debugf("%s: failed to remove the download record %s: %s", t.label, path, err)
+	}
+}
+
+// loadRecord reads the record for a download, or returns nil when there is none
+// to be had. An unreadable or unparseable record is treated as no record at all,
+// since the answer to both is the same download.
+func (t *Tracker) loadRecord(dlURL, dst string) *Record {
+	dir, err := t.recordsDir()
+	if err != nil {
+		log.Debugf("%s: no download records available: %s", t.label, err)
+		return nil
+	}
+	path := t.user.Join(dir, recordName(t.user, dlURL, dst))
+	data, err := t.user.ReadFile(path)
+	if err != nil {
+		if !errors.Is(err, fs.ErrNotExist) {
+			log.Debugf("%s: failed to read the download record %s: %s", t.label, path, err)
+		}
+		return nil
+	}
+	var rec Record
+	if err := json.Unmarshal(data, &rec); err != nil {
+		log.Debugf("%s: failed to parse the download record %s: %s", t.label, path, err)
+		return nil
+	}
+	// The name is a truncated digest, so a record found under it should be for
+	// this download; a mismatch would mean answering for a different one, which
+	// is not worth doing on the off chance.
+	if rec.URLDigest != urlDigest(dlURL) || rec.Destination != dst {
+		log.Debugf("%s: the download record %s is for a different download (%s), ignoring it", t.label, path, rec.Destination)
+		return nil
+	}
+	return &rec
+}
+
+// recordsDir is where this host keeps its download records. The user's cache
+// directory is looked up on the host, which costs a command, so the answer is
+// kept for the lifetime of the Tracker.
+func (t *Tracker) recordsDir() (string, error) {
+	t.dirOnce.Do(func() {
+		cache := t.user.UserCacheDir()
+		if !isAbs(cache) {
+			// An empty or relative cache directory would put the records
+			// somewhere that depends on where a command happened to run, which
+			// is no place to look for them later.
+			log.Debugf("%s: no usable user cache directory (%q), download records are disabled", t.label, cache)
+			return
+		}
+		t.dir = t.user.Join(cache, "k0sctl", "downloads")
+	})
+	if t.dir == "" {
+		return "", errNoCacheDir
+	}
+	return t.dir, nil
+}
+
+// urlDigest identifies a url without keeping it, so that a record can be matched
+// to a download without writing whatever the url carries to the host.
+func urlDigest(dlURL string) string {
+	sum := sha256.Sum256([]byte(dlURL))
+	return hex.EncodeToString(sum[:])
+}
+
+// recordName is the file name a download's record is kept under.
+//
+// Both the url and the destination go into the digest so that a record can only
+// ever be found by a lookup for the same pair, and the destination's base name
+// is kept in front of it to make the directory readable to whoever ends up
+// looking at it.
+func recordName(fsys remotefs.FS, dlURL, dst string) string {
+	sum := sha256.Sum256([]byte(dlURL + "\x00" + dst))
+	return fsys.Base(dst) + "-" + hex.EncodeToString(sum[:8]) + ".json"
+}
+
+// isHTTP reports whether a url is one that rig's Download can handle.
+func isHTTP(rawURL string) bool {
+	u, err := url.Parse(rawURL)
+	if err != nil {
+		return false
+	}
+	switch strings.ToLower(u.Scheme) {
+	case "http", "https":
+		return true
+	default:
+		return false
+	}
+}
+
+// isAbs reports whether a remote path is absolute in either the posix or the
+// windows sense. The host's own path rules are not exposed as a predicate, and
+// the two shapes are distinct enough to tell apart here.
+func isAbs(path string) bool {
+	if strings.HasPrefix(path, "/") || strings.HasPrefix(path, `\`) {
+		return true
+	}
+	// A windows path like C:/Users/foo or C:\Users\foo.
+	if len(path) > 2 && path[1] == ':' && (path[2] == '/' || path[2] == '\\') {
+		return true
+	}
+	return false
+}

--- a/pkg/download/download_test.go
+++ b/pkg/download/download_test.go
@@ -1,0 +1,310 @@
+package download
+
+import (
+	"encoding/json"
+	"io/fs"
+	"testing"
+	"time"
+
+	"github.com/k0sproject/rig/v2/remotefs"
+	"github.com/stretchr/testify/require"
+)
+
+// stubStat is the little of fs.FileInfo that a download record is compared
+// against.
+type stubStat struct {
+	size    int64
+	modTime time.Time
+}
+
+func (s stubStat) Name() string       { return "stub" }
+func (s stubStat) Size() int64        { return s.size }
+func (s stubStat) Mode() fs.FileMode  { return 0o644 }
+func (s stubStat) ModTime() time.Time { return s.modTime }
+func (s stubStat) IsDir() bool        { return false }
+func (s stubStat) Sys() any           { return nil }
+
+func TestUsable(t *testing.T) {
+	const sum = "1111111111111111111111111111111111111111111111111111111111111111"
+	written := time.Date(2026, 8, 10, 12, 0, 0, 0, time.UTC)
+	onDisk := stubStat{size: 100, modTime: written}
+	rec := func(mod func(*Record)) *Record {
+		r := &Record{
+			URLDigest:     urlDigest("https://example.com/f"),
+			Destination:   "/tmp/f",
+			Size:          100,
+			ModTime:       written,
+			ContentLength: 100,
+			Sha256:        sum,
+		}
+		if mod != nil {
+			mod(r)
+		}
+		return r
+	}
+
+	t.Run("no record", func(t *testing.T) {
+		ok, why := usable(nil, onDisk, "")
+		require.False(t, ok)
+		require.Equal(t, "no record of an earlier download", why)
+	})
+
+	t.Run("matching record", func(t *testing.T) {
+		ok, _ := usable(rec(nil), onDisk, sum)
+		require.True(t, ok)
+	})
+
+	t.Run("file was written to after the download", func(t *testing.T) {
+		ok, why := usable(rec(nil), stubStat{size: 120, modTime: written}, "")
+		require.False(t, ok)
+		require.Contains(t, why, "does not match the downloaded")
+	})
+
+	t.Run("file was replaced with content of the same length", func(t *testing.T) {
+		ok, why := usable(rec(nil), stubStat{size: 100, modTime: written.Add(time.Minute)}, "")
+		require.False(t, ok)
+		require.Contains(t, why, "was modified at")
+	})
+
+	t.Run("modification time in another zone is the same instant", func(t *testing.T) {
+		berlin := time.FixedZone("CEST", 2*60*60)
+		ok, _ := usable(rec(nil), stubStat{size: 100, modTime: written.In(berlin)}, sum)
+		require.True(t, ok)
+	})
+
+	t.Run("record without a modification time", func(t *testing.T) {
+		ok, why := usable(rec(func(r *Record) { r.ModTime = time.Time{} }), onDisk, "")
+		require.False(t, ok)
+		require.Contains(t, why, "without a modification time")
+	})
+
+	t.Run("configured sum changed", func(t *testing.T) {
+		ok, why := usable(rec(nil), onDisk, "2222222222222222222222222222222222222222222222222222222222222222")
+		require.False(t, ok)
+		require.Contains(t, why, "configured sha256 differs")
+	})
+
+	t.Run("sum configured after the download", func(t *testing.T) {
+		ok, _ := usable(rec(func(r *Record) { r.Sha256 = "" }), onDisk, sum)
+		require.False(t, ok)
+	})
+
+	t.Run("configured sum in a different case", func(t *testing.T) {
+		ok, _ := usable(rec(func(r *Record) { r.Sha256 = "AAAA" }), onDisk, "aaaa")
+		require.True(t, ok)
+	})
+
+	t.Run("no sum configured or recorded", func(t *testing.T) {
+		ok, _ := usable(rec(func(r *Record) { r.Sha256 = "" }), onDisk, "")
+		require.True(t, ok)
+	})
+}
+
+func TestUnchanged(t *testing.T) {
+	modified := time.Date(2026, 8, 10, 12, 0, 0, 0, time.UTC)
+
+	for _, tc := range []struct {
+		name string
+		rec  Record
+		info remotefs.URLInfo
+		want bool
+		why  string
+	}{
+		{
+			name: "same strong etag",
+			rec:  Record{ETag: `"abc"`, Size: 100, ContentLength: 100},
+			info: remotefs.URLInfo{ETag: `"abc"`, ContentLength: 100},
+			want: true,
+			why:  "etag unchanged",
+		},
+		{
+			name: "different etag",
+			rec:  Record{ETag: `"abc"`, Size: 100, ContentLength: 100},
+			info: remotefs.URLInfo{ETag: `"def"`, ContentLength: 100},
+			want: false,
+			why:  "etag changed",
+		},
+		{
+			// A weak validator only promises that the two representations mean
+			// the same thing, so it cannot stand in for byte identity.
+			name: "same weak etag, nothing else",
+			rec:  Record{ETag: `W/"abc"`, Size: 100, ContentLength: 100},
+			info: remotefs.URLInfo{ETag: `W/"abc"`, ContentLength: 100},
+			want: false,
+			why:  "server reports no strong etag or last-modified",
+		},
+		{
+			name: "same weak etag and last-modified",
+			rec:  Record{ETag: `W/"abc"`, LastModified: modified, Size: 100, ContentLength: 100},
+			info: remotefs.URLInfo{ETag: `W/"abc"`, LastModified: modified, ContentLength: 100},
+			want: true,
+			why:  "last-modified unchanged",
+		},
+		{
+			name: "different weak etag, same last-modified",
+			rec:  Record{ETag: `W/"abc"`, LastModified: modified, Size: 100, ContentLength: 100},
+			info: remotefs.URLInfo{ETag: `W/"def"`, LastModified: modified, ContentLength: 100},
+			want: false,
+			why:  "etag changed",
+		},
+		{
+			name: "etag turned weak",
+			rec:  Record{ETag: `"abc"`, Size: 100, ContentLength: 100},
+			info: remotefs.URLInfo{ETag: `W/"abc"`, ContentLength: 100},
+			want: false,
+			why:  "etag changed",
+		},
+		{
+			name: "same etag but a different length",
+			rec:  Record{ETag: `"abc"`, Size: 100, ContentLength: 100},
+			info: remotefs.URLInfo{ETag: `"abc"`, ContentLength: 200},
+			want: true,
+			why:  "etag unchanged",
+		},
+		{
+			name: "no etag, same last-modified and length",
+			rec:  Record{LastModified: modified, Size: 100, ContentLength: 100},
+			info: remotefs.URLInfo{LastModified: modified, ContentLength: 100},
+			want: true,
+			why:  "last-modified unchanged",
+		},
+		{
+			name: "no etag, newer last-modified",
+			rec:  Record{LastModified: modified, Size: 100, ContentLength: 100},
+			info: remotefs.URLInfo{LastModified: modified.Add(time.Hour), ContentLength: 100},
+			want: false,
+			why:  "last-modified changed",
+		},
+		{
+			name: "no etag, same last-modified but a different length",
+			rec:  Record{LastModified: modified, Size: 100, ContentLength: 100},
+			info: remotefs.URLInfo{LastModified: modified, ContentLength: 200},
+			want: false,
+			why:  "content-length changed",
+		},
+		{
+			name: "no etag, same last-modified and an unknown length",
+			rec:  Record{LastModified: modified, Size: 100, ContentLength: 100},
+			info: remotefs.URLInfo{LastModified: modified, ContentLength: -1},
+			want: true,
+			why:  "last-modified unchanged",
+		},
+		{
+			// Same length, different bytes is exactly what a length cannot rule
+			// out, so a length on its own never confirms anything.
+			name: "length only, unchanged",
+			rec:  Record{Size: 100, ContentLength: 100},
+			info: remotefs.URLInfo{ContentLength: 100},
+			want: false,
+			why:  "server reports no strong etag or last-modified",
+		},
+		{
+			name: "length only, changed",
+			rec:  Record{Size: 100, ContentLength: 100},
+			info: remotefs.URLInfo{ContentLength: 200},
+			want: false,
+			why:  "server reports no strong etag or last-modified",
+		},
+		{
+			name: "server says nothing at all",
+			rec:  Record{Size: 100, ContentLength: -1},
+			info: remotefs.URLInfo{ContentLength: -1},
+			want: false,
+			why:  "server reports no strong etag or last-modified",
+		},
+		{
+			name: "only the recorded side has an etag",
+			rec:  Record{ETag: `"abc"`, Size: 100, ContentLength: 100},
+			info: remotefs.URLInfo{ContentLength: 100},
+			want: false,
+			why:  "server reports no strong etag or last-modified",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			got, why := unchanged(&tc.rec, &tc.info)
+			require.Equal(t, tc.want, got, why)
+			require.Equal(t, tc.why, why)
+		})
+	}
+}
+
+func TestRecordRoundTrip(t *testing.T) {
+	rec := Record{
+		URLDigest:     urlDigest("https://example.com/bundle.tar"),
+		Destination:   "/var/lib/k0s/images/bundle.tar",
+		Size:          1234,
+		ModTime:       time.Date(2026, 9, 1, 8, 29, 0, 0, time.UTC),
+		ContentLength: 1234,
+		ETag:          `"abc"`,
+		LastModified:  time.Date(2026, 8, 10, 12, 0, 0, 0, time.UTC),
+		Sha256:        "1111111111111111111111111111111111111111111111111111111111111111",
+		DownloadedAt:  time.Date(2026, 9, 1, 8, 30, 0, 0, time.UTC),
+	}
+
+	data, err := json.Marshal(rec)
+	require.NoError(t, err)
+
+	var got Record
+	require.NoError(t, json.Unmarshal(data, &got))
+	require.Equal(t, rec, got)
+}
+
+func TestIsHTTP(t *testing.T) {
+	for url, want := range map[string]bool{
+		"https://example.com/f":  true,
+		"http://example.com/f":   true,
+		"HTTPS://example.com/f":  true,
+		"ftp://example.com/f":    false,
+		"file:///tmp/f":          false,
+		"example.com/f":          false,
+		"://":                    false,
+		"https://user@host/f":    true,
+		"http://host:8080/a%20b": true,
+	} {
+		require.Equal(t, want, isHTTP(url), url)
+	}
+}
+
+func TestIsAbs(t *testing.T) {
+	for path, want := range map[string]bool{
+		"/home/user/.cache":           true,
+		`C:\Users\user\AppData\Local`: true,
+		"C:/Users/user/AppData/Local": true,
+		`\\server\share`:              true,
+		".cache":                      false,
+		"":                            false,
+		"home/user/.cache":            false,
+		"C:":                          false,
+		"~/.cache":                    false,
+	} {
+		require.Equal(t, want, isAbs(path), path)
+	}
+}
+
+func TestStrongETag(t *testing.T) {
+	for tag, want := range map[string]bool{
+		`"abc"`:      true,
+		`W/"abc"`:    false,
+		``:           false,
+		`abc`:        true,
+		`w/"abc"`:    true, // the prefix is case sensitive per RFC 9110
+		`"W/nested"`: true,
+	} {
+		require.Equal(t, want, strongETag(tag), tag)
+	}
+}
+
+func TestRecordKeepsNoURL(t *testing.T) {
+	// A download url can carry its own authorization, and a record outlives the
+	// apply that wrote it.
+	const secret = "https://example.com/bundle.tar?X-Amz-Signature=deadbeefcafe"
+
+	rec := Record{URLDigest: urlDigest(secret), Destination: "/tmp/bundle.tar"}
+	data, err := json.Marshal(rec)
+	require.NoError(t, err)
+
+	require.NotContains(t, string(data), "deadbeefcafe")
+	require.NotContains(t, string(data), "example.com")
+	require.Equal(t, urlDigest(secret), rec.URLDigest)
+	require.NotEqual(t, urlDigest(secret), urlDigest(secret+"x"))
+}

--- a/smoke-test/.gitignore
+++ b/smoke-test/.gitignore
@@ -7,3 +7,4 @@ k0sctl_040
 kubectl
 upload/
 upload_chmod/
+k0sctl-badsum.yaml

--- a/smoke-test/bootloose.yaml.files.tpl
+++ b/smoke-test/bootloose.yaml.files.tpl
@@ -1,0 +1,51 @@
+cluster:
+  name: k0s
+  privateKey: ./id_rsa_k0s
+machines:
+- count: 1
+  backend: docker
+  spec:
+    image: $LINUX_IMAGE
+    name: manager%d
+    privileged: true
+    volumes:
+    - type: bind
+      source: /lib/modules
+      destination: /lib/modules
+    - type: volume
+      destination: /var/lib/k0s
+    portMappings:
+    - containerPort: 22
+      hostPort: 9022
+    - containerPort: 443
+      hostPort: 443
+    - containerPort: 6443
+      hostPort: 6443
+- count: 1
+  backend: docker
+  spec:
+    image: $LINUX_IMAGE
+    name: worker%d
+    privileged: true
+    volumes:
+    - type: bind
+      source: /lib/modules
+      destination: /lib/modules
+    - type: volume
+      destination: /var/lib/k0s
+    portMappings:
+    - containerPort: 22
+      hostPort: 9022
+# The file server the URL sources are downloaded from. It is not part of the
+# cluster and is only reachable from the other machines, so the k0sctl config
+# refers to it by its address on the container network. It comes last so that
+# the ssh port mappings of the cluster machines stay as they are.
+- count: 1
+  backend: docker
+  spec:
+    image: $LINUX_IMAGE
+    name: filesrv%d
+    privileged: true
+    portMappings:
+    - containerPort: 22
+      hostPort: 9022

--- a/smoke-test/filesrv.py
+++ b/smoke-test/filesrv.py
@@ -1,0 +1,174 @@
+#!/usr/bin/env python3
+"""A small HTTP file server for the k0sctl files smoke test.
+
+It serves the files in ROOT with the response headers k0sctl compares between
+applies to decide whether a download is still needed, and it honors the open
+ended range requests curl makes when it continues an interrupted download.
+
+Two knobs make the interesting cases reachable from a shell script:
+
+  - a path under /noetag/ is served without an ETag, which is what makes k0sctl
+    fall back to comparing Last-Modified
+  - a <file>.drop marker beside a served file cuts the next transfer of that
+    file short and closes the connection, which is what an interrupted download
+    looks like to curl. The marker is consumed by the transfer that trips over
+    it, so the attempt that follows can succeed.
+
+Every request is appended to LOG as "<method> <path> <status>", with a trailing
+" dropped" for a transfer that was cut short, for the test to assert on.
+"""
+
+import email.utils
+import http.server
+import os
+import socketserver
+import threading
+
+# The defaults are where the smoke test puts things on the server machine; the
+# environment overrides exist so that the script can be exercised locally.
+ROOT = os.environ.get("FILESRV_ROOT", "/srv/files")
+LOG = os.environ.get("FILESRV_LOG", "/srv/requests.log")
+ADDRESS = ("0.0.0.0", int(os.environ.get("FILESRV_PORT", "8080")))
+
+# How much of a transfer is delivered before a dropped one gives up.
+DROP_RATIO = 0.4
+CHUNK = 64 * 1024
+
+log_lock = threading.Lock()
+
+
+def record(line):
+    with log_lock, open(LOG, "a") as f:
+        f.write(line + "\n")
+
+
+def parse_range(header, size):
+    """Return the first byte the client asked for, or None when the range can
+    not be served. Only the forms curl and wget send are understood."""
+    if not header.startswith("bytes="):
+        return None
+    spec = header[len("bytes="):].split(",")[0].strip()
+    first = spec.split("-")[0]
+    if not first.isdigit():
+        return None
+    start = int(first)
+    if start >= size:
+        return None
+    return start
+
+
+def consume_drop_marker(name):
+    """Report whether this transfer should be cut short, clearing the marker so
+    that only one transfer is affected by it."""
+    marker = name + ".drop"
+    try:
+        os.remove(marker)
+    except FileNotFoundError:
+        return False
+    return True
+
+
+class Handler(http.server.BaseHTTPRequestHandler):
+    protocol_version = "HTTP/1.1"
+    server_version = "k0sctl-smoke-filesrv/1"
+
+    def log_message(self, fmt, *args):
+        # The request log this test reads is the one record() writes.
+        pass
+
+    def resolve(self):
+        """Return the path on disk for the request and whether it gets an ETag,
+        or (None, ...) when the request is not for a served file."""
+        path = self.path.split("?", 1)[0]
+        etag = True
+        if path.startswith("/noetag/"):
+            path = path[len("/noetag/"):]
+            etag = False
+        elif path.startswith("/files/"):
+            path = path[len("/files/"):]
+        else:
+            return None, etag
+        # Only plain names directly under ROOT are served, which is all the test
+        # asks for and leaves no room for a traversal.
+        if not path or "/" in path or path.startswith("."):
+            return None, etag
+        return os.path.join(ROOT, path), etag
+
+    def do_HEAD(self):
+        self.serve(with_body=False)
+
+    def do_GET(self):
+        self.serve(with_body=True)
+
+    def serve(self, with_body):
+        name, with_etag = self.resolve()
+        if name is None or not os.path.isfile(name):
+            self.respond(404)
+            return
+
+        stat = os.stat(name)
+        start = 0
+        if header := self.headers.get("Range"):
+            start = parse_range(header, stat.st_size)
+            if start is None:
+                self.send_response(416)
+                self.send_header("Content-Range", "bytes */%d" % stat.st_size)
+                self.send_header("Content-Length", "0")
+                self.end_headers()
+                record("%s %s 416" % (self.command, self.path))
+                return
+
+        status = 206 if start else 200
+        length = stat.st_size - start
+        self.send_response(status)
+        self.send_header("Content-Type", "application/octet-stream")
+        self.send_header("Content-Length", str(length))
+        self.send_header("Accept-Ranges", "bytes")
+        self.send_header("Last-Modified", email.utils.formatdate(stat.st_mtime, usegmt=True))
+        if with_etag:
+            self.send_header("ETag", '"%x-%x"' % (int(stat.st_mtime), stat.st_size))
+        if status == 206:
+            self.send_header("Content-Range", "bytes %d-%d/%d" % (start, stat.st_size - 1, stat.st_size))
+        self.end_headers()
+
+        if not with_body:
+            record("%s %s %d" % (self.command, self.path, status))
+            return
+
+        drop = consume_drop_marker(name)
+        limit = int(length * DROP_RATIO) if drop else length
+        sent = 0
+        with open(name, "rb") as f:
+            f.seek(start)
+            while sent < limit:
+                chunk = f.read(min(CHUNK, limit - sent))
+                if not chunk:
+                    break
+                self.wfile.write(chunk)
+                sent += len(chunk)
+
+        if drop:
+            # The body is short of the Content-Length that was promised and the
+            # connection goes away with it, so the client is left with a partial
+            # file and an error.
+            self.close_connection = True
+            record("%s %s %d dropped" % (self.command, self.path, status))
+            return
+        record("%s %s %d" % (self.command, self.path, status))
+
+    def respond(self, status):
+        self.send_response(status)
+        self.send_header("Content-Length", "0")
+        self.end_headers()
+        record("%s %s %d" % (self.command, self.path, status))
+
+
+class Server(socketserver.ThreadingTCPServer):
+    allow_reuse_address = True
+    daemon_threads = True
+
+
+if __name__ == "__main__":
+    os.makedirs(ROOT, exist_ok=True)
+    with Server(ADDRESS, Handler) as httpd:
+        httpd.serve_forever()

--- a/smoke-test/k0sctl-files-badsum.yaml.tpl
+++ b/smoke-test/k0sctl-files-badsum.yaml.tpl
@@ -1,0 +1,23 @@
+# Applied on top of the k0sctl-files.yaml cluster to check that a wrong sha256
+# fails the apply instead of leaving the file on the host.
+apiVersion: k0sctl.k0sproject.io/v1beta1
+kind: cluster
+spec:
+  hosts:
+    - role: controller
+      uploadBinary: true
+      ssh:
+        address: "127.0.0.1"
+        port: 9022
+        keyPath: ./id_rsa_k0s
+      files:
+        - name: badsum
+          src: http://$FILESRV/files/badsum.bin
+          dst: /root/srv/badsum.bin
+          sha256: "0000000000000000000000000000000000000000000000000000000000000000"
+  k0s:
+    version: "$K0S_VERSION"
+    config:
+      spec:
+        telemetry:
+          enabled: false

--- a/smoke-test/k0sctl-files.yaml.tpl
+++ b/smoke-test/k0sctl-files.yaml.tpl
@@ -45,6 +45,24 @@ spec:
         - name: url-destdir
           src: https://api.github.com/repos/k0sproject/k0s/releases
           dstDir: /root/url_destdir
+        # Served by the filesrv machine, which lets the test control the
+        # response headers k0sctl compares between applies.
+        - name: srv-etag
+          src: http://$FILESRV/files/plain.bin
+          dst: /root/srv/plain.bin
+        - name: srv-noetag
+          src: http://$FILESRV/noetag/plain.bin
+          dst: /root/srv/noetag.bin
+        - name: srv-checksum
+          src: http://$FILESRV/files/bundle.bin
+          dst: /root/srv/bundle.bin
+          sha256: $BUNDLE_SHA256
+        # Already on the host before k0sctl ever runs, which is how an airgap
+        # bundle often gets there. The sum is what lets it be accepted as is.
+        - name: srv-adopted
+          src: http://$FILESRV/files/adopt.bin
+          dst: /root/srv/adopt.bin
+          sha256: $ADOPT_SHA256
     - role: worker
       uploadBinary: true
       ssh:

--- a/smoke-test/smoke-files.sh
+++ b/smoke-test/smoke-files.sh
@@ -1,16 +1,20 @@
 #!/usr/bin/env sh
 
 K0SCTL_TEMPLATE=${K0SCTL_TEMPLATE:-"k0sctl.yaml.tpl"}
+# The template adds a machine that serves the URL sources, so that this test can
+# decide what the server says about them.
+BOOTLOOSE_TEMPLATE=${BOOTLOOSE_TEMPLATE:-"bootloose.yaml.files.tpl"}
+export BOOTLOOSE_TEMPLATE
 
 set -e
 
 . ./smoke.common.sh
 trap cleanup EXIT
 
-envsubst < k0sctl-files.yaml.tpl > k0sctl.yaml
-
 deleteCluster
-createCluster
+# filesrv0 is ssh'd into long before k0sctl connects to anything, so it has to be
+# waited for as well - k0sctl's own connection retries do not cover it.
+createCluster root@filesrv0
 
 remoteCommand() {
   local userhost="$1"
@@ -30,6 +34,42 @@ remoteFileContent() {
   remoteCommand "${userhost}" cat "${path}"
 }
 
+remoteSha256() {
+  local userhost="$1"
+  local path="$2"
+  remoteCommand "${userhost}" sha256sum "${path}" | awk '{print $1}' | tr -d '\r'
+}
+
+FILESRV_HOST="root@filesrv0"
+
+# serverLog prints the requests the file server has served so far, one
+# "<method> <path> <status>" per line.
+serverLog() {
+  remoteCommand "${FILESRV_HOST}" cat /srv/requests.log | tr -d '\r'
+}
+
+# serverRequests counts the requests for a path, for example
+# "serverRequests GET /files/plain.bin".
+serverRequests() {
+  serverLog | grep -c "^$1 $2 " || true
+}
+
+# assertRequestCount fails the test when a path has been requested more times
+# than it was when the count was taken.
+assertRequestCount() {
+  local method="$1"
+  local path="$2"
+  local want="$3"
+  local now
+  now=$(serverRequests "${method}" "${path}")
+  if [ "${now}" != "${want}" ]; then
+    echo "FAIL"
+    echo "  ${method} ${path} was requested ${now} times, expected ${want}"
+    serverLog
+    exit 1
+  fi
+}
+
 echo "* Creating random files"
 mkdir -p upload
 mkdir -p upload/nested
@@ -43,6 +83,54 @@ cat << EOF > upload_chmod/script.sh
 echo hello
 EOF
 chmod 0744 upload_chmod/script.sh
+
+echo "* Starting the file server"
+# Not every image in the matrix ships python3, and the file server machine is
+# not the one under test, so installing it there is fair game.
+remoteCommand "${FILESRV_HOST}" "command -v python3 > /dev/null || { apt-get update > /dev/null && apt-get install -y python3 > /dev/null; }"
+remoteCommand "${FILESRV_HOST}" "mkdir -p /srv/files && : > /srv/requests.log"
+# Handing the script over on the command line keeps this from depending on file
+# transfer support in the ssh helper.
+remoteCommand "${FILESRV_HOST}" "printf %s '$(base64 < filesrv.py | tr -d '\n')' | base64 -d > /srv/filesrv.py"
+remoteCommand "${FILESRV_HOST}" "head -c 1048576 </dev/urandom > /srv/files/plain.bin"
+remoteCommand "${FILESRV_HOST}" "head -c 2097152 </dev/urandom > /srv/files/bundle.bin"
+remoteCommand "${FILESRV_HOST}" "head -c 8192 </dev/urandom > /srv/files/badsum.bin"
+remoteCommand "${FILESRV_HOST}" "head -c 524288 </dev/urandom > /srv/files/adopt.bin"
+remoteCommand "${FILESRV_HOST}" "echo ok > /srv/files/health"
+remoteCommand "${FILESRV_HOST}" "setsid python3 /srv/filesrv.py > /srv/filesrv.out 2>&1 < /dev/null &"
+
+FILESRV="$(remoteCommand "${FILESRV_HOST}" hostname -i | awk '{print $1}' | tr -d '\r'):8080"
+export FILESRV
+echo "  - serving on ${FILESRV}"
+
+echo "* Waiting for the file server to answer from the cluster"
+i=0
+until remoteCommand root@manager0 "curl -sSf -o /dev/null http://${FILESRV}/files/health"; do
+  i=$((i+1))
+  if [ $i -gt 30 ]; then
+    echo "the file server did not come up"
+    remoteCommand "${FILESRV_HOST}" cat /srv/filesrv.out
+    exit 1
+  fi
+  sleep 1
+done
+
+PLAIN_SHA256=$(remoteSha256 "${FILESRV_HOST}" /srv/files/plain.bin)
+BUNDLE_SHA256=$(remoteSha256 "${FILESRV_HOST}" /srv/files/bundle.bin)
+ADOPT_SHA256=$(remoteSha256 "${FILESRV_HOST}" /srv/files/adopt.bin)
+export BUNDLE_SHA256 ADOPT_SHA256
+
+# Put one of the files on the host by other means, so the apply meets a
+# destination that is already correct and has nothing recording it.
+remoteCommand root@manager0 "mkdir -p /root/srv && curl -sSf -o /root/srv/adopt.bin http://${FILESRV}/files/adopt.bin"
+adopt_gets=$(serverRequests GET /files/adopt.bin)
+
+# The marker makes the file server cut the first transfer of the bundle short,
+# so the download has to be resumed to ever finish. It is consumed by that
+# transfer, which leaves the retry to succeed.
+remoteCommand "${FILESRV_HOST}" touch /srv/files/bundle.bin.drop
+
+envsubst < k0sctl-files.yaml.tpl > k0sctl.yaml
 
 echo "* Creating test user"
 remoteCommand root@manager0 useradd test
@@ -125,13 +213,55 @@ remoteFileContent root@manager0 /root/url_destdir/releases | grep -q html_url
 printf %s "[content] "
 echo "OK"
 
+printf %s "  - URL from the file server .. "
+[ "$(remoteSha256 root@manager0 /root/srv/plain.bin)" = "${PLAIN_SHA256}" ]
+printf %s "[etag source] "
+[ "$(remoteSha256 root@manager0 /root/srv/noetag.bin)" = "${PLAIN_SHA256}" ]
+printf %s "[no-etag source] "
+echo "OK"
+
+printf %s "  - Interrupted download of a file with a sha256 was resumed .. "
+serverLog | grep -q "^GET /files/bundle.bin 200 dropped$"
+printf %s "[interrupted] "
+serverLog | grep -q "^GET /files/bundle.bin 206$"
+printf %s "[resumed] "
+[ "$(remoteSha256 root@manager0 /root/srv/bundle.bin)" = "${BUNDLE_SHA256}" ]
+printf %s "[checksum] "
+echo "OK"
+
+printf %s "  - A pre-seeded file with a sha256 is adopted, not downloaded .. "
+assertRequestCount GET /files/adopt.bin "${adopt_gets}"
+printf %s "[not downloaded] "
+remoteCommand root@manager0 "ls /root/.cache/k0sctl/downloads | grep -q '^adopt.bin-'"
+printf %s "[recorded] "
+echo "OK"
+
+# The download records are written as the connecting user, so they must not need
+# sudo and must not end up beside the downloaded files.
+printf %s "  - Downloads are recorded in the user's cache dir .. "
+remoteCommand root@manager0 "test -d /root/.cache/k0sctl/downloads"
+printf %s "[exist] "
+remoteCommand root@manager0 "ls /root/.cache/k0sctl/downloads | grep -q '^bundle.bin-'"
+printf %s "[named] "
+if remoteCommand root@manager0 "ls /root/srv | grep -qv '\.bin$'"; then
+  echo "FAIL"
+  remoteCommand root@manager0 "ls -la /root/srv"
+  exit 1
+fi
+printf %s "[no leftovers] "
+echo "OK"
+
 echo "* Re-applying to verify the uploads are idempotent"
+plain_gets=$(serverRequests GET /files/plain.bin)
+noetag_gets=$(serverRequests GET /noetag/plain.bin)
+bundle_gets=$(serverRequests GET /files/bundle.bin)
+adopt_gets=$(serverRequests GET /files/adopt.bin)
+
 ../k0sctl apply --config k0sctl.yaml --debug > reapply.log 2>&1 || { cat reapply.log; exit 1; }
 
 # Host.FileChanged compares the local and remote size and mtime and logs which of
 # the two differed, so a re-upload of an unchanged file always leaves a trace in
-# the debug log. URL sources are not compared at all - UploadFiles sends them
-# through uploadURL - so these only cover the local file and directory sources.
+# the debug log.
 printf %s "  - No unchanged file is considered changed .. "
 if grep -qE "file (sizes|modtimes) for .* differ|(local|remote) stat failed" reapply.log; then
   echo "FAIL"
@@ -148,8 +278,88 @@ if ! grep -q "hasn.t been changed, skipping upload" reapply.log; then
 fi
 echo "OK"
 
-# Not asserted here: "k0s will be upgraded". GatherK0sFacts.needsUpgrade returns
-# true for any host with a URL file source without comparing anything, and this
-# config has two, so the re-apply restarts k0s no matter what the uploads did.
+printf %s "  - Unchanged URL sources are not downloaded again .. "
+assertRequestCount GET /files/plain.bin "${plain_gets}"
+assertRequestCount GET /noetag/plain.bin "${noetag_gets}"
+assertRequestCount GET /files/bundle.bin "${bundle_gets}"
+assertRequestCount GET /files/adopt.bin "${adopt_gets}"
+printf %s "[no requests] "
+if ! grep -q "is already downloaded to /root/srv/plain.bin" reapply.log; then
+  echo "FAIL"
+  grep -i "download" reapply.log
+  exit 1
+fi
+printf %s "[skipped] "
+echo "OK"
+
+# Only the file server sources are expected to be left alone here. The github API
+# sources in this config answer with a weak etag and no last-modified, which is
+# precisely the case k0sctl refuses to draw a conclusion from, so they are
+# downloaded on every apply and do mark the host for upgrade - by design. Real
+# release assets, which is what this feature is for, send a strong etag.
+printf %s "  - A skipped URL source does not mark the host for upgrade .. "
+if grep -q "marked for upgrade because /root/srv/" reapply.log; then
+  echo "FAIL"
+  grep "marked for upgrade because /root/srv/" reapply.log
+  exit 1
+fi
+echo "OK"
+
+echo "* Replacing a served file to verify changed sources are downloaded again"
+remoteCommand "${FILESRV_HOST}" "head -c 1572864 </dev/urandom > /srv/files/plain.bin"
+NEW_PLAIN_SHA256=$(remoteSha256 "${FILESRV_HOST}" /srv/files/plain.bin)
+
+../k0sctl apply --config k0sctl.yaml --debug > changed.log 2>&1 || { cat changed.log; exit 1; }
+
+printf %s "  - A changed URL source is downloaded again .. "
+[ "$(remoteSha256 root@manager0 /root/srv/plain.bin)" = "${NEW_PLAIN_SHA256}" ]
+printf %s "[etag] "
+[ "$(remoteSha256 root@manager0 /root/srv/noetag.bin)" = "${NEW_PLAIN_SHA256}" ]
+printf %s "[last-modified] "
+assertRequestCount GET /files/bundle.bin "${bundle_gets}"
+printf %s "[others untouched] "
+echo "OK"
+
+echo "* Corrupting a downloaded file in place"
+plain_gets=$(serverRequests GET /files/plain.bin)
+# Same length, different bytes: nothing the server says about the url can catch
+# this, only the recorded state of the file itself.
+remoteCommand root@manager0 "printf CORRUPT | dd of=/root/srv/plain.bin bs=1 seek=0 conv=notrunc 2>/dev/null"
+../k0sctl apply --config k0sctl.yaml --debug > corrupt.log 2>&1 || { cat corrupt.log; exit 1; }
+
+printf %s "  - A same-size local modification is downloaded again .. "
+assertRequestCount GET /files/plain.bin "$((plain_gets + 1))"
+printf %s "[downloaded] "
+[ "$(remoteSha256 root@manager0 /root/srv/plain.bin)" = "${NEW_PLAIN_SHA256}" ]
+printf %s "[restored] "
+echo "OK"
+
+echo "* Applying a file with a wrong sha256"
+envsubst < k0sctl-files-badsum.yaml.tpl > k0sctl-badsum.yaml
+printf %s "  - The apply fails and the file is not left behind .. "
+if ../k0sctl apply --config k0sctl-badsum.yaml --debug > badsum.log 2>&1; then
+  echo "FAIL"
+  echo "  the apply succeeded with a wrong sha256"
+  exit 1
+fi
+grep -q "checksum mismatch" badsum.log
+printf %s "[failed] "
+if remoteFileExist root@manager0 /root/srv/badsum.bin; then
+  echo "FAIL"
+  echo "  the mismatching file was left on the host"
+  exit 1
+fi
+printf %s "[removed] "
+# A download that does not end up at its destination must not leave its partial
+# behind either: nothing continues it, and in a directory k0s reads it would be
+# a truncated artifact for something else to trip over.
+if remoteCommand root@manager0 "ls -a /root/srv | grep -q rigpart"; then
+  echo "FAIL"
+  echo "  a partial download was left on the host"
+  remoteCommand root@manager0 "ls -la /root/srv"
+  exit 1
+fi
+printf %s "[no partial] "
+echo "OK"
 
 echo "* Done"


### PR DESCRIPTION
Fixes #1131

An apply downloaded every `files:` entry with a URL source on every run, and GatherK0sFacts marked any host that had one for upgrade without comparing anything, so a re-apply pulled the file again and restarted k0s for it.

k0sctl now records what an HTTP HEAD from the host reports about the URL -- ETag, Last-Modified and Content-Length -- and skips the transfer while a fresh HEAD still agrees with the record and the file on the host is untouched. needsUpgrade asks the same question instead of assuming the worst. The records live in k0sctl/downloads under the connecting user's cache directory on the host, so writing them needs no sudo and no unexpected file turns up in a destination directory such as the k0s images directory.

`files:` entries gain a `sha256` field. For a URL source it answers the question on its own, it is verified after the download, and it is what allows an interrupted transfer to be continued rather than restarted: resuming is limited to that case because neither curl nor wget can tell whether the bytes already on disk are still a valid prefix of what the URL serves. A download that fails the check takes the destination with it. For a local source the file is checked once per run before it is uploaded.

The files smoke test grows a machine that serves the URL sources, which makes the skip, the resume, the changed-content re-download and the checksum failure testable against a server whose response headers and interruptions the test controls.

