### PR TITLE
smoke: wait for sshd before the first bare bootloose ssh

### DIFF
--- a/smoke-test/smoke.common.sh
+++ b/smoke-test/smoke.common.sh
@@ -4,9 +4,33 @@ export LINUX_IMAGE="${LINUX_IMAGE:-"quay.io/k0sproject/bootloose-ubuntu26.04:lat
 export PRESERVE_CLUSTER="${PRESERVE_CLUSTER:-""}"
 export K0S_VERSION
 
+# bootloose create returns once the containers exist, which is not the same as
+# sshd inside them accepting connections. k0sctl apply retries its own
+# connections, so scripts that go straight into apply never see the gap, but a
+# bare `bootloose ssh` issued right after createCluster races sshd and dies with
+# exit 255 - intermittently, and more often on a loaded runner.
+waitForSSH() {
+  userhost="$1"
+  timeout="${2:-60}"
+  deadline=$(( $(date +%s) + timeout ))
+  until bootloose ssh "${userhost}" -- true >/dev/null 2>&1; do
+    if [ "$(date +%s)" -ge "${deadline}" ]; then
+      echo "Timed out after ${timeout}s waiting for sshd on ${userhost}" >&2
+      return 1
+    fi
+    sleep 1
+  done
+}
+
+# Waits for manager0, which every bootloose template here defines, so no script
+# has to remember to do it. Name any other machines the script will ssh into
+# before k0sctl does as extra arguments.
 createCluster() {
   envsubst < "${BOOTLOOSE_TEMPLATE}" > bootloose.yaml
   bootloose create
+  for userhost in "root@manager0" "$@"; do
+    waitForSSH "${userhost}"
+  done
 }
 
 deleteCluster() {


### PR DESCRIPTION
createCluster ran `bootloose create` and returned, which means the containers exist, not that sshd inside them is accepting connections. k0sctl apply retries its own connections, so every script that goes straight into apply rides out the gap without noticing it. smoke-files.sh does not: it ssh's in to create a test user before apply ever runs, and on a loaded runner it loses the race.

  12:10:45.36  Creating machine: k0s-worker0 ...
  12:10:45.62  * Creating random files
  12:10:45.63  * Creating test user
  12:10:46.08  level=fatal msg="exit status 255"

Seven tenths of a second between creating the machines and ssh'ing into them, and 255 is ssh's own "could not connect". It is intermittent, which is what makes it expensive: it reads as infrastructure noise, invites a re-run, and comes back.

Wait for manager0 inside createCluster rather than leaving each script to remember, since every bootloose template here defines it. Scripts that reach other machines before k0sctl does can name them as arguments.