### PR TITLE
ci: scope the GITHUB_TOKEN in the workflows that never declared one

### DIFF
--- a/.github/workflows/actionlint.yml
+++ b/.github/workflows/actionlint.yml
@@ -4,6 +4,11 @@ on:
     paths:
       - .github/**
 
+permissions:
+  contents: read
+  # reviewdog's default reporter is github-pr-check, which posts a check run
+  checks: write
+
 jobs:
   actionlint:
     runs-on: ubuntu-latest

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -8,6 +8,9 @@ on:
       - go.sum
       - Makefile
 
+permissions:
+  contents: read
+
 jobs:
   unit-test:
     strategy:

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -4,6 +4,9 @@ on:
     paths:
       - '**.go'
 
+permissions:
+  contents: read
+
 jobs:
   golangci-lint:
     name: Run golangci-lint

--- a/.github/workflows/gomod-lint.yml
+++ b/.github/workflows/gomod-lint.yml
@@ -5,6 +5,9 @@ on:
       - 'go.mod'
       - 'go.sum'
 
+permissions:
+  contents: read
+
 jobs:
   gomod-lint:
     name: Validate go module file consistency

--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -10,6 +10,9 @@ on:
       - .github/workflows/smoke.yml
       - smoke-test/**
 
+permissions:
+  contents: read
+
 jobs:
 
   build:


### PR DESCRIPTION
The repository default for workflow permissions is write, and five workflows declare no permissions block, so each of them runs with a token holding write on contents, issues, pull requests, packages, actions, deployments, statuses and the rest. smoke.yml is the one that matters: it runs make targets and shell scripts from the pull request branch, so the code under test shares a job with a token that can push to the repository.

None of them need it. All five check out and build; actionlint also posts a check run, because reviewdog's default reporter is github-pr-check.

Left unverified on purpose: whether actions/upload-artifact and actions/cache still work under contents: read. Neither documents a permission requirement, and the one data point available points the wrong way — a job with issues: write and pull-requests: write was refused a cache write for having "no writable scopes", which suggests the cache service wants actions: write specifically. smoke.yml's own paths filter includes .github/workflows/smoke.yml, so this commit triggers the full matrix and answers the question. If artifacts or caches break, the fix is to add the scope they turn out to need, not to drop the block.

The systemic fix is the repository setting itself: default workflow permissions of read, which the workflows that genuinely need write already survive, since every one of them declares its own block.